### PR TITLE
Check stored window position against all available screens

### DIFF
--- a/UM/Qt/Bindings/MainWindow.py
+++ b/UM/Qt/Bindings/MainWindow.py
@@ -44,7 +44,12 @@ class MainWindow(QQuickWindow):
         self.setHeight(int(self._preferences.getValue("general/window_height")))
         self.setPosition(int(self._preferences.getValue("general/window_left")), int(self._preferences.getValue("general/window_top")))
         # Make sure restored geometry is not outside the currently available screens
-        if not self.geometry().intersects(self.screen().availableGeometry()):
+        screenFound = False
+        for screenNr in range(0, self._app.desktop().screenCount()):
+            if self.geometry().intersects(self._app.desktop().availableGeometry(screenNr)):
+                screenFound = True
+                break
+        if not screenFound:
             self.setPosition(50,50)
 
         self.setWindowState(int(self._preferences.getValue("general/window_state")))

--- a/UM/Qt/Bindings/MainWindow.py
+++ b/UM/Qt/Bindings/MainWindow.py
@@ -44,12 +44,12 @@ class MainWindow(QQuickWindow):
         self.setHeight(int(self._preferences.getValue("general/window_height")))
         self.setPosition(int(self._preferences.getValue("general/window_left")), int(self._preferences.getValue("general/window_top")))
         # Make sure restored geometry is not outside the currently available screens
-        screenFound = False
-        for screenNr in range(0, self._app.desktop().screenCount()):
-            if self.geometry().intersects(self._app.desktop().availableGeometry(screenNr)):
-                screenFound = True
+        screen_found = False
+        for s in range(0, self._app.desktop().screenCount()):
+            if self.geometry().intersects(self._app.desktop().availableGeometry(s)):
+                screen_found = True
                 break
-        if not screenFound:
+        if not screen_found:
             self.setPosition(50,50)
 
         self.setWindowState(int(self._preferences.getValue("general/window_state")))


### PR DESCRIPTION
In 37fe8028a57e6a3090da59ef7de9881c543405de I tried to make sure the stored position of the window fits within the currently available screen geometry by looking at self.screen().availableGeometry(). 

It turns out that - at least under Windows - self.screen() does not get properly populated until after the window is shown. This update to the patch iterates through all available screens instead of relying on self.screen().