### PR TITLE
[WIP] i18n: Adding new set of helper commands

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -61,7 +61,9 @@ if(GETTEXT_FOUND)
         file(GLOB po_files ${CMAKE_SOURCE_DIR}/resources/i18n/${lang}/*.po)
         foreach(po_file ${po_files})
             string(REGEX REPLACE ".*/(.*).po" "${CMAKE_BINARY_DIR}/resources/i18n/${lang}/LC_MESSAGES/\\1.mo" mo_file ${po_file})
-            add_custom_command(TARGET translations POST_BUILD COMMAND mkdir ARGS -p ${CMAKE_BINARY_DIR}/resources/i18n/${lang}/LC_MESSAGES/ COMMAND ${GETTEXT_MSGFMT_EXECUTABLE} ARGS ${po_file} -o ${mo_file})
+            add_custom_command(TARGET translations POST_BUILD
+                               COMMAND mkdir ARGS -p ${CMAKE_BINARY_DIR}/resources/i18n/${lang}/LC_MESSAGES/
+                               COMMAND ${GETTEXT_MSGFMT_EXECUTABLE} ARGS ${po_file} -o ${mo_file})
         endforeach()
     endforeach()
     install(DIRECTORY ${CMAKE_BINARY_DIR}/resources DESTINATION ${CMAKE_INSTALL_DATADIR}/uranium/)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,11 +50,6 @@ if(GETTEXT_FOUND)
     # The files are checked for a _qt suffix and if it is found, converted to
     # qm, otherwise they are converted to .po.
     add_custom_target(translations ALL)
-    # copy-translations can be used to copy the built translation files from the
-    # build directory to the source resources directory. This is mostly a convenience
-    # during development, normally you want to simply use the install target to install
-    # the files along side the rest of the application.
-    add_custom_target(copy-translations)
 
     SUBDIRLIST(languages ${CMAKE_SOURCE_DIR}/resources/i18n/)
     foreach(lang ${languages})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -70,7 +70,6 @@ if(GETTEXT_FOUND)
             else()
                 message("GETTEXT_MSGINIT_EXECUTABLE not found!")
             endif()
-            message("GETTEXT_MSGMERGE_EXECUTABLE:" ${GETTEXT_MSGMERGE_EXECUTABLE})
             add_custom_command(TARGET i18n-update-po-${language} POST_BUILD
                                COMMAND ${GETTEXT_MSGMERGE_EXECUTABLE} ARGS -o ${po_file} ${po_file} ${po_file})
         endforeach()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -49,15 +49,18 @@ if(GETTEXT_FOUND)
     # translations target will convert .po files into .mo and .qm as needed.
     # The files are checked for a _qt suffix and if it is found, converted to
     # qm, otherwise they are converted to .po.
-    add_custom_target(translations ALL)
+    add_custom_target(i18n-create-mo ALL)
 
     SUBDIRLIST(languages ${CMAKE_SOURCE_DIR}/resources/i18n/)
-    foreach(lang ${languages})
-        file(GLOB po_files ${CMAKE_SOURCE_DIR}/resources/i18n/${lang}/*.po)
+    foreach(language ${languages})
+        add_custom_target(i18n-create-mo-${language})
+        add_dependencies(i18n-create-mo i18n-create-mo-${language})
+
+        file(GLOB po_files ${CMAKE_SOURCE_DIR}/resources/i18n/${language}/*.po)
         foreach(po_file ${po_files})
-            string(REGEX REPLACE ".*/(.*).po" "${CMAKE_BINARY_DIR}/resources/i18n/${lang}/LC_MESSAGES/\\1.mo" mo_file ${po_file})
-            add_custom_command(TARGET translations POST_BUILD
-                               COMMAND mkdir ARGS -p ${CMAKE_BINARY_DIR}/resources/i18n/${lang}/LC_MESSAGES/
+            string(REGEX REPLACE ".*/(.*).po" "${CMAKE_BINARY_DIR}/resources/i18n/${language}/LC_MESSAGES/\\1.mo" mo_file ${po_file})
+            add_custom_command(TARGET i18n-create-mo-${language} POST_BUILD
+                               COMMAND mkdir ARGS -p ${CMAKE_BINARY_DIR}/resources/i18n/${language}/LC_MESSAGES/
                                COMMAND ${GETTEXT_MSGFMT_EXECUTABLE} ARGS ${po_file} -o ${mo_file})
         endforeach()
     endforeach()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -49,10 +49,34 @@ if(GETTEXT_FOUND)
     # translations target will convert .po files into .mo and .qm as needed.
     # The files are checked for a _qt suffix and if it is found, converted to
     # qm, otherwise they are converted to .po.
+    add_custom_target(i18n-create-po)
+    add_custom_target(i18n-update-po)
     add_custom_target(i18n-create-mo ALL)
 
     SUBDIRLIST(languages ${CMAKE_SOURCE_DIR}/resources/i18n/)
+    file(GLOB pot_files ${CMAKE_SOURCE_DIR}/resources/i18n/*.pot)
     foreach(language ${languages})
+        # *.po files
+        add_custom_target(i18n-create-po-${language})
+        add_dependencies(i18n-create-po i18n-create-po-${language})
+        add_custom_target(i18n-update-po-${language})
+        add_dependencies(i18n-update-po i18n-update-po-${language})
+
+        foreach(pot_file ${pot_files})
+            string(REGEX REPLACE ".*/(.*).pot" "${CMAKE_BINARY_DIR}/resources/i18n/${language}/\\1.po" po_file ${pot_file})
+            if(DEFINED GETTEXT_MSGINIT_EXECUTABLE)
+                message("Using GETTEXT_MSGINIT_EXECUTABLE at:" ${GETTEXT_MSGINIT_EXECUTABLE})
+                add_custom_command(TARGET i18n-create-po-${language} POST_BUILD
+                                   COMMAND ${GETTEXT_MSGINIT_EXECUTABLE} ARGS --no-translator -l ${language} -i ${pot_file} -o ${po_file})
+            else()
+                message("GETTEXT_MSGINIT_EXECUTABLE not found!")
+            endif()
+            message("GETTEXT_MSGMERGE_EXECUTABLE:" ${GETTEXT_MSGMERGE_EXECUTABLE})
+            add_custom_command(TARGET i18n-update-po-${language} POST_BUILD
+                               COMMAND ${GETTEXT_MSGMERGE_EXECUTABLE} ARGS -o ${po_file} ${po_file} ${po_file})
+        endforeach()
+
+        # *.mo files
         add_custom_target(i18n-create-mo-${language})
         add_dependencies(i18n-create-mo i18n-create-mo-${language})
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -65,7 +65,6 @@ if(GETTEXT_FOUND)
         foreach(pot_file ${pot_files})
             string(REGEX REPLACE ".*/(.*).pot" "${CMAKE_BINARY_DIR}/resources/i18n/${language}/\\1.po" po_file ${pot_file})
             if(DEFINED GETTEXT_MSGINIT_EXECUTABLE)
-                message("Using GETTEXT_MSGINIT_EXECUTABLE at:" ${GETTEXT_MSGINIT_EXECUTABLE})
                 add_custom_command(TARGET i18n-create-po-${language} POST_BUILD
                                    COMMAND ${GETTEXT_MSGINIT_EXECUTABLE} ARGS --no-translator -l ${language} -i ${pot_file} -o ${po_file})
             else()


### PR DESCRIPTION
After @TMHogenhout added a documentation how to translate Uranium (and Cura), I decided to create some commands to CMake.

I think about calling the commands like this:
```make i18n-create-po``` - to (re-)create po-file for all languages
```make i18n-create-po-de``` - to (re-)create po-file for _de_ language
```make i18n-create-po-[etc]``` - for every directory at resources/i18n/*

```make i18n-update-po``` - to update po-file all languages
```make i18n-update-po-de``` - to update po-file for _de_ language
```make i18n-update-po-[etc]``` - for every directory at resources/i18n/*

```make i18n-create-mo``` - to (re-)create mo-file for all languages
```make i18n-create-mo-de``` - to (re-)create mo-file for _de_ language
```make i18n-create-mo-[etc]``` - for every directory at resources/i18n/*

I already played a bit with it and it works so far. I also ran into an problem in FindGettext.cmake, which does not find "msginit", so all ```i18n-create-*``` do not work for me
However, in case it works, it is easy then to add new language support. Just ```mkdir resources/i18n/ru```, rerun ```cmake .``` and run ```make i18n-create-po-ru```, for example.

----

TODOs:
* Add version to CMakeLists and only add "-f" when URANIUM_VERSION == "master"
- https://github.com/Ultimaker/Cura/commit/2300410c2ef29362f0cbf8480e6e7b702674cdf9

----

What do you think?