### PR TITLE
Fix crash on exit when no machine is selected

### DIFF
--- a/UM/Settings/MachineManager.py
+++ b/UM/Settings/MachineManager.py
@@ -320,7 +320,8 @@ class MachineManager(SignalEmitter):
         self.saveVisibility()
 
     def saveMachineInstances(self):
-        Preferences.getInstance().setValue("machines/active_instance", self._active_machine.getName())
+        if self._active_machine:
+            Preferences.getInstance().setValue("machines/active_instance", self._active_machine.getName())
 
         for instance in self._machine_instances:
             file_name = urllib.parse.quote_plus(instance.getName()) + ".cfg"


### PR DESCRIPTION
Steps to reproduce:
* delete cura profile
* start cura
=> machine wizard pops up
* close machine wizard
=> no machine is added
* close cura
=> crash because _active_machine is None