### PR TITLE
Per-machineinstance profiles

### DIFF
--- a/UM/Qt/Bindings/MachineManagerProxy.py
+++ b/UM/Qt/Bindings/MachineManagerProxy.py
@@ -109,9 +109,9 @@ class MachineManagerProxy(QObject):
                 custom_profile = deepcopy(profile)
                 custom_profile.setReadOnly(False)
                 custom_profile.setName(custom_profile_name)
-                custom_profile.setMachineType(machine_instance.getMachineDefinition().getId())
-                custom_profile.setMachineVariant(machine_instance.getMachineDefinition().getVariantName())
-                custom_profile.setMachineInstance(machine_instance.getName())
+                custom_profile.setMachineTypeName(machine_instance.getMachineDefinition().getId())
+                custom_profile.setMachineVariantName(machine_instance.getMachineDefinition().getVariantName())
+                custom_profile.setMachineInstanceName(machine_instance.getName())
                 self._manager.addProfile(custom_profile)
 
             self._changed_setting = (key, value)

--- a/UM/Qt/Bindings/MachineManagerProxy.py
+++ b/UM/Qt/Bindings/MachineManagerProxy.py
@@ -104,9 +104,14 @@ class MachineManagerProxy(QObject):
             custom_profile_name = catalog.i18nc("@item:intext appended to customised profiles ({0} is old profile name)", "{0} (Customised)", profile.getName())
             custom_profile = self._manager.findProfile(custom_profile_name)
             if not custom_profile:
+                machine_instance = self._manager.getActiveMachineInstance()
+
                 custom_profile = deepcopy(profile)
                 custom_profile.setReadOnly(False)
                 custom_profile.setName(custom_profile_name)
+                custom_profile.setMachineType(machine_instance.getMachineDefinition().getId())
+                custom_profile.setMachineVariant(machine_instance.getMachineDefinition().getVariantName())
+                custom_profile.setMachineInstance(machine_instance.getName())
                 self._manager.addProfile(custom_profile)
 
             self._changed_setting = (key, value)

--- a/UM/Qt/Bindings/ProfilesModel.py
+++ b/UM/Qt/Bindings/ProfilesModel.py
@@ -197,14 +197,8 @@ class ProfilesModel(ListModel):
         self._onProfilesChanged()
 
         #Restore active profile for this machine_instance.
-        active_profile = None
         active_instance_name = self._manager.getActiveMachineInstance().getActiveProfileName()
-        #We can't use findProfile(active_instance_name) because there may be multiple profiles with the same name on different machine instances.
-        profiles = self._manager.getProfiles()
-        for profile in profiles:
-            if profile.getName() == active_instance_name:
-                active_profile = profile
-                break
+        active_profile = self._manager.findProfile(name)
 
         self._manager.setActiveProfile(active_profile)
 

--- a/UM/Qt/Bindings/ProfilesModel.py
+++ b/UM/Qt/Bindings/ProfilesModel.py
@@ -200,6 +200,13 @@ class ProfilesModel(ListModel):
         active_instance_name = self._manager.getActiveMachineInstance().getActiveProfileName()
         active_profile = self._manager.findProfile(active_instance_name)
 
+        if not active_profile:
+            #A profile by this name is no longer in the filtered list of profiles.
+            profiles = self._manager.getProfiles()
+            for profile in profiles:
+                active_profile = profile #Default to first profile you can find.
+                break
+
         self._manager.setActiveProfile(active_profile)
 
     def _onProfilesChanged(self):

--- a/UM/Qt/Bindings/ProfilesModel.py
+++ b/UM/Qt/Bindings/ProfilesModel.py
@@ -196,6 +196,18 @@ class ProfilesModel(ListModel):
     def _onMachineInstanceChanged(self):
         self._onProfilesChanged()
 
+        #Restore active profile for this machine_instance.
+        active_profile = None
+        active_instance_name = self._manager.getActiveMachineInstance().getActiveProfileName()
+        #We can't use findProfile(active_instance_name) because there may be multiple profiles with the same name on different machine instances.
+        profiles = self._manager.getProfiles()
+        for profile in profiles:
+            if profile.getName() == active_instance_name:
+                active_profile = profile
+                break
+
+        self._manager.setActiveProfile(active_profile)
+
     def _onProfilesChanged(self):
         self.clear()
 

--- a/UM/Qt/Bindings/ProfilesModel.py
+++ b/UM/Qt/Bindings/ProfilesModel.py
@@ -37,6 +37,7 @@ class ProfilesModel(ListModel):
         self._manager = Application.getInstance().getMachineManager()
 
         self._manager.profilesChanged.connect(self._onProfilesChanged)
+        self._manager.activeMachineInstanceChanged.connect(self._onMachineInstanceChanged)
         self._manager.activeProfileChanged.connect(self._onActiveProfileChanged)
         self._manager.profileNameChanged.connect(self._onProfileNameChanged)
         self._onProfilesChanged()
@@ -191,6 +192,9 @@ class ProfilesModel(ListModel):
             filters.append(description + " (*." + extension + ")")
         filters.append(catalog.i18nc("@item:inlistbox", "All Files (*)")) #Also allow arbitrary files, if the user so prefers.
         return filters
+
+    def _onMachineInstanceChanged(self):
+        self._onProfilesChanged()
 
     def _onProfilesChanged(self):
         self.clear()

--- a/UM/Qt/Bindings/ProfilesModel.py
+++ b/UM/Qt/Bindings/ProfilesModel.py
@@ -198,7 +198,7 @@ class ProfilesModel(ListModel):
 
         #Restore active profile for this machine_instance.
         active_instance_name = self._manager.getActiveMachineInstance().getActiveProfileName()
-        active_profile = self._manager.findProfile(name)
+        active_profile = self._manager.findProfile(active_instance_name)
 
         self._manager.setActiveProfile(active_profile)
 

--- a/UM/Qt/Bindings/SettingCategoriesModel.py
+++ b/UM/Qt/Bindings/SettingCategoriesModel.py
@@ -77,6 +77,9 @@ class SettingCategoriesModel(ListModel):
         self.setProperty(index, "hiddenValuesCount", category.getHiddenValuesCount())
 
     def _onActiveProfileChanged(self):
+        if not self._machine_instance:
+            return
+
         for category in self._machine_instance.getMachineDefinition().getAllCategories():
             index = self.find("id", category.getKey())
             self.setProperty(index, "hiddenValuesCount", category.getHiddenValuesCount())

--- a/UM/Qt/Bindings/SettingsFromCategoryModel.py
+++ b/UM/Qt/Bindings/SettingsFromCategoryModel.py
@@ -84,9 +84,9 @@ class SettingsFromCategoryModel(ListModel, SignalEmitter):
                     custom_profile = deepcopy(self._profile)
                     custom_profile.setReadOnly(False)
                     custom_profile.setName(custom_profile_name)
-                    custom_profile.setMachineType(machine_instance.getMachineDefinition().getId())
-                    custom_profile.setMachineVariant(machine_instance.getMachineDefinition().getVariantName())
-                    custom_profile.setMachineInstance(machine_instance.getName())
+                    custom_profile.setMachineTypeName(machine_instance.getMachineDefinition().getId())
+                    custom_profile.setMachineVariantName(machine_instance.getMachineDefinition().getVariantName())
+                    custom_profile.setMachineInstanceName(machine_instance.getName())
                     self._machine_manager.addProfile(custom_profile)
 
                 self._changed_setting = (key, value)

--- a/UM/Qt/Bindings/SettingsFromCategoryModel.py
+++ b/UM/Qt/Bindings/SettingsFromCategoryModel.py
@@ -79,9 +79,14 @@ class SettingsFromCategoryModel(ListModel, SignalEmitter):
                 custom_profile_name = catalog.i18nc("@item:intext appended to customised profiles ({0} is old profile name)", "{0} (Customised)", self._profile.getName())
                 custom_profile = self._machine_manager.findProfile(custom_profile_name)
                 if not custom_profile:
+                    machine_instance = self._machine_manager.getActiveMachineInstance()
+
                     custom_profile = deepcopy(self._profile)
                     custom_profile.setReadOnly(False)
                     custom_profile.setName(custom_profile_name)
+                    custom_profile.setMachineType(machine_instance.getMachineDefinition().getId())
+                    custom_profile.setMachineVariant(machine_instance.getMachineDefinition().getVariantName())
+                    custom_profile.setMachineInstance(machine_instance.getName())
                     self._machine_manager.addProfile(custom_profile)
 
                 self._changed_setting = (key, value)

--- a/UM/Settings/MachineInstance.py
+++ b/UM/Settings/MachineInstance.py
@@ -102,7 +102,7 @@ class MachineInstance(SignalEmitter):
         self._machine_definition.loadAll()
 
         self._name = config.get("general", "name")
-        self._active_profile_name = config.get("general", "acitve_profile", fallback="")
+        self._active_profile_name = config.get("general", "active_profile", fallback="")
 
         for key, value in config["machine_settings"].items():
             self._machine_setting_overrides[key] = value

--- a/UM/Settings/MachineInstance.py
+++ b/UM/Settings/MachineInstance.py
@@ -22,6 +22,8 @@ class MachineInstance(SignalEmitter):
             self._machine_definition.loadAll()
         self._machine_setting_overrides = {}
 
+        self._active_profile_name = None
+
     nameChanged = Signal()
 
     def getName(self):
@@ -32,6 +34,12 @@ class MachineInstance(SignalEmitter):
             old_name = self._name
             self._name = name
             self.nameChanged.emit(self, old_name)
+
+    def getActiveProfileName(self):
+        return self._active_profile_name
+
+    def setActiveProfileName(self, active_profile_name):
+        self._active_profile_name = active_profile_name
 
     def getMachineDefinition(self):
         return self._machine_definition

--- a/UM/Settings/MachineInstance.py
+++ b/UM/Settings/MachineInstance.py
@@ -102,6 +102,7 @@ class MachineInstance(SignalEmitter):
         self._machine_definition.loadAll()
 
         self._name = config.get("general", "name")
+        self._active_profile_name = config.get("general", "acitve_profile", fallback="")
 
         for key, value in config["machine_settings"].items():
             self._machine_setting_overrides[key] = value
@@ -112,6 +113,7 @@ class MachineInstance(SignalEmitter):
         config.add_section("general")
         config["general"]["name"] = self._name
         config["general"]["type"] = self._machine_definition.getId()
+        config["general"]["active_profile"] = self._active_profile_name
         config["general"]["version"] = str(self.MachineInstanceVersion)
         if self._machine_definition.getVariantName():
             config["general"]["variant"] = self._machine_definition.getVariantName()

--- a/UM/Settings/MachineManager.py
+++ b/UM/Settings/MachineManager.py
@@ -175,7 +175,27 @@ class MachineManager(SignalEmitter):
     profileNameChanged = Signal()
 
     def getProfiles(self):
-        return self._profiles
+        active_machine_type = self._active_machine.getMachineDefinition().getId()
+        active_machine_variant = self._active_machine.getMachineDefinition().getVariantName()
+        active_machine_instance = self._active_machine.getName()
+
+        filtered_profiles = []
+        for profile in self._profiles:
+            machine_type = profile.getMachineType()
+            machine_variant = profile.getMachineVariant()
+            machine_instance = profile.getMachineInstance()
+
+            if machine_type and machine_type == active_machine_type:
+                if (not machine_instance) and (not machine_variant):
+                    filtered_profiles.append(profile)                
+                elif (not machine_instance) or (machine_instance == active_machine_instance):
+                    filtered_profiles.append(profile)
+                elif (not machine_variant) or (machine_variant == active_machine_variant):
+                    filtered_profiles.append(profile)
+            elif not machine_type:
+                filtered_profiles.append(profile)
+
+        return filtered_profiles
 
     def addProfile(self, profile):
         if profile in self._profiles:

--- a/UM/Settings/MachineManager.py
+++ b/UM/Settings/MachineManager.py
@@ -184,7 +184,7 @@ class MachineManager(SignalEmitter):
     def getProfiles(self, active_instance_profiles_only = True):
         if not active_instance_profiles_only:
             return self._profiles
-        
+
         if not self._active_machine:
             return self._profiles
 
@@ -200,7 +200,7 @@ class MachineManager(SignalEmitter):
 
             if machine_type and machine_type == active_machine_type:
                 if (not machine_instance) and (not machine_variant):
-                    filtered_profiles.append(profile)                
+                    filtered_profiles.append(profile)
                 elif (not machine_instance) or (machine_instance == active_machine_instance):
                     filtered_profiles.append(profile)
                 elif (not machine_instance) and (machine_variant == active_machine_variant):
@@ -380,7 +380,7 @@ class MachineManager(SignalEmitter):
                 if profile.isReadOnly():
                     continue
 
-                profile_name = profile.getName() + "@" + profile.getMachineInstanceName() 
+                profile_name = profile.getName() + "@" + profile.getMachineInstanceName()
                 file_name = urllib.parse.quote_plus(profile_name) + ".cfg"
                 profile.saveToFile(Resources.getStoragePath(Resources.Profiles, file_name))
         except AttributeError:

--- a/UM/Settings/MachineManager.py
+++ b/UM/Settings/MachineManager.py
@@ -190,7 +190,7 @@ class MachineManager(SignalEmitter):
                     filtered_profiles.append(profile)                
                 elif (not machine_instance) or (machine_instance == active_machine_instance):
                     filtered_profiles.append(profile)
-                elif (not machine_variant) or (machine_variant == active_machine_variant):
+                elif (not machine_instance) and (machine_variant == active_machine_variant):
                     filtered_profiles.append(profile)
             elif not machine_type:
                 filtered_profiles.append(profile)

--- a/UM/Settings/MachineManager.py
+++ b/UM/Settings/MachineManager.py
@@ -373,7 +373,8 @@ class MachineManager(SignalEmitter):
                 if profile.isReadOnly():
                     continue
 
-                file_name = urllib.parse.quote_plus(profile.getName()) + ".cfg"
+                profile_name = profile.getName() + "@" + profile.getMachineInstance() 
+                file_name = urllib.parse.quote_plus(profile_name) + ".cfg"
                 profile.saveToFile(Resources.getStoragePath(Resources.Profiles, file_name))
         except AttributeError:
             pass

--- a/UM/Settings/MachineManager.py
+++ b/UM/Settings/MachineManager.py
@@ -244,6 +244,7 @@ class MachineManager(SignalEmitter):
             return
 
         self._active_profile = profile
+        self._active_machine.setActiveProfileName(profile.getName())
 
         self.activeProfileChanged.emit()
 

--- a/UM/Settings/MachineManager.py
+++ b/UM/Settings/MachineManager.py
@@ -184,6 +184,9 @@ class MachineManager(SignalEmitter):
     def getProfiles(self, active_instance_profiles_only = True):
         if not active_instance_profiles_only:
             return self._profiles
+        
+        if not self._active_machine:
+            return self._profiles
 
         active_machine_type = self._active_machine.getMachineDefinition().getId()
         active_machine_variant = self._active_machine.getMachineDefinition().getVariantName()
@@ -211,7 +214,8 @@ class MachineManager(SignalEmitter):
         if profile in self._profiles:
             return
 
-        for p in self._profiles:
+        profiles = self.getProfiles()
+        for p in profiles:
             if p.getName() == profile.getName():
                 raise SettingsError.DuplicateProfileError(profile.getName())
 
@@ -376,7 +380,7 @@ class MachineManager(SignalEmitter):
                 if profile.isReadOnly():
                     continue
 
-                profile_name = profile.getName() + "@" + profile.getMachineInstance() 
+                profile_name = profile.getName() + "@" + profile.getMachineInstanceName() 
                 file_name = urllib.parse.quote_plus(profile_name) + ".cfg"
                 profile.saveToFile(Resources.getStoragePath(Resources.Profiles, file_name))
         except AttributeError:

--- a/UM/Settings/MachineManager.py
+++ b/UM/Settings/MachineManager.py
@@ -39,7 +39,6 @@ class MachineManager(SignalEmitter):
 
         Preferences.getInstance().addPreference("machines/setting_visibility", "")
         Preferences.getInstance().addPreference("machines/active_instance", "")
-        Preferences.getInstance().addPreference("machines/active_profile", "Normal Quality")
 
     def getApplicationName(self):
         return self._application_name
@@ -336,14 +335,6 @@ class MachineManager(SignalEmitter):
                     self._profiles.append(profile)
                     profile.nameChanged.connect(self._onProfileNameChanged)
 
-        profile = self.findProfile(Preferences.getInstance().getValue("machines/active_profile"))
-        if profile:
-            self.setActiveProfile(profile)
-        else:
-            if Preferences.getInstance().getValue("machines/active_profile") == "":
-                for profile in self._profiles:
-                    self.setActiveProfile(profile) #default to first profile you can find
-                    break
         self.profilesChanged.emit()
 
     def loadVisibility(self):
@@ -368,7 +359,6 @@ class MachineManager(SignalEmitter):
 
     def saveProfiles(self):
         try:
-            Preferences.getInstance().setValue("machines/active_profile", self._active_profile.getName())
             for profile in self._profiles:
                 if profile.isReadOnly():
                     continue

--- a/UM/Settings/MachineManager.py
+++ b/UM/Settings/MachineManager.py
@@ -181,7 +181,10 @@ class MachineManager(SignalEmitter):
 
     profileNameChanged = Signal()
 
-    def getProfiles(self):
+    def getProfiles(self, active_instance_profiles_only = True):
+        if not active_instance_profiles_only:
+            return self._profiles
+
         active_machine_type = self._active_machine.getMachineDefinition().getId()
         active_machine_variant = self._active_machine.getMachineDefinition().getVariantName()
         active_machine_instance = self._active_machine.getName()
@@ -234,8 +237,10 @@ class MachineManager(SignalEmitter):
         if profile == self._active_profile:
             self.setActiveProfile(self._profiles[0])
 
-    def findProfile(self, name):
-        for profile in self._profiles:
+    def findProfile(self, name, active_instance_profiles_only = True):
+        profiles = self.getProfiles(active_instance_profiles_only);
+
+        for profile in profiles:
             if profile.getName() == name:
                 return profile
 

--- a/UM/Settings/MachineManager.py
+++ b/UM/Settings/MachineManager.py
@@ -201,9 +201,9 @@ class MachineManager(SignalEmitter):
             if machine_type and machine_type == active_machine_type:
                 if (not machine_instance) and (not machine_variant):
                     filtered_profiles.append(profile)
-                elif (not machine_instance) or (machine_instance == active_machine_instance):
+                elif machine_instance and (machine_instance == active_machine_instance):
                     filtered_profiles.append(profile)
-                elif (not machine_instance) and (machine_variant == active_machine_variant):
+                elif machine_variant and (machine_variant == active_machine_variant):
                     filtered_profiles.append(profile)
             elif not machine_type:
                 filtered_profiles.append(profile)

--- a/UM/Settings/MachineManager.py
+++ b/UM/Settings/MachineManager.py
@@ -181,9 +181,9 @@ class MachineManager(SignalEmitter):
 
         filtered_profiles = []
         for profile in self._profiles:
-            machine_type = profile.getMachineType()
-            machine_variant = profile.getMachineVariant()
-            machine_instance = profile.getMachineInstance()
+            machine_type = profile.getMachineTypeName()
+            machine_variant = profile.getMachineVariantName()
+            machine_instance = profile.getMachineInstanceName()
 
             if machine_type and machine_type == active_machine_type:
                 if (not machine_instance) and (not machine_variant):

--- a/UM/Settings/MachineManager.py
+++ b/UM/Settings/MachineManager.py
@@ -146,6 +146,14 @@ class MachineManager(SignalEmitter):
 
         self._updateSettingVisibility(setting_visibility)
 
+        profile = self.findProfile(machine.getActiveProfileName())
+        if profile:
+            self.setActiveProfile(profile)
+        else:
+            for profile in self._profiles:
+                self.setActiveProfile(profile) #default to first profile you can find
+                break
+
         self.activeMachineInstanceChanged.emit()
 
     def setActiveMachineVariant(self, variant):
@@ -248,9 +256,9 @@ class MachineManager(SignalEmitter):
         self.activeProfileChanged.emit()
 
     def loadAll(self):
+        self.loadProfiles()
         self.loadMachineDefinitions()
         self.loadMachineInstances()
-        self.loadProfiles()
         self.loadVisibility()
 
     def loadMachineDefinitions(self):

--- a/UM/Settings/Profile.py
+++ b/UM/Settings/Profile.py
@@ -279,7 +279,7 @@ class Profile(SignalEmitter):
             Logger.log("e", "Failed to write profile to %s: %s", file, str(e))
             return str(e)
         return None
-    
+
     ##  Serialise this profile to a string.
     def serialise(self):
         stream = io.StringIO() #ConfigParser needs to write to a stream.
@@ -298,7 +298,7 @@ class Profile(SignalEmitter):
         parser.add_section("settings") #Write each changed setting in a settings section.
         for setting_key in self._changed_settings:
             parser.set("settings", setting_key , str(self._changed_settings[setting_key]))
-        
+
         parser.write(stream) #Actually serialise it to the stream.
         return stream.getvalue()
 

--- a/UM/Settings/Profile.py
+++ b/UM/Settings/Profile.py
@@ -31,9 +31,9 @@ class Profile(SignalEmitter):
         self._machine_manager = machine_manager
         self._changed_settings = {}
         self._name = "Unknown Profile"
-        self._machine_type = None
-        self._machine_variant = None
-        self._machine_instance = None
+        self._machine_type_name = None
+        self._machine_variant_name = None
+        self._machine_instance_name = None
         self._read_only = read_only
 
         self._active_instance = None
@@ -65,28 +65,28 @@ class Profile(SignalEmitter):
         return self._read_only
 
     ##  Retrieve the name of the machine type.
-    def getMachineType(self):
-        return self._machine_type
+    def getMachineTypeName(self):
+        return self._machine_type_name
 
     ##  Set the name of the machine type.
-    def setMachineType(self, machine_type):
-        self._machine_type = machine_type
+    def setMachineTypeName(self, machine_type):
+        self._machine_type_name = machine_type
 
     ##  Retrieve the name of the machine variant.
-    def getMachineVariant(self):
-        return self._machine_variant
+    def getMachineVariantName(self):
+        return self._machine_variant_name
 
     ##  Set the name of the machine type.
-    def setMachineVariant(self, machine_variant):
-        self._machine_variant = machine_variant
+    def setMachineVariantName(self, machine_variant):
+        self._machine_variant_name = machine_variant
 
     ##  Retrieve the name of the machine instance.
-    def getMachineInstance(self):
-        return self._machine_instance
+    def getMachineInstanceName(self):
+        return self._machine_instance_name
 
     ##  Set the name of the machine type.
-    def setMachineInstance(self, machine_instance):
-        self._machine_instance = machine_instance
+    def setMachineInstanceName(self, machine_instance):
+        self._machine_instance_name = machine_instance
 
     ##  Emitted whenever a setting value changes.
     #
@@ -257,11 +257,11 @@ class Profile(SignalEmitter):
 
         self._name = parser.get("general", "name")
         if "machine_type" in parser["general"]:
-            self._machine_type = parser.get("general", "machine_type")
+            self._machine_type_name = parser.get("general", "machine_type")
         if "machine_variant" in parser["general"]:
-            self._machine_variant = parser.get("general", "machine_variant")
+            self._machine_variant_name = parser.get("general", "machine_variant")
         if "machine_instance" in parser["general"]:
-            self._machine_instance = parser.get("general", "machine_instance")
+            self._machine_instance_name = parser.get("general", "machine_instance")
 
         if parser.has_section("settings"):
             for key, value in parser["settings"].items():
@@ -288,12 +288,12 @@ class Profile(SignalEmitter):
         parser.add_section("general") #Write a general section.
         parser.set("general", "version", str(self.ProfileVersion))
         parser.set("general", "name", self._name)
-        if self._machine_type:
-            parser.set("general", "machine_type", self._machine_type)
-        if self._machine_variant:
-            parser.set("general", "machine_variant", self._machine_variant)
-        if self._machine_instance:
-            parser.set("general", "machine_instance", self._machine_instance)
+        if self._machine_type_name:
+            parser.set("general", "machine_type", self._machine_type_name)
+        if self._machine_variant_name:
+            parser.set("general", "machine_variant", self._machine_variant_name)
+        if self._machine_instance_name:
+            parser.set("general", "machine_instance", self._machine_instance_name)
 
         parser.add_section("settings") #Write each changed setting in a settings section.
         for setting_key in self._changed_settings:

--- a/UM/Settings/Profile.py
+++ b/UM/Settings/Profile.py
@@ -76,7 +76,7 @@ class Profile(SignalEmitter):
     def getMachineVariantName(self):
         return self._machine_variant_name
 
-    ##  Set the name of the machine type.
+    ##  Set the name of the machine variant.
     def setMachineVariantName(self, machine_variant):
         self._machine_variant_name = machine_variant
 
@@ -84,7 +84,7 @@ class Profile(SignalEmitter):
     def getMachineInstanceName(self):
         return self._machine_instance_name
 
-    ##  Set the name of the machine type.
+    ##  Set the name of the machine instance.
     def setMachineInstanceName(self, machine_instance):
         self._machine_instance_name = machine_instance
 

--- a/UM/Settings/Profile.py
+++ b/UM/Settings/Profile.py
@@ -68,13 +68,25 @@ class Profile(SignalEmitter):
     def getMachineType(self):
         return self._machine_type
 
+    ##  Set the name of the machine type.
+    def setMachineType(self, machine_type):
+        self._machine_type = machine_type
+
     ##  Retrieve the name of the machine variant.
     def getMachineVariant(self):
         return self._machine_variant
 
+    ##  Set the name of the machine type.
+    def setMachineVariant(self, machine_variant):
+        self._machine_variant = machine_variant
+
     ##  Retrieve the name of the machine instance.
     def getMachineInstance(self):
         return self._machine_instance
+
+    ##  Set the name of the machine type.
+    def setMachineInstance(self, machine_instance):
+        self._machine_instance = machine_instance
 
     ##  Emitted whenever a setting value changes.
     #

--- a/UM/Settings/Profile.py
+++ b/UM/Settings/Profile.py
@@ -31,6 +31,9 @@ class Profile(SignalEmitter):
         self._machine_manager = machine_manager
         self._changed_settings = {}
         self._name = "Unknown Profile"
+        self._machine_type = None
+        self._machine_variant = None
+        self._machine_instance = None
         self._read_only = read_only
 
         self._active_instance = None
@@ -60,6 +63,18 @@ class Profile(SignalEmitter):
     ##  Retrieve if this profile is a read only profile.
     def isReadOnly(self):
         return self._read_only
+
+    ##  Retrieve the name of the machine type.
+    def getMachineType(self):
+        return self._machine_type
+
+    ##  Retrieve the name of the machine variant.
+    def getMachineVariant(self):
+        return self._machine_variant
+
+    ##  Retrieve the name of the machine instance.
+    def getMachineInstance(self):
+        return self._machine_instance
 
     ##  Emitted whenever a setting value changes.
     #
@@ -229,6 +244,12 @@ class Profile(SignalEmitter):
             raise SettingsError.InvalidVersionError(origin)
 
         self._name = parser.get("general", "name")
+        if "machine_type" in parser["general"]:
+            self._machine_type = parser.get("general", "machine_type")
+        if "machine_variant" in parser["general"]:
+            self._machine_variant = parser.get("general", "machine_variant")
+        if "machine_instance" in parser["general"]:
+            self._machine_instance = parser.get("general", "machine_instance")
 
         if parser.has_section("settings"):
             for key, value in parser["settings"].items():
@@ -255,6 +276,12 @@ class Profile(SignalEmitter):
         parser.add_section("general") #Write a general section.
         parser.set("general", "version", str(self.ProfileVersion))
         parser.set("general", "name", self._name)
+        if self._machine_type:
+            parser.set("general", "machine_type", self._machine_type)
+        if self._machine_variant:
+            parser.set("general", "machine_variant", self._machine_variant)
+        if self._machine_instance:
+            parser.set("general", "machine_instance", self._machine_instance)
 
         parser.add_section("settings") #Write each changed setting in a settings section.
         for setting_key in self._changed_settings:


### PR DESCRIPTION
There are "starter-profiles" (eg Low, Normal, High, Ulti) for each Machine Type (eg UMO+) and Machine Variant (eg UM2+ 0.25mm nozzle).

Fields can be added to profile files:
```
[general]
...
machine_type=Ultimaker 2
machine_variant=0.25mm Nozzle
```
Cura will filter the profiles to show just the profiles for the currently selected machine. Custom profiles (created by the user in Cura by modifiying a starter profile) add an additional field:
```
[general]
...
machine_instance=Aldo's Ultimaker 2
```
This is used to show that profile only for the machine instance for which the profile has been created. This mechanism can be extended to filter profiles based on materials ([general] material=PLA).

From a user's perspective not much has changed; the proper profiles are loaded automatically. 

The current active profile is removed from cura.cfg, and is now stored per machine instance.

CURA-568
CURA-569