### PR TITLE
Better fix for crash when no platform mesh is set

### DIFF
--- a/UM/Scene/Platform.py
+++ b/UM/Scene/Platform.py
@@ -43,10 +43,11 @@ class Platform(SceneNode.SceneNode):
         self._settings = app.getActiveMachine()
         if self._settings:
             mesh = self._settings.getPlatformMesh()
-            if not mesh:
-                mesh = "" # Dirty hack to ensure that if no mesh is set it doesn't crash.
+            if mesh:
+                self.setMeshData(app.getMeshFileHandler().read(Resources.getPath(Resources.MeshesLocation, mesh), center = False).getMeshData())
+            else:
+                self.setMeshData(None)
 
-            self.setMeshData(app.getMeshFileHandler().read(Resources.getPath(Resources.MeshesLocation, mesh), center = False).getMeshData())
             self._texture = self._settings.getPlatformTexture()
 
             if self._material and self._texture:

--- a/UM/Scene/Platform.py
+++ b/UM/Scene/Platform.py
@@ -42,11 +42,13 @@ class Platform(SceneNode.SceneNode):
         app = Application.getInstance()
         self._settings = app.getActiveMachine()
         if self._settings:
+            meshData = None
             mesh = self._settings.getPlatformMesh()
             if mesh:
-                self.setMeshData(app.getMeshFileHandler().read(Resources.getPath(Resources.MeshesLocation, mesh), center = False).getMeshData())
-            else:
-                self.setMeshData(None)
+                _meshData = app.getMeshFileHandler().read(Resources.getPath(Resources.MeshesLocation, mesh), center = False)
+                if _meshData:
+                    meshData = _meshData.getMeshData()
+            self.setMeshData(meshData)
 
             self._texture = self._settings.getPlatformTexture()
 


### PR DESCRIPTION
https://github.com/Ultimaker/Uranium/commit/78ee44b2c5c00628de4a16b90ea87000272fa076 was a quick fix for when no mesh filename is set by supplying an empty filename. https://github.com/Ultimaker/Uranium/commit/e20745af40d78591239a176721d6d3b53aee7b80 changed how MeshReading returns when the read operation fails. Because of this the quick fix doesn't work anymore. This PR is an updated fix for the problem.