### PR TITLE
Disable dragging the advanced settings pane horizontally

### DIFF
--- a/UM/Qt/qml/UM/Settings/SettingView.qml
+++ b/UM/Qt/qml/UM/Settings/SettingView.qml
@@ -13,6 +13,7 @@ ScrollView
     id: base;
 
     style: UM.Theme.styles.scrollview;
+    flickableItem.flickableDirection: Flickable.VerticalFlick;
 
     property Action configureSettings;
     signal showTooltip(Item item, point location, string text);


### PR DESCRIPTION
The advanced settings pane can be dragged horizontally, which is weird.

Steps to reproduce:
* Switch to advanced settings
* Expand a couple of categories
* Drag the scrollview horizontally

Expected result:
Dragging horizontally has doesn't