### PR TITLE
in RotateTool, make angle a multiple of _snap_angle when _snap_rotation is enabled

### DIFF
--- a/plugins/Tools/RotateTool/RotateTool.py
+++ b/plugins/Tools/RotateTool/RotateTool.py
@@ -71,8 +71,10 @@ class RotateTool(Tool):
             drag_end = (drag_position - handle_position).normalize()
 
             angle = math.acos(drag_start.dot(drag_end))
-            if self._snap_rotation and angle < self._snap_angle:
-                return
+            if self._snap_rotation:
+                angle = int(angle / self._snap_angle) * self._snap_angle
+                if angle == 0:
+                    return
 
             rotation = None
             if self.getLockedAxis() == ToolHandle.XAxis:


### PR DESCRIPTION
Fixes a problem where rotation would not snap to the right angles, and was therefore not terribly useful