### PR TITLE
Add "Lay flat" functionality

### DIFF
--- a/UM/Operations/LayFlatOperation.py
+++ b/UM/Operations/LayFlatOperation.py
@@ -1,0 +1,119 @@
+# Copyright (c) 2015 Ultimaker B.V.
+# Uranium is released under the terms of the AGPLv3 or higher.
+
+from . import Operation
+
+from UM.Scene.SceneNode import SceneNode
+from UM.Math.Matrix import Matrix
+from UM.Math.Quaternion import Quaternion
+
+import math
+
+
+class LayFlatOperation(Operation.Operation):
+
+    def __init__(self, node, orientation = None):
+        super().__init__()
+        self._node = node
+
+        self._old_orientation = node.getOrientation()
+        self._new_orientation = orientation
+
+        if orientation:
+            return
+        
+        # Based on https://github.com/daid/Cura/blob/SteamEngine/Cura/util/printableObject.py#L207
+        # Note: Y & Z axis are swapped
+
+        transformed_vertices = node.getMeshDataTransformed().getVertices()
+        min_y_vertex = transformed_vertices[transformed_vertices.argmin(0)[1]]
+        dot_min = 1.0
+        dot_v = None
+
+        for v in transformed_vertices:
+            diff = v - min_y_vertex
+            length = math.sqrt(diff[0] * diff[0] + diff[2] * diff[2] + diff[1] * diff[1])
+            if length < 5:
+                continue
+            dot = (diff[1] / length)
+            if dot_min > dot:
+                dot_min = dot
+                dot_v = diff
+
+        if dot_v is None:
+            return
+
+        rad = -math.asin(dot_min)
+
+        m = Matrix([
+            [ math.cos(rad), math.sin(rad), 0 ],
+            [-math.sin(rad), math.cos(rad), 0 ],
+            [ 0,             0,             1 ]
+        ])
+        node.rotate(Quaternion.fromMatrix(m), SceneNode.TransformSpace.Parent)
+
+        rad = math.atan2(dot_v[2], dot_v[0])
+        m = Matrix([
+            [ math.cos(rad), 0, math.sin(rad)],
+            [ 0,             1, 0 ],
+            [-math.sin(rad), 0, math.cos(rad)]
+        ])
+        node.rotate(Quaternion.fromMatrix(m), SceneNode.TransformSpace.Parent)
+
+        transformed_vertices = node.getMeshDataTransformed().getVertices()
+        min_y_vertex = transformed_vertices[transformed_vertices.argmin(0)[1]]
+        dot_min = 1.0
+        dot_v = None
+
+        for v in transformed_vertices:
+            diff = v - min_y_vertex
+            length = math.sqrt(diff[2] * diff[2] + diff[1] * diff[1])
+            if length < 5:
+                continue
+            dot = (diff[1] / length)
+            if dot_min > dot:
+                dot_min = dot
+                dot_v = diff
+
+        if dot_v is None:
+            node.setOrientation(self._old_orientation)
+            return
+
+        if dot_v[2] < 0:
+            rad = -math.asin(dot_min)
+        else:
+            rad = math.asin(dot_min)
+        m = Matrix([
+            [ 1, 0,             0 ],
+            [ 0, math.cos(rad),-math.sin(rad) ],
+            [ 0, math.sin(rad), math.cos(rad) ]
+        ])
+        node.rotate(Quaternion.fromMatrix(m), SceneNode.TransformSpace.Parent)
+
+        self._new_orientation = node.getOrientation()
+        node.setOrientation(self._old_orientation)
+
+    def undo(self):
+        self._node.setOrientation(self._old_orientation)
+
+    def redo(self):
+        if self._new_orientation:
+            self._node.setOrientation(self._new_orientation)
+            pass
+
+    def mergeWith(self, other):
+        if type(other) is not LayFlatOperation:
+            return False
+
+        if other._node != self._node:
+            return False
+
+        if other._new_orientation is None or self._new_orientation is None:
+            return False
+
+        op = LayFlatOperation(self._node, self._new_orientation)
+        op._old_orientation = other._old_orientation
+        return op
+
+    def __repr__(self):
+        return "LayFlatOperation(node = {0})".format(self._node)

--- a/UM/Operations/LayFlatOperation.py
+++ b/UM/Operations/LayFlatOperation.py
@@ -4,7 +4,7 @@
 from . import Operation
 
 from UM.Scene.SceneNode import SceneNode
-from UM.Math.Matrix import Matrix
+from UM.Math.Vector import Vector
 from UM.Math.Quaternion import Quaternion
 
 from UM.Signal import Signal
@@ -55,20 +55,11 @@ class LayFlatOperation(Operation.Operation):
             return
 
         rad = math.atan2(dot_v[2], dot_v[0])
-        m = Matrix([
-            [ math.cos(rad), 0, math.sin(rad)],
-            [ 0,             1, 0 ],
-            [-math.sin(rad), 0, math.cos(rad)]
-        ])
-        self._node.rotate(Quaternion.fromMatrix(m), SceneNode.TransformSpace.Parent)
+        self._node.rotate(Quaternion.fromAngleAxis(rad, Vector.Unit_Y), SceneNode.TransformSpace.Parent)
+
 
         rad = -math.asin(dot_min)
-        m = Matrix([
-            [ math.cos(rad), math.sin(rad), 0 ],
-            [-math.sin(rad), math.cos(rad), 0 ],
-            [ 0,             0,             1 ]
-        ])
-        self._node.rotate(Quaternion.fromMatrix(m), SceneNode.TransformSpace.Parent)
+        self._node.rotate(Quaternion.fromAngleAxis(rad, Vector.Unit_Z), SceneNode.TransformSpace.Parent)
 
         transformed_vertices = self._node.getMeshDataTransformed().getVertices()
         min_y_vertex = transformed_vertices[transformed_vertices.argmin(0)[1]]
@@ -94,12 +85,7 @@ class LayFlatOperation(Operation.Operation):
             rad = -math.asin(dot_min)
         else:
             rad = math.asin(dot_min)
-        m = Matrix([
-            [ 1, 0,             0 ],
-            [ 0, math.cos(rad),-math.sin(rad) ],
-            [ 0, math.sin(rad), math.cos(rad) ]
-        ])
-        self._node.rotate(Quaternion.fromMatrix(m), SceneNode.TransformSpace.Parent)
+        self._node.rotate(Quaternion.fromAngleAxis(rad, Vector.Unit_X), SceneNode.TransformSpace.Parent)
 
         self._new_orientation = self._node.getOrientation()
 

--- a/UM/Qt/qml/UM/MessageStack.qml
+++ b/UM/Qt/qml/UM/MessageStack.qml
@@ -66,7 +66,6 @@ ListView {
                 maximumValue: model.max_progress;
 
                 value: 0
-                Behavior on value { NumberAnimation { duration: 100; } }
 
                 // Doing this in an explicit binding since the implicit binding breaks on occasion.
                 Binding { target: totalProgressBar; property: "value"; value: model.progress }

--- a/UM/Scene/Selection.py
+++ b/UM/Scene/Selection.py
@@ -71,23 +71,30 @@ class Selection:
     #   \param operation \type{Class} The operation to create and push. It should take a SceneNode as first positional parameter.
     #   \param args The additional positional arguments passed along to the operation constructor.
     #   \param kwargs The additional keyword arguements that will be passed along to the operation constructor.
+    #
+    #   \return list of instantiated operations
     @classmethod
     def applyOperation(cls, operation, *args, **kwargs):
         if not cls.__selection:
             return
 
         op = None
+        operations = []
 
         if len(cls.__selection) == 1:
             node = cls.__selection[0]
             op = operation(node, *args, **kwargs)
+            operations.append(op)
         else:
             op = GroupedOperation()
 
             for node in Selection.getAllSelectedObjects():
-                op.addOperation(operation(node, *args, **kwargs))
+                sub_op = operation(node, *args, **kwargs)
+                op.addOperation(sub_op)
+                operations.append(sub_op)
 
         op.push()
+        return operations
 
     @classmethod
     def _onTransformationChanged(cls, node):

--- a/plugins/Tools/RotateTool/RotateTool.py
+++ b/plugins/Tools/RotateTool/RotateTool.py
@@ -161,7 +161,7 @@ class RotateTool(Tool):
         # Note: Y & Z axis are swapped
 
         self.operationStarted.emit(self)
-        progress_message = Message("Finding flat base...", lifetime = 0, dismissable = False)
+        progress_message = Message("Laying object flat on buildplate...", lifetime = 0, dismissable = False)
         progress_message.setProgress(0)
         progress_message.show()
 

--- a/plugins/Tools/RotateTool/RotateTool.py
+++ b/plugins/Tools/RotateTool/RotateTool.py
@@ -164,7 +164,7 @@ class RotateTool(Tool):
         progress_message = Message("Finding flat base...", lifetime = 0, dismissable = False)
         progress_message.setProgress(0)
         progress_message.show()
-    
+
         selected_object = Selection.getSelectedObject(0)
         transformed_vertices = selected_object.getMeshDataTransformed().getVertices()
         min_y_vertex = transformed_vertices[transformed_vertices.argmin(0)[1]]
@@ -174,7 +174,7 @@ class RotateTool(Tool):
         iterations = 0
         total_iterations = len(transformed_vertices) * 2
         last_progress = 0
-        
+
         for v in transformed_vertices:
             diff = v - min_y_vertex
             length = math.sqrt(diff[0] * diff[0] + diff[2] * diff[2] + diff[1] * diff[1])
@@ -195,19 +195,20 @@ class RotateTool(Tool):
             progress_message.hide()
             self.operationStopped.emit(self)
             return
-        rad = math.atan2(dot_v[2], dot_v[0])
-        m = Matrix([
-            [ math.cos(rad), 0, math.sin(rad)],
-            [ 0,             1, 0 ],
-            [-math.sin(rad), 0, math.cos(rad)]
-        ])
-        selected_object.rotate(Quaternion.fromMatrix(m), SceneNode.TransformSpace.Parent)
 
         rad = -math.asin(dot_min)
         m = Matrix([
             [ math.cos(rad), math.sin(rad), 0 ],
             [-math.sin(rad), math.cos(rad), 0 ],
             [ 0,             0,             1 ]
+        ])
+        selected_object.rotate(Quaternion.fromMatrix(m), SceneNode.TransformSpace.Parent)
+
+        rad = math.atan2(dot_v[2], dot_v[0])
+        m = Matrix([
+            [ math.cos(rad), 0, math.sin(rad)],
+            [ 0,             1, 0 ],
+            [-math.sin(rad), 0, math.cos(rad)]
         ])
         selected_object.rotate(Quaternion.fromMatrix(m), SceneNode.TransformSpace.Parent)
 
@@ -236,6 +237,7 @@ class RotateTool(Tool):
             progress_message.hide()
             self.operationStopped.emit(self)
             return
+
         if dot_v[2] < 0:
             rad = -math.asin(dot_min)
         else:
@@ -246,5 +248,6 @@ class RotateTool(Tool):
             [ 0, math.sin(rad), math.cos(rad) ]
         ])
         selected_object.rotate(Quaternion.fromMatrix(m), SceneNode.TransformSpace.Parent)
+
         progress_message.hide()
         self.operationStopped.emit(self)

--- a/plugins/Tools/RotateTool/RotateTool.py
+++ b/plugins/Tools/RotateTool/RotateTool.py
@@ -167,5 +167,5 @@ class RotateTool(Tool):
             
         Selection.applyOperation(LayFlatOperation)
 
-        self._progress_message.hide()
+        progress_message.hide()
         self.operationStopped.emit(self)

--- a/plugins/Tools/RotateTool/RotateTool.py
+++ b/plugins/Tools/RotateTool/RotateTool.py
@@ -201,7 +201,7 @@ class RotateTool(Tool):
             [ 0,             1, 0 ],
             [-math.sin(rad), 0, math.cos(rad)]
         ])
-        selected_object.rotate(Quaternion.fromMatrix(m), SceneNode.TransformSpace.World)
+        selected_object.rotate(Quaternion.fromMatrix(m), SceneNode.TransformSpace.Parent)
 
         rad = -math.asin(dot_min)
         m = Matrix([
@@ -209,7 +209,7 @@ class RotateTool(Tool):
             [-math.sin(rad), math.cos(rad), 0 ],
             [ 0,             0,             1 ]
         ])
-        selected_object.rotate(Quaternion.fromMatrix(m), SceneNode.TransformSpace.World)
+        selected_object.rotate(Quaternion.fromMatrix(m), SceneNode.TransformSpace.Parent)
 
         transformed_vertices = selected_object.getMeshDataTransformed().getVertices()
         min_y_vertex = transformed_vertices[transformed_vertices.argmin(0)[1]]
@@ -245,6 +245,6 @@ class RotateTool(Tool):
             [ 0, math.cos(rad),-math.sin(rad) ],
             [ 0, math.sin(rad), math.cos(rad) ]
         ])
-        selected_object.rotate(Quaternion.fromMatrix(m), SceneNode.TransformSpace.World)
+        selected_object.rotate(Quaternion.fromMatrix(m), SceneNode.TransformSpace.Parent)
         progress_message.hide()
         self.operationStopped.emit(self)

--- a/plugins/Tools/RotateTool/RotateTool.py
+++ b/plugins/Tools/RotateTool/RotateTool.py
@@ -1,26 +1,23 @@
 # Copyright (c) 2015 Ultimaker B.V.
 # Uranium is released under the terms of the AGPLv3 or higher.
 
-from PyQt5.QtWidgets import QApplication
-
 from UM.Tool import Tool
 from UM.Event import Event, MouseEvent, KeyEvent
 from UM.Application import Application
 from UM.Message import Message
 from UM.Scene.ToolHandle import ToolHandle
 from UM.Scene.Selection import Selection
-from UM.Scene.SceneNode import SceneNode
 
 from UM.Math.Plane import Plane
 from UM.Math.Vector import Vector
 from UM.Math.Quaternion import Quaternion
-from UM.Math.Matrix import Matrix
 from UM.Math.Float import Float
 
 from UM.Operations.RotateOperation import RotateOperation
 from UM.Operations.TranslateOperation import TranslateOperation
 from UM.Operations.GroupedOperation import GroupedOperation
 from UM.Operations.SetTransformOperation import SetTransformOperation
+from UM.Operations.LayFlatOperation import LayFlatOperation
 
 from . import RotateToolHandle
 
@@ -157,96 +154,18 @@ class RotateTool(Tool):
         Selection.applyOperation(SetTransformOperation, None, Quaternion(), None)
 
     def layFlat(self):
-        # Based on https://github.com/daid/Cura/blob/SteamEngine/Cura/util/printableObject.py#L207
-        # Note: Y & Z axis are swapped
-
         self.operationStarted.emit(self)
         progress_message = Message("Laying object flat on buildplate...", lifetime = 0, dismissable = False)
-        progress_message.setProgress(0)
-        progress_message.show()
+        progress_message.setProgress(-1)
 
-        iterations = 0
-        last_progress = 0
         total_iterations = 0
         for selected_object in Selection.getAllSelectedObjects():
             total_iterations += len(selected_object.getMeshDataTransformed().getVertices()) * 2
 
-        for selected_object in Selection.getAllSelectedObjects():
-            transformed_vertices = selected_object.getMeshDataTransformed().getVertices()
-            min_y_vertex = transformed_vertices[transformed_vertices.argmin(0)[1]]
-            dot_min = 1.0
-            dot_v = None
+        progress_message.setMaxProgress(total_iterations)
+        progress_message.show()
+            
+        Selection.applyOperation(LayFlatOperation)
 
-            for v in transformed_vertices:
-                diff = v - min_y_vertex
-                length = math.sqrt(diff[0] * diff[0] + diff[2] * diff[2] + diff[1] * diff[1])
-                if length < 5:
-                    continue
-                dot = (diff[1] / length)
-                if dot_min > dot:
-                    dot_min = dot
-                    dot_v = diff
-                iterations += 1
-                progress = round(100*iterations/total_iterations)
-                if progress != last_progress:
-                    last_progress = progress
-                    progress_message.setProgress(progress)
-                    QApplication.processEvents()
-
-            if dot_v is None:
-                iterations += len(transformed_vertices)
-                continue
-
-            rad = -math.asin(dot_min)
-            m = Matrix([
-                [ math.cos(rad), math.sin(rad), 0 ],
-                [-math.sin(rad), math.cos(rad), 0 ],
-                [ 0,             0,             1 ]
-            ])
-            selected_object.rotate(Quaternion.fromMatrix(m), SceneNode.TransformSpace.Parent)
-
-            rad = math.atan2(dot_v[2], dot_v[0])
-            m = Matrix([
-                [ math.cos(rad), 0, math.sin(rad)],
-                [ 0,             1, 0 ],
-                [-math.sin(rad), 0, math.cos(rad)]
-            ])
-            selected_object.rotate(Quaternion.fromMatrix(m), SceneNode.TransformSpace.Parent)
-
-            transformed_vertices = selected_object.getMeshDataTransformed().getVertices()
-            min_y_vertex = transformed_vertices[transformed_vertices.argmin(0)[1]]
-            dot_min = 1.0
-            dot_v = None
-
-            for v in transformed_vertices:
-                diff = v - min_y_vertex
-                length = math.sqrt(diff[2] * diff[2] + diff[1] * diff[1])
-                if length < 5:
-                    continue
-                dot = (diff[1] / length)
-                if dot_min > dot:
-                    dot_min = dot
-                    dot_v = diff
-                iterations += 1
-                progress = round(100*iterations/total_iterations)
-                if progress != last_progress:
-                    last_progress = progress
-                    progress_message.setProgress(progress)
-                    QApplication.processEvents()
-
-            if dot_v is None:
-                continue
-
-            if dot_v[2] < 0:
-                rad = -math.asin(dot_min)
-            else:
-                rad = math.asin(dot_min)
-            m = Matrix([
-                [ 1, 0,             0 ],
-                [ 0, math.cos(rad),-math.sin(rad) ],
-                [ 0, math.sin(rad), math.cos(rad) ]
-            ])
-            selected_object.rotate(Quaternion.fromMatrix(m), SceneNode.TransformSpace.Parent)
-
-        progress_message.hide()
+        self._progress_message.hide()
         self.operationStopped.emit(self)

--- a/plugins/Tools/RotateTool/RotateTool.py
+++ b/plugins/Tools/RotateTool/RotateTool.py
@@ -157,6 +157,9 @@ class RotateTool(Tool):
         Selection.applyOperation(SetTransformOperation, None, Quaternion(), None)
 
     def layFlat(self):
+        # Based on https://github.com/daid/Cura/blob/SteamEngine/Cura/util/printableObject.py#L207
+        # Note: Y & Z axis are swapped
+
         self.operationStarted.emit(self)
         progress_message = Message("Finding flat base...", lifetime = 0, dismissable = False)
         progress_message.setProgress(0)
@@ -164,7 +167,7 @@ class RotateTool(Tool):
     
         selected_object = Selection.getSelectedObject(0)
         transformed_vertices = selected_object.getMeshDataTransformed().getVertices()
-        min_z_vertex = transformed_vertices[transformed_vertices.argmin(0)[2]]
+        min_y_vertex = transformed_vertices[transformed_vertices.argmin(0)[1]]
         dot_min = 1.0
         dot_v = None
 
@@ -173,11 +176,11 @@ class RotateTool(Tool):
         last_progress = 0
         
         for v in transformed_vertices:
-            diff = v - min_z_vertex
-            length = math.sqrt(diff[0] * diff[0] + diff[1] * diff[1] + diff[2] * diff[2])
+            diff = v - min_y_vertex
+            length = math.sqrt(diff[0] * diff[0] + diff[2] * diff[2] + diff[1] * diff[1])
             if length < 5:
                 continue
-            dot = (diff[2] / length)
+            dot = (diff[1] / length)
             if dot_min > dot:
                 dot_min = dot
                 dot_v = diff
@@ -192,15 +195,7 @@ class RotateTool(Tool):
             progress_message.hide()
             self.operationStopped.emit(self)
             return
-        rad = -math.atan2(dot_v[1], dot_v[0])
-        m = Matrix([
-            [ math.cos(rad), math.sin(rad), 0 ],
-            [-math.sin(rad), math.cos(rad), 0 ],
-            [ 0,             0,             1 ]
-        ])
-        selected_object.rotate(Quaternion.fromMatrix(m), SceneNode.TransformSpace.Local)
-
-        rad = -math.asin(dot_min)
+        rad = -math.atan2(dot_v[2], dot_v[0])
         m = Matrix([
             [ math.cos(rad), 0, math.sin(rad)],
             [ 0,             1, 0 ],
@@ -208,17 +203,25 @@ class RotateTool(Tool):
         ])
         selected_object.rotate(Quaternion.fromMatrix(m), SceneNode.TransformSpace.Local)
 
+        rad = -math.asin(dot_min)
+        m = Matrix([
+            [ math.cos(rad), math.sin(rad), 0 ],
+            [-math.sin(rad), math.cos(rad), 0 ],
+            [ 0,             0,             1 ]
+        ])
+        selected_object.rotate(Quaternion.fromMatrix(m), SceneNode.TransformSpace.Local)
+
         transformed_vertices = selected_object.getMeshDataTransformed().getVertices()
-        min_z_vertex = transformed_vertices[transformed_vertices.argmin(0)[2]]
+        min_y_vertex = transformed_vertices[transformed_vertices.argmin(0)[1]]
         dot_min = 1.0
         dot_v = None
 
         for v in transformed_vertices:
-            diff = v - min_z_vertex
-            length = math.sqrt(diff[1] * diff[1] + diff[2] * diff[2])
+            diff = v - min_y_vertex
+            length = math.sqrt(diff[2] * diff[2] + diff[1] * diff[1])
             if length < 5:
                 continue
-            dot = (diff[2] / length)
+            dot = (diff[1] / length)
             if dot_min > dot:
                 dot_min = dot
                 dot_v = diff
@@ -233,14 +236,14 @@ class RotateTool(Tool):
             progress_message.hide()
             self.operationStopped.emit(self)
             return
-        if dot_v[1] < 0:
+        if dot_v[2] < 0:
             rad = math.asin(dot_min)
         else:
             rad = -math.asin(dot_min)
         m = Matrix([
             [ 1, 0,             0 ],
-            [ 0, math.cos(rad), math.sin(rad) ],
-            [ 0,-math.sin(rad), math.cos(rad) ]
+            [ 0, math.cos(rad),-math.sin(rad) ],
+            [ 0, math.sin(rad), math.cos(rad) ]
         ])
         selected_object.rotate(Quaternion.fromMatrix(m), SceneNode.TransformSpace.Local)
         progress_message.hide()

--- a/plugins/Tools/RotateTool/RotateTool.py
+++ b/plugins/Tools/RotateTool/RotateTool.py
@@ -1,6 +1,9 @@
 # Copyright (c) 2015 Ultimaker B.V.
 # Uranium is released under the terms of the AGPLv3 or higher.
 
+# TODO: find a better way to let the gui thread process events
+from PyQt5.QtWidgets import QApplication
+
 from UM.Tool import Tool
 from UM.Event import Event, MouseEvent, KeyEvent
 from UM.Application import Application
@@ -158,13 +161,17 @@ class RotateTool(Tool):
         progress_message = Message("Laying object flat on buildplate...", lifetime = 0, dismissable = False)
         progress_message.setProgress(-1)
 
+        # TODO: find a better way to let the gui thread process events
+        QApplication.processEvents()
+        
         total_iterations = 0
         for selected_object in Selection.getAllSelectedObjects():
             total_iterations += len(selected_object.getMeshDataTransformed().getVertices()) * 2
 
         progress_message.setMaxProgress(total_iterations)
         progress_message.show()
-            
+
+        # TODO: find a way to show progress during applyOperation
         Selection.applyOperation(LayFlatOperation)
 
         progress_message.hide()

--- a/plugins/Tools/RotateTool/RotateTool.py
+++ b/plugins/Tools/RotateTool/RotateTool.py
@@ -192,7 +192,7 @@ class RotateTool(Tool):
             progress_message.hide()
             self.operationStopped.emit(self)
             return
-        rad = math.atan2(dot_v[1], dot_v[0])
+        rad = -math.atan2(dot_v[1], dot_v[0])
         m = Matrix([
             [ math.cos(rad), math.sin(rad), 0 ],
             [-math.sin(rad), math.cos(rad), 0 ],
@@ -200,7 +200,7 @@ class RotateTool(Tool):
         ])
         selected_object.rotate(Quaternion.fromMatrix(m), SceneNode.TransformSpace.Local)
 
-        rad = math.asin(dot_min)
+        rad = -math.asin(dot_min)
         m = Matrix([
             [ math.cos(rad), 0, math.sin(rad)],
             [ 0,             1, 0 ],
@@ -234,9 +234,9 @@ class RotateTool(Tool):
             self.operationStopped.emit(self)
             return
         if dot_v[1] < 0:
-            rad = -math.asin(dot_min)
-        else:
             rad = math.asin(dot_min)
+        else:
+            rad = -math.asin(dot_min)
         m = Matrix([
             [ 1, 0,             0 ],
             [ 0, math.cos(rad), math.sin(rad) ],

--- a/plugins/Tools/RotateTool/RotateTool.py
+++ b/plugins/Tools/RotateTool/RotateTool.py
@@ -171,7 +171,7 @@ class RotateTool(Tool):
                 dot_v = diff
         if dot_v is None:
             return
-        rad = -math.atan2(dot_v[1], dot_v[0])
+        rad = math.atan2(dot_v[1], dot_v[0])
         m = Matrix([
             [ math.cos(rad), math.sin(rad), 0 ],
             [-math.sin(rad), math.cos(rad), 0 ],
@@ -179,7 +179,7 @@ class RotateTool(Tool):
         ])
         selected_object.rotate(Quaternion.fromMatrix(m), SceneNode.TransformSpace.Local)
 
-        rad = -math.asin(dot_min)
+        rad = math.asin(dot_min)
         m = Matrix([
             [ math.cos(rad), 0, math.sin(rad)],
             [ 0,             1, 0 ],
@@ -204,56 +204,12 @@ class RotateTool(Tool):
         if dot_v is None:
             return
         if dot_v[1] < 0:
-            rad = math.asin(dot_min)
-        else:
             rad = -math.asin(dot_min)
+        else:
+            rad = math.asin(dot_min)
         m = Matrix([
             [ 1, 0,             0 ],
             [ 0, math.cos(rad), math.sin(rad) ],
             [ 0,-math.sin(rad), math.cos(rad) ]
         ])
         selected_object.rotate(Quaternion.fromMatrix(m), SceneNode.TransformSpace.Local)
-
-        """
-		transformedVertexes = self._meshList[0].getTransformedVertexes()
-		minZvertex = transformedVertexes[transformedVertexes.argmin(0)[2]]
-		dotMin = 1.0
-		dotV = None
-		for v in transformedVertexes:
-			diff = v - minZvertex
-			len = math.sqrt(diff[0] * diff[0] + diff[1] * diff[1] + diff[2] * diff[2])
-			if len < 5:
-				continue
-			dot = (diff[2] / len)
-			if dotMin > dot:
-				dotMin = dot
-				dotV = diff
-		if dotV is None:
-			return
-		rad = -math.atan2(dotV[1], dotV[0])
-		self._matrix *= numpy.matrix([[math.cos(rad), math.sin(rad), 0], [-math.sin(rad), math.cos(rad), 0], [0,0,1]], numpy.float64)
-		rad = -math.asin(dotMin)
-		self._matrix *= numpy.matrix([[math.cos(rad), 0, math.sin(rad)], [0,1,0], [-math.sin(rad), 0, math.cos(rad)]], numpy.float64)
-
-
-		transformedVertexes = self._meshList[0].getTransformedVertexes()
-		minZvertex = transformedVertexes[transformedVertexes.argmin(0)[2]]
-		dotMin = 1.0
-		dotV = None
-		for v in transformedVertexes:
-			diff = v - minZvertex
-			len = math.sqrt(diff[1] * diff[1] + diff[2] * diff[2])
-			if len < 5:
-				continue
-			dot = (diff[2] / len)
-			if dotMin > dot:
-				dotMin = dot
-				dotV = diff
-		if dotV is None:
-			return
-		if dotV[1] < 0:
-			rad = math.asin(dotMin)
-		else:
-			rad = -math.asin(dotMin)
-		self.applyMatrix(numpy.matrix([[1,0,0], [0, math.cos(rad), math.sin(rad)], [0, -math.sin(rad), math.cos(rad)]], numpy.float64))
-		"""

--- a/plugins/Tools/RotateTool/RotateTool.py
+++ b/plugins/Tools/RotateTool/RotateTool.py
@@ -185,15 +185,15 @@ class RotateTool(Tool):
         if self._progress_message:
             self._progress_message.hide()
             self._progress_message = None
-            
+
         self.operationStopped.emit(self)
-        
+
 class LayFlatJob(Job):
     def __init__(self, operations):
         super().__init__()
 
         self._operations = operations
 
-    def run(self):        
+    def run(self):
         for op in self._operations:
             op.process()

--- a/plugins/Tools/RotateTool/RotateTool.py
+++ b/plugins/Tools/RotateTool/RotateTool.py
@@ -195,13 +195,13 @@ class RotateTool(Tool):
             progress_message.hide()
             self.operationStopped.emit(self)
             return
-        rad = -math.atan2(dot_v[2], dot_v[0])
+        rad = math.atan2(dot_v[2], dot_v[0])
         m = Matrix([
             [ math.cos(rad), 0, math.sin(rad)],
             [ 0,             1, 0 ],
             [-math.sin(rad), 0, math.cos(rad)]
         ])
-        selected_object.rotate(Quaternion.fromMatrix(m), SceneNode.TransformSpace.Local)
+        selected_object.rotate(Quaternion.fromMatrix(m), SceneNode.TransformSpace.World)
 
         rad = -math.asin(dot_min)
         m = Matrix([
@@ -209,7 +209,7 @@ class RotateTool(Tool):
             [-math.sin(rad), math.cos(rad), 0 ],
             [ 0,             0,             1 ]
         ])
-        selected_object.rotate(Quaternion.fromMatrix(m), SceneNode.TransformSpace.Local)
+        selected_object.rotate(Quaternion.fromMatrix(m), SceneNode.TransformSpace.World)
 
         transformed_vertices = selected_object.getMeshDataTransformed().getVertices()
         min_y_vertex = transformed_vertices[transformed_vertices.argmin(0)[1]]
@@ -237,14 +237,14 @@ class RotateTool(Tool):
             self.operationStopped.emit(self)
             return
         if dot_v[2] < 0:
-            rad = math.asin(dot_min)
-        else:
             rad = -math.asin(dot_min)
+        else:
+            rad = math.asin(dot_min)
         m = Matrix([
             [ 1, 0,             0 ],
             [ 0, math.cos(rad),-math.sin(rad) ],
             [ 0, math.sin(rad), math.cos(rad) ]
         ])
-        selected_object.rotate(Quaternion.fromMatrix(m), SceneNode.TransformSpace.Local)
+        selected_object.rotate(Quaternion.fromMatrix(m), SceneNode.TransformSpace.World)
         progress_message.hide()
         self.operationStopped.emit(self)

--- a/plugins/Tools/RotateTool/RotateTool.qml
+++ b/plugins/Tools/RotateTool/RotateTool.qml
@@ -15,6 +15,9 @@ Item
     {
         id: resetRotationButton
 
+        anchors.left: parent.left;
+        anchors.leftMargin: UM.Theme.sizes.default_margin.width;
+
         //: Reset Rotation tool button
         text: catalog.i18nc("@action:button","Reset")
         iconSource: UM.Theme.icons.rotate_reset;
@@ -27,11 +30,30 @@ Item
         onClicked: UM.ActiveTool.triggerAction("resetRotation");
     }
 
-    CheckBox
+    Button
     {
+        id: layFlatButton
+
         anchors.left: resetRotationButton.right;
         anchors.leftMargin: UM.Theme.sizes.default_margin.width;
-        anchors.bottom: resetRotationButton.bottom;
+
+        //: Lay Flat tool button
+        text: catalog.i18nc("@action:button","Lay flat")
+        iconSource: UM.Theme.icons.rotate_reset;
+        //: Reset Rotation tool button tooltip
+        tooltip: catalog.i18nc("@info:tooltip","Attempt to lay the object flat on the buildplate.");
+
+        style: UM.Theme.styles.tool_button;
+
+        onClicked: UM.ActiveTool.triggerAction("layFlat");
+    }
+
+    CheckBox
+    {
+        anchors.left: parent.left;
+        anchors.leftMargin: UM.Theme.sizes.default_margin.width;
+        anchors.top: resetRotationButton.bottom;
+        anchors.topMargin: UM.Theme.sizes.default_margin.width;
 
         //: Snap Rotation checkbox
         text: catalog.i18nc("@action:checkbox","Snap Rotation");

--- a/plugins/Tools/RotateTool/RotateTool.qml
+++ b/plugins/Tools/RotateTool/RotateTool.qml
@@ -39,7 +39,7 @@ Item
 
         //: Lay Flat tool button
         text: catalog.i18nc("@action:button","Lay flat")
-        iconSource: UM.Theme.icons.rotate_reset;
+        iconSource: UM.Theme.icons.rotate_layflat;
         //: Reset Rotation tool button tooltip
         tooltip: catalog.i18nc("@info:tooltip","Attempt to lay the object flat on the buildplate.");
 


### PR DESCRIPTION
Reissue of #79, against 2.1 branch

Mostly a straight port of @daid's version in legacy cura:
https://github.com/daid/Cura/blob/SteamEngine/Cura/util/printableObject.py#L207

Changes:
* Swap Y & Z axes
* Add progressbar during calculation
* (Add button to rotatetool panel)
* Iterate over all selected objects