### PR TITLE
Fix translate tool moving objects with an offset

### DIFF
--- a/plugins/Tools/TranslateTool/TranslateTool.py
+++ b/plugins/Tools/TranslateTool/TranslateTool.py
@@ -63,6 +63,8 @@ class TranslateTool(Tool):
             else:
                 self.setDragPlane(Plane(Vector(0, 1, 0), 0))
 
+            self.setDragStart(event.x, event.y)
+
         if event.type == Event.MouseMoveEvent:
             if not self.getDragPlane():
                 return False

--- a/plugins/Tools/TranslateTool/TranslateTool.py
+++ b/plugins/Tools/TranslateTool/TranslateTool.py
@@ -63,8 +63,6 @@ class TranslateTool(Tool):
             else:
                 self.setDragPlane(Plane(Vector(0, 1, 0), 0))
 
-            self.setDragStart(event.x, event.y)
-
         if event.type == Event.MouseMoveEvent:
             if not self.getDragPlane():
                 return False
@@ -97,6 +95,7 @@ class TranslateTool(Tool):
             if self.getDragPlane():
                 self.setLockedAxis(None)
                 self.setDragPlane(None)
+                self.setDragStart(None, None)
                 self.operationStopped.emit(self)
                 return True
 


### PR DESCRIPTION
The translate tool moves objects with an offset on subsequent operations.

Steps to reproduce before fix:
* Load object
* Use translate tool to move object around (either one of the axes, or the object itself)
-> behaves as expected
* Use translate tool again
-> jumps to an offset position, moves correctly with object
