### PR TITLE
Prevent starting a new tooloperation while a tooloperation is running

### DIFF
--- a/UM/Controller.py
+++ b/UM/Controller.py
@@ -34,6 +34,8 @@ class Controller(SignalEmitter):
         self._camera_tool = None
         self._selection_tool = None
 
+        self._tools_enabled = True
+
         PluginRegistry.addType("view", self.addView)
         PluginRegistry.addType("tool", self.addTool)
         PluginRegistry.addType("input_device", self.addInputDevice)
@@ -242,3 +244,10 @@ class Controller(SignalEmitter):
     #   \sa setActiveTool
     def setSelectionTool(self, tool):
         self._selection_tool = self.getTool(tool)
+
+
+    def getToolsEnabled(self):
+        return self._tools_enabled
+
+    def setToolsEnabled(self, enabled):
+        self._tools_enabled = enabled

--- a/UM/Qt/Bindings/ControllerProxy.py
+++ b/UM/Qt/Bindings/ControllerProxy.py
@@ -19,6 +19,7 @@ class ControllerProxy(QObject):
         self._controller = Application.getInstance().getController()
         self._controller.contextMenuRequested.connect(self._onContextMenuRequested)
         self._selection_pass = None
+        self._tools_enabled = True
         
         self._controller.toolOperationStarted.connect(self._onToolOperationStarted)
         self._controller.toolOperationStopped.connect(self._onToolOperationStopped)

--- a/UM/Qt/Bindings/ControllerProxy.py
+++ b/UM/Qt/Bindings/ControllerProxy.py
@@ -20,7 +20,7 @@ class ControllerProxy(QObject):
         self._controller.contextMenuRequested.connect(self._onContextMenuRequested)
         self._selection_pass = None
         self._tools_enabled = True
-        
+
         self._controller.toolOperationStarted.connect(self._onToolOperationStarted)
         self._controller.toolOperationStopped.connect(self._onToolOperationStopped)
 
@@ -64,9 +64,10 @@ class ControllerProxy(QObject):
 
     def _onToolOperationStarted(self, tool):
         self._tools_enabled = False
+        self._controller.setToolsEnabled(False)
         self.toolsEnabledChanged.emit()
 
     def _onToolOperationStopped(self, tool):
         self._tools_enabled = True
+        self._controller.setToolsEnabled(True)
         self.toolsEnabledChanged.emit()
- 

--- a/UM/Qt/Bindings/ControllerProxy.py
+++ b/UM/Qt/Bindings/ControllerProxy.py
@@ -1,7 +1,7 @@
 # Copyright (c) 2015 Ultimaker B.V.
 # Uranium is released under the terms of the AGPLv3 or higher.
 
-from PyQt5.QtCore import QObject, QCoreApplication, pyqtSlot, QUrl, pyqtSignal
+from PyQt5.QtCore import QObject, QCoreApplication, pyqtSlot, QUrl, pyqtSignal, pyqtProperty
 
 from UM.Application import Application
 from UM.Scene.SceneNode import SceneNode
@@ -19,6 +19,15 @@ class ControllerProxy(QObject):
         self._controller = Application.getInstance().getController()
         self._controller.contextMenuRequested.connect(self._onContextMenuRequested)
         self._selection_pass = None
+        
+        self._controller.toolOperationStarted.connect(self._onToolOperationStarted)
+        self._controller.toolOperationStopped.connect(self._onToolOperationStopped)
+
+    toolsEnabledChanged = pyqtSignal()
+
+    @pyqtProperty(bool, notify = toolsEnabledChanged)
+    def toolsEnabled(self):
+        return self._tools_enabled
 
     @pyqtSlot(str)
     def setActiveView(self, view):
@@ -51,3 +60,12 @@ class ControllerProxy(QObject):
             self.contextMenuRequested.emit(id)
         else:
             self.contextMenuRequested.emit(0)
+
+    def _onToolOperationStarted(self, tool):
+        self._tools_enabled = False
+        self.toolsEnabledChanged.emit()
+
+    def _onToolOperationStopped(self, tool):
+        self._tools_enabled = True
+        self.toolsEnabledChanged.emit()
+ 

--- a/plugins/Tools/MirrorTool/MirrorTool.py
+++ b/plugins/Tools/MirrorTool/MirrorTool.py
@@ -26,7 +26,7 @@ class MirrorTool(Tool):
     def event(self, event):
         super().event(event)
 
-        if event.type == Event.MousePressEvent:
+        if event.type == Event.MousePressEvent and self._controller.getToolsEnabled():
             if MouseEvent.LeftButton not in event.buttons:
                 return False
 

--- a/plugins/Tools/RotateTool/RotateTool.py
+++ b/plugins/Tools/RotateTool/RotateTool.py
@@ -53,7 +53,7 @@ class RotateTool(Tool):
             self._snap_rotation = (not self._snap_rotation)
             self.propertyChanged.emit()
 
-        if event.type == Event.MousePressEvent:
+        if event.type == Event.MousePressEvent and self._controller.getToolsEnabled():
             if MouseEvent.LeftButton not in event.buttons:
                 return False
 

--- a/plugins/Tools/ScaleTool/ScaleTool.py
+++ b/plugins/Tools/ScaleTool/ScaleTool.py
@@ -71,7 +71,7 @@ class ScaleTool(Tool):
                 self._non_uniform_scale = False
                 self.propertyChanged.emit()
 
-        if event.type == Event.MousePressEvent:
+        if event.type == Event.MousePressEvent and self._controller.getToolsEnabled():
             if MouseEvent.LeftButton not in event.buttons:
                 return False
 

--- a/plugins/Tools/SelectionTool/SelectionTool.py
+++ b/plugins/Tools/SelectionTool/SelectionTool.py
@@ -39,7 +39,7 @@ class SelectionTool(Tool):
             self._selection_pass = self._renderer.getRenderPass("selection")
 
         self.checkModifierKeys(event)
-        if event.type == MouseEvent.MousePressEvent and MouseEvent.LeftButton in event.buttons:
+        if event.type == MouseEvent.MousePressEvent and MouseEvent.LeftButton in event.buttons and self._controller.getToolsEnabled():
             if self._selection_mode == self.PixelSelectionMode:
                 self._pixelSelection(event)
             else:

--- a/plugins/Tools/TranslateTool/TranslateTool.py
+++ b/plugins/Tools/TranslateTool/TranslateTool.py
@@ -41,7 +41,7 @@ class TranslateTool(Tool):
         if event.type == Event.KeyReleaseEvent and event.key == KeyEvent.ShiftKey:
             self._grid_snap = False
 
-        if event.type == Event.MousePressEvent:
+        if event.type == Event.MousePressEvent and self._controller.getToolsEnabled():
             if MouseEvent.LeftButton not in event.buttons:
                 return False
 


### PR DESCRIPTION
This patch disables tools while a tooloperation is running. Some tool-operations, such as the Lay Flat operation, take a while to complete. It should not be possible to relaunch the lay flat operation while the same operation is already loading. Also manipulating an object with a different tool while an operation is running may affect the outcome of either tools.

Fixes CURA-623
Also see https://github.com/Ultimaker/Cura/pull/606