### PR TITLE
Profiles rework

### DIFF
--- a/UM/Qt/Bindings/ActiveProfileProxy.py
+++ b/UM/Qt/Bindings/ActiveProfileProxy.py
@@ -32,6 +32,15 @@ class ActiveProfileProxy(QObject):
     def setSettingValue(self, key, value):
         self._active_profile.setSettingValue(key, value)
 
+    ## Show any settings that have a value in the current profile but are not visible.
+    @pyqtSlot(str)
+    def showHiddenValues(self, category_id):
+        category = Application.getInstance().getMachineManager().getActiveMachineInstance().getMachineDefinition().getSettingsCategory(category_id)
+        for setting in category.getAllSettings():
+            if not setting.isVisible() and self._active_profile.hasSettingValue(setting.getKey()):
+                setting.setVisible(True)
+        category.visibleChanged.emit(category)
+
     def _onActiveProfileChanged(self):
         if self._active_profile:
             self._active_profile.settingValueChanged.disconnect(self._onSettingValuesChanged)

--- a/UM/Qt/Bindings/ActiveProfileProxy.py
+++ b/UM/Qt/Bindings/ActiveProfileProxy.py
@@ -37,7 +37,7 @@ class ActiveProfileProxy(QObject):
     def showHiddenValues(self, category_id):
         category = Application.getInstance().getMachineManager().getActiveMachineInstance().getMachineDefinition().getSettingsCategory(category_id)
         for setting in category.getAllSettings():
-            if not setting.isVisible() and self._active_profile.hasSettingValue(setting.getKey()):
+            if not setting.isVisible() and self._active_profile.hasSettingValue(setting.getKey(), filter_defaults = False):
                 setting.setVisible(True)
         category.visibleChanged.emit(category)
 

--- a/UM/Qt/Bindings/ActiveProfileProxy.py
+++ b/UM/Qt/Bindings/ActiveProfileProxy.py
@@ -36,7 +36,7 @@ class ActiveProfileProxy(QObject):
         if self._active_profile:
             self._active_profile.settingValueChanged.disconnect(self._onSettingValuesChanged)
 
-        self._active_profile = Application.getInstance().getMachineManager().getActiveProfile()
+        self._active_profile = Application.getInstance().getMachineManager().getWorkingProfile()
         self.activeProfileChanged.emit()
 
         if self._active_profile:

--- a/UM/Qt/Bindings/Bindings.py
+++ b/UM/Qt/Bindings/Bindings.py
@@ -103,7 +103,7 @@ class Bindings:
         qmlRegisterType(MachineDefinitionsModel.MachineDefinitionsModel, "UM", 1, 1, "MachineDefinitionsModel")
         qmlRegisterType(MachineInstancesModel.MachineInstancesModel, "UM", 1, 1, "MachineInstancesModel")
         qmlRegisterType(MachineVariantsModel.MachineVariantsModel, "UM", 1, 1, "MachineVariantsModel")
-        qmlRegisterType(MachineVariantsModel.MachineVariantsModel, "UM", 1, 1, "MachineMaterialsModel")
+        qmlRegisterType(MachineMaterialsModel.MachineMaterialsModel, "UM", 1, 1, "MachineMaterialsModel")
         qmlRegisterType(ProfilesModel.ProfilesModel, "UM", 1, 1, "ProfilesModel")
 
         qmlRegisterSingletonType(OutputDeviceManagerProxy.OutputDeviceManagerProxy, "UM", 1, 1, "OutputDeviceManager", OutputDeviceManagerProxy.createOutputDeviceManagerProxy)

--- a/UM/Qt/Bindings/Bindings.py
+++ b/UM/Qt/Bindings/Bindings.py
@@ -35,6 +35,7 @@ from . import MachineInstancesModel
 from . import ProfilesModel
 from . import MachineManagerProxy
 from . import MachineVariantsModel
+from . import MachineMaterialsModel
 from . import i18nCatalogProxy
 from . import ActiveProfileProxy
 
@@ -102,6 +103,7 @@ class Bindings:
         qmlRegisterType(MachineDefinitionsModel.MachineDefinitionsModel, "UM", 1, 1, "MachineDefinitionsModel")
         qmlRegisterType(MachineInstancesModel.MachineInstancesModel, "UM", 1, 1, "MachineInstancesModel")
         qmlRegisterType(MachineVariantsModel.MachineVariantsModel, "UM", 1, 1, "MachineVariantsModel")
+        qmlRegisterType(MachineVariantsModel.MachineVariantsModel, "UM", 1, 1, "MachineMaterialsModel")
         qmlRegisterType(ProfilesModel.ProfilesModel, "UM", 1, 1, "ProfilesModel")
 
         qmlRegisterSingletonType(OutputDeviceManagerProxy.OutputDeviceManagerProxy, "UM", 1, 1, "OutputDeviceManager", OutputDeviceManagerProxy.createOutputDeviceManagerProxy)

--- a/UM/Qt/Bindings/MachineInstancesModel.py
+++ b/UM/Qt/Bindings/MachineInstancesModel.py
@@ -72,7 +72,7 @@ class MachineInstancesModel(ListModel):
                 "typeName": machine.getMachineDefinition().getName(),
                 "variantName": machine.getMachineDefinition().getVariantName(),
                 "hasVariants": machine.getMachineDefinition().hasVariants(),
-                "hasMaterials": machine.getMachineDefinition().hasMaterials()
+                "hasMaterials": machine.hasMaterials()
             })
 
     def _onActiveMachineChanged(self):

--- a/UM/Qt/Bindings/MachineInstancesModel.py
+++ b/UM/Qt/Bindings/MachineInstancesModel.py
@@ -12,6 +12,7 @@ class MachineInstancesModel(ListModel):
     TypeNameRole = Qt.UserRole + 3
     VariantNameRole = Qt.UserRole + 4
     HasVariantsRole = Qt.UserRole + 5
+    HasMaterialsRole = Qt.UserRole + 6
 
     def __init__(self, parent = None):
         super().__init__(parent)
@@ -21,6 +22,7 @@ class MachineInstancesModel(ListModel):
         self.addRoleName(self.TypeNameRole, "typeName")
         self.addRoleName(self.VariantNameRole, "variantName")
         self.addRoleName(self.HasVariantsRole, "hasVariants")
+        self.addRoleName(self.HasMaterialsRole, "hasMaterials")
 
         self._manager = Application.getInstance().getMachineManager()
 
@@ -69,7 +71,8 @@ class MachineInstancesModel(ListModel):
                 "active": self._manager.getActiveMachineInstance() == machine,
                 "typeName": machine.getMachineDefinition().getName(),
                 "variantName": machine.getMachineDefinition().getVariantName(),
-                "hasVariants": machine.getMachineDefinition().hasVariants()
+                "hasVariants": machine.getMachineDefinition().hasVariants(),
+                "hasMaterials": machine.getMachineDefinition().hasMaterials()
             })
 
     def _onActiveMachineChanged(self):

--- a/UM/Qt/Bindings/MachineManagerProxy.py
+++ b/UM/Qt/Bindings/MachineManagerProxy.py
@@ -132,7 +132,11 @@ class MachineManagerProxy(QObject):
 
     @pyqtSlot(result = str)
     def createProfile(self):
-        return self._manager.addProfileFromWorkingProfile()
+        profile = self._manager.addProfileFromWorkingProfile()
+        #Hack to prevent "Replace profile?" dialog; working profile will get replaced by setActiveProfile()
+        self._manager.getWorkingProfile().setChangedSettings({})
+        self._manager.setActiveProfile(profile)
+        return profile.getName()
 
     def _onActiveMachineInstanceChanged(self):
         self.activeMachineInstanceChanged.emit()

--- a/UM/Qt/Bindings/MachineManagerProxy.py
+++ b/UM/Qt/Bindings/MachineManagerProxy.py
@@ -108,24 +108,6 @@ class MachineManagerProxy(QObject):
         if not profile:
             return
 
-        if profile.isReadOnly():
-            custom_profile_name = catalog.i18nc("@item:intext appended to customised profiles ({0} is old profile name)", "{0} (Customised)", profile.getName())
-            custom_profile = self._manager.findProfile(custom_profile_name)
-            if not custom_profile:
-                machine_instance = self._manager.getActiveMachineInstance()
-
-                custom_profile = deepcopy(profile)
-                custom_profile.setReadOnly(False)
-                custom_profile.setName(custom_profile_name)
-                custom_profile.setMachineTypeName(machine_instance.getMachineDefinition().getId())
-                custom_profile.setMachineVariantName(machine_instance.getMachineDefinition().getVariantName())
-                custom_profile.setMachineInstanceName(machine_instance.getName())
-                self._manager.addProfile(custom_profile)
-
-            self._changed_setting = (key, value)
-            self._manager.setActiveProfile(custom_profile)
-            return
-
         profile.setSettingValue(key, value)
 
     @pyqtSlot(str, "QVariant")

--- a/UM/Qt/Bindings/MachineManagerProxy.py
+++ b/UM/Qt/Bindings/MachineManagerProxy.py
@@ -52,6 +52,14 @@ class MachineManagerProxy(QObject):
 
         return instance.getMachineDefinition().hasVariants()
 
+    @pyqtProperty(bool, notify = activeMachineInstanceChanged)
+    def hasMaterials(self):
+        instance = self._manager.getActiveMachineInstance()
+        if not instance:
+            return False
+
+        return instance.getMachineDefinition().hasMaterials()
+
     @pyqtProperty(str, notify = activeMachineInstanceChanged)
     def activeMachineVariant(self):
         instance = self._manager.getActiveMachineInstance()

--- a/UM/Qt/Bindings/MachineManagerProxy.py
+++ b/UM/Qt/Bindings/MachineManagerProxy.py
@@ -130,6 +130,10 @@ class MachineManagerProxy(QObject):
 
         instance.setMachineSettingValue(key, value)
 
+    @pyqtSlot()
+    def createProfile(self):
+        self._manager.addProfileFromWorkingProfile()
+
     def _onActiveMachineInstanceChanged(self):
         self.activeMachineInstanceChanged.emit()
 

--- a/UM/Qt/Bindings/MachineManagerProxy.py
+++ b/UM/Qt/Bindings/MachineManagerProxy.py
@@ -109,14 +109,14 @@ class MachineManagerProxy(QObject):
 
     @pyqtSlot(str, result = int)
     def getSettingValue(self, setting):
-        profile = self._manager.getActiveProfile()
+        profile = self._manager.getWorkingProfile()
         if not profile:
             return None
         return profile.getSettingValue(setting)
 
     @pyqtSlot(str, "QVariant")
     def setSettingValue(self, key, value):
-        profile = self._manager.getActiveProfile()
+        profile = self._manager.getWorkingProfile()
         if not profile:
             return
 

--- a/UM/Qt/Bindings/MachineManagerProxy.py
+++ b/UM/Qt/Bindings/MachineManagerProxy.py
@@ -52,14 +52,6 @@ class MachineManagerProxy(QObject):
 
         return instance.getMachineDefinition().hasVariants()
 
-    @pyqtProperty(bool, notify = activeMachineInstanceChanged)
-    def hasMaterials(self):
-        instance = self._manager.getActiveMachineInstance()
-        if not instance:
-            return False
-
-        return instance.hasMaterials()
-
     @pyqtProperty(str, notify = activeMachineInstanceChanged)
     def activeMachineVariant(self):
         instance = self._manager.getActiveMachineInstance()
@@ -71,6 +63,26 @@ class MachineManagerProxy(QObject):
     @pyqtSlot(str)
     def setActiveMachineVariant(self, name):
         self._manager.setActiveMachineVariant(name)
+
+    @pyqtProperty(bool, notify = activeMachineInstanceChanged)
+    def hasMaterials(self):
+        instance = self._manager.getActiveMachineInstance()
+        if not instance:
+            return False
+
+        return instance.hasMaterials()
+
+    @pyqtProperty(str, notify = activeMachineInstanceChanged)
+    def activeMaterial(self):
+        instance = self._manager.getActiveMachineInstance()
+        if not instance:
+            return ""
+
+        return instance.getMaterialName()
+
+    @pyqtSlot(str)
+    def setActiveMaterial(self, name):
+        self._manager.setActiveMaterial(name)
 
     activeProfileChanged = pyqtSignal()
     @pyqtProperty(str, notify = activeProfileChanged)

--- a/UM/Qt/Bindings/MachineManagerProxy.py
+++ b/UM/Qt/Bindings/MachineManagerProxy.py
@@ -130,9 +130,9 @@ class MachineManagerProxy(QObject):
 
         instance.setMachineSettingValue(key, value)
 
-    @pyqtSlot()
+    @pyqtSlot(result = str)
     def createProfile(self):
-        self._manager.addProfileFromWorkingProfile()
+        return self._manager.addProfileFromWorkingProfile()
 
     def _onActiveMachineInstanceChanged(self):
         self.activeMachineInstanceChanged.emit()

--- a/UM/Qt/Bindings/MachineManagerProxy.py
+++ b/UM/Qt/Bindings/MachineManagerProxy.py
@@ -58,7 +58,7 @@ class MachineManagerProxy(QObject):
         if not instance:
             return False
 
-        return instance.getMachineDefinition().hasMaterials()
+        return instance.hasMaterials()
 
     @pyqtProperty(str, notify = activeMachineInstanceChanged)
     def activeMachineVariant(self):

--- a/UM/Qt/Bindings/MachineMaterialsModel.py
+++ b/UM/Qt/Bindings/MachineMaterialsModel.py
@@ -28,14 +28,14 @@ class MachineMaterialsModel(ListModel):
         if not instance:
             return
 
-        definitions = self._manager.getAllMachineMaterials(instance.getMachineDefinition().getId())
-        if len(definitions) <= 1:
+        materials = self._manager.getAllMachineMaterials(instance.getName())
+        if len(materials) < 1:
             return
 
-        definitions.sort(key = lambda k: k.getMaterialName())
+        materials.sort()
 
-        for definition in definitions:
+        for material in materials:
             self.appendItem({
-                "name": definition.getMaterialName(),
-                "active": definition.getMaterialName() == instance.getMachineDefinition().getMaterialName()
+                "name": material,
+                "active": material == instance.getMaterialName()
             })

--- a/UM/Qt/Bindings/MachineMaterialsModel.py
+++ b/UM/Qt/Bindings/MachineMaterialsModel.py
@@ -1,0 +1,41 @@
+# Copyright (c) 2015 Ultimaker B.V.
+# Uranium is released under the terms of the AGPLv3 or higher.
+
+from UM.Qt.ListModel import ListModel
+from UM.Application import Application
+
+from PyQt5.QtCore import Qt, pyqtSlot
+
+class MachineMaterialsModel(ListModel):
+    NameRole = Qt.UserRole + 1
+    ActiveRole = Qt.UserRole + 2
+
+    def __init__(self, parent = None):
+        super().__init__(parent)
+
+        self.addRoleName(self.NameRole, "name")
+        self.addRoleName(self.ActiveRole, "active")
+
+        self._manager = Application.getInstance().getMachineManager()
+
+        self._manager.activeMachineInstanceChanged.connect(self._onInstanceChanged)
+        self._onInstanceChanged()
+
+    def _onInstanceChanged(self):
+        self.clear()
+
+        instance = self._manager.getActiveMachineInstance()
+        if not instance:
+            return
+
+        definitions = self._manager.getAllMachineMaterials(instance.getMachineDefinition().getId())
+        if len(definitions) <= 1:
+            return
+
+        definitions.sort(key = lambda k: k.getMaterialName())
+
+        for definition in definitions:
+            self.appendItem({
+                "name": definition.getMaterialName(),
+                "active": definition.getMaterialName() == instance.getMachineDefinition().getMaterialName()
+            })

--- a/UM/Qt/Bindings/ProfilesModel.py
+++ b/UM/Qt/Bindings/ProfilesModel.py
@@ -197,14 +197,8 @@ class ProfilesModel(ListModel):
         self._onProfilesChanged()
 
         #Restore active profile for this machine_instance.
-        active_profile = None
         active_instance_name = self._manager.getActiveMachineInstance().getActiveProfileName()
-        #We can't use findProfile(active_instance_name) because there may be multiple profiles with the same name on different machine instances.
-        profiles = self._manager.getProfiles()
-        for profile in profiles:
-            if profile.getName() == active_instance_name:
-                active_profile = profile
-                break
+        active_profile = self._manager.findProfile(name)
 
         self._manager.setActiveProfile(active_profile)
 

--- a/UM/Qt/Bindings/ProfilesModel.py
+++ b/UM/Qt/Bindings/ProfilesModel.py
@@ -200,6 +200,13 @@ class ProfilesModel(ListModel):
         active_instance_name = self._manager.getActiveMachineInstance().getActiveProfileName()
         active_profile = self._manager.findProfile(active_instance_name)
 
+        if not active_profile:
+            #A profile by this name is no longer in the filtered list of profiles.
+            profiles = self._manager.getProfiles()
+            for profile in profiles:
+                active_profile = profile #Default to first profile you can find.
+                break
+
         self._manager.setActiveProfile(active_profile)
 
     def _onProfilesChanged(self):

--- a/UM/Qt/Bindings/ProfilesModel.py
+++ b/UM/Qt/Bindings/ProfilesModel.py
@@ -237,14 +237,17 @@ class ProfilesModel(ListModel):
                 "settings": None
             })
 
-        if self._add_working_profile:
+        active_machine = self._manager.getActiveMachineInstance()
+
+        if self._add_working_profile and active_machine:
             profile = self._manager.getWorkingProfile()
             settings_dict = profile.getChangedSettings()
             settings_list = []
-            for key, value in settings_dict.items():
-                setting = self._manager.getActiveMachineInstance().getMachineDefinition().getSetting(key)
-                settings_list.append({"name": setting.getLabel(), "value": value})
-            settings_list = sorted(settings_list, key = lambda setting:setting["name"])
+            if active_machine:
+                for key, value in settings_dict.items():
+                    setting = active_machine.getMachineDefinition().getSetting(key)
+                    settings_list.append({"name": setting.getLabel(), "value": value})
+                settings_list = sorted(settings_list, key = lambda setting:setting["name"])
             self.appendItem({
                 "id": 0,
                 "name": catalog.i18nc("@item:inlistbox", "Current settings"),
@@ -260,9 +263,10 @@ class ProfilesModel(ListModel):
         for profile in profiles:
             settings_dict = profile.getChangedSettings()
             settings_list = []
-            for key, value in settings_dict.items():
-                setting = self._manager.getActiveMachineInstance().getMachineDefinition().getSetting(key)
-                settings_list.append({"name": setting.getLabel(), "value": value})
+            if active_machine:
+                for key, value in settings_dict.items():
+                    setting = self._manager.getActiveMachineInstance().getMachineDefinition().getSetting(key)
+                    settings_list.append({"name": setting.getLabel(), "value": value})
             settings_list = sorted(settings_list, key = lambda setting:setting["name"])
             self.appendItem({
                 "id": id(profile),

--- a/UM/Qt/Bindings/ProfilesModel.py
+++ b/UM/Qt/Bindings/ProfilesModel.py
@@ -76,7 +76,7 @@ class ProfilesModel(ListModel):
 
     @pyqtSlot(str)
     def removeProfile(self, name):
-        profile = self._manager.findProfile(name)
+        profile = self._manager.findProfile(name, instance = self._manager.getActiveMachineInstance())
         if not profile:
             return
 
@@ -84,7 +84,7 @@ class ProfilesModel(ListModel):
 
     @pyqtSlot(str, str)
     def renameProfile(self, old_name, new_name):
-        profile = self._manager.findProfile(old_name)
+        profile = self._manager.findProfile(old_name, instance = self._manager.getActiveMachineInstance())
         if not profile:
             return
 
@@ -93,7 +93,7 @@ class ProfilesModel(ListModel):
 
     @pyqtSlot(str, result = bool)
     def checkProfileExists(self, name):
-        profile = self._manager.findProfile(name)
+        profile = self._manager.findProfile(name, instance = self._manager.getActiveMachineInstance())
         if profile:
             return True
 
@@ -136,7 +136,7 @@ class ProfilesModel(ListModel):
             profile.setType(None)
             profile.setMachineTypeId(self._manager.getActiveMachineInstance().getMachineDefinition().getProfilesMachineId())
         else:
-            profile = self._manager.findProfile(name)
+            profile = self._manager.findProfile(name, instance = self._manager.getActiveMachineInstance())
         if not profile:
             return
 
@@ -222,11 +222,11 @@ class ProfilesModel(ListModel):
 
         #Restore active profile for this machine_instance.
         active_instance_name = self._manager.getActiveMachineInstance().getActiveProfileName()
-        active_profile = self._manager.findProfile(active_instance_name)
+        active_profile = self._manager.findProfile(active_instance_name, instance = self._manager.getActiveMachineInstance())
 
         if not active_profile:
             #A profile by this name is no longer in the filtered list of profiles.
-            profiles = self._manager.getProfiles()
+            profiles = self._manager.getProfiles(instance = self._manager.getActiveMachineInstance())
             for profile in profiles:
                 active_profile = profile #Default to first profile you can find.
                 break
@@ -258,7 +258,8 @@ class ProfilesModel(ListModel):
             if active_machine:
                 for key, value in settings_dict.items():
                     setting = active_machine.getMachineDefinition().getSetting(key)
-                    settings_list.append({"name": setting.getLabel(), "value": value})
+                    if setting:
+                        settings_list.append({"name": setting.getLabel(), "value": value})
                 settings_list = sorted(settings_list, key = lambda setting:setting["name"])
             self.appendItem({
                 "id": -1,
@@ -270,7 +271,7 @@ class ProfilesModel(ListModel):
             })
 
 
-        profiles = self._manager.getProfiles()
+        profiles = self._manager.getProfiles(instance = self._manager.getActiveMachineInstance())
         profiles.sort(key = lambda k: k.getName())
         for profile in profiles:
             settings_dict = profile.getChangedSettings()

--- a/UM/Qt/Bindings/ProfilesModel.py
+++ b/UM/Qt/Bindings/ProfilesModel.py
@@ -117,7 +117,7 @@ class ProfilesModel(ListModel):
                 profile.setName(self._manager.makeUniqueProfileName(profile.getName())) #Ensure a unique name
                 if profile.getMachineTypeId():
                     #Make sure the profile is available for the currently selected printer
-                    profile.setMachineTypeId(self._manager.getActiveMachineInstance().getMachineDefinition().getId())
+                    profile.setMachineTypeId(self._manager.getActiveMachineInstance().getMachineDefinition().getProfilesMachineId())
                 self._manager.addProfile(profile) #Add the new profile to the list of profiles.
                 return { "status": "ok", "message": catalog.i18nc("@info:status", "Successfully imported profile {0}", profile.getName()) }
 
@@ -134,7 +134,7 @@ class ProfilesModel(ListModel):
         if id==0:
             profile = copy.deepcopy(self._working_profile)
             profile.setType(None)
-            profile.setMachineTypeId(self._manager.getActiveMachineInstance().getMachineDefinition().getId())
+            profile.setMachineTypeId(self._manager.getActiveMachineInstance().getMachineDefinition().getProfilesMachineId())
         else:
             profile = self._manager.findProfile(name)
         if not profile:

--- a/UM/Qt/Bindings/ProfilesModel.py
+++ b/UM/Qt/Bindings/ProfilesModel.py
@@ -1,6 +1,8 @@
 # Copyright (c) 2015 Ultimaker B.V.
 # Uranium is released under the terms of the AGPLv3 or higher.
 
+import copy
+
 from UM.Qt.ListModel import ListModel
 from UM.Application import Application
 from UM.Logger import Logger
@@ -119,14 +121,19 @@ class ProfilesModel(ListModel):
         #If it hasn't returned by now, none of the plugins loaded the profile successfully.
         return { "status": "error", "message": catalog.i18nc("@info:status", "Profile {0} has an unknown file type.", path) }
 
-    @pyqtSlot(str, QUrl, str)
-    def exportProfile(self, name, url, fileType):
+    @pyqtSlot(int, str, QUrl, str)
+    def exportProfile(self, id, name, url, fileType):
         #Input checking.
         path = url.toLocalFile()
         if not path:
             return
 
-        profile = self._manager.findProfile(name)
+        if id==0:
+            profile = copy.deepcopy(self._manager.getWorkingProfile())
+            profile.setType(None)
+            profile.setMachineTypeId(self._manager.getActiveMachineInstance().getMachineDefinition().getId())
+        else:
+            profile = self._manager.findProfile(name)
         if not profile:
             return
 
@@ -239,7 +246,7 @@ class ProfilesModel(ListModel):
                 settings_list.append({"name": setting.getLabel(), "value": value})
             settings_list = sorted(settings_list, key = lambda setting:setting["name"])
             self.appendItem({
-                "id": 1,
+                "id": 0,
                 "name": catalog.i18nc("@item:inlistbox", "Current settings"),
                 "active": False,
                 "readOnly": True,

--- a/UM/Qt/Bindings/ProfilesModel.py
+++ b/UM/Qt/Bindings/ProfilesModel.py
@@ -96,6 +96,9 @@ class ProfilesModel(ListModel):
             if profile: #Success!
                 profile.setReadOnly(False)
                 profile.setName(self._manager.makeUniqueProfileName(profile.getName())) #Ensure a unique name
+                if profile.getMachineTypeId():
+                    #Make sure the profile is available for the currently selected printer
+                    profile.setMachineTypeId(self._manager.getActiveMachineInstance().getMachineDefinition().getId())
                 self._manager.addProfile(profile) #Add the new profile to the list of profiles.
                 return { "status": "ok", "message": catalog.i18nc("@info:status", "Successfully imported profile {0}", profile.getName()) }
 

--- a/UM/Qt/Bindings/ProfilesModel.py
+++ b/UM/Qt/Bindings/ProfilesModel.py
@@ -124,6 +124,11 @@ class ProfilesModel(ListModel):
         #If it hasn't returned by now, none of the plugins loaded the profile successfully.
         return { "status": "error", "message": catalog.i18nc("@info:status", "Profile {0} has an unknown file type.", path) }
 
+    ##  Exports a profile to a file.
+    #   \param id: the id() added by the model. An id of -1 can be used to export the working profile of the active machine
+    #   \param name: the name of the profile to be exported, used to find the actual profile
+    #   \param url: the path returned from the FileDialog
+    #   \param fileType: the file type description ("<description> (*.<extension>)"), used to add an extension if the user did not enter one
     @pyqtSlot(int, str, QUrl, str)
     def exportProfile(self, id, name, url, fileType):
         #Input checking.
@@ -131,7 +136,8 @@ class ProfilesModel(ListModel):
         if not path:
             return
 
-        if id==-1:
+        if id == -1:
+            #id -1 references the "Current settings"/working profile
             profile = copy.deepcopy(self._working_profile)
             profile.setType(None)
             profile.setMachineTypeId(self._manager.getActiveMachineInstance().getMachineDefinition().getProfilesMachineId())
@@ -241,7 +247,7 @@ class ProfilesModel(ListModel):
 
         if self._add_use_global:
             self.appendItem({
-                "id": 1,
+                "id": -1, #-1 is used in order not to conflict with a normally created id()
                 "name": catalog.i18nc("@item:inlistbox", "- Use Global Profile -"),
                 "active": False,
                 "readOnly": True,
@@ -262,7 +268,7 @@ class ProfilesModel(ListModel):
                         settings_list.append({"name": setting.getLabel(), "value": value})
                 settings_list = sorted(settings_list, key = lambda setting:setting["name"])
             self.appendItem({
-                "id": -1,
+                "id": -1, #-1 is used in order not to conflict with a normally created id()
                 "name": catalog.i18nc("@item:inlistbox", "Current settings"),
                 "active": False,
                 "readOnly": True,

--- a/UM/Qt/Bindings/ProfilesModel.py
+++ b/UM/Qt/Bindings/ProfilesModel.py
@@ -70,6 +70,7 @@ class ProfilesModel(ListModel):
             return
 
         profile.setName(new_name)
+        self._manager.profilesChanged.emit()
 
     @pyqtSlot(str, result = bool)
     def checkProfileExists(self, name):

--- a/UM/Qt/Bindings/ProfilesModel.py
+++ b/UM/Qt/Bindings/ProfilesModel.py
@@ -131,7 +131,7 @@ class ProfilesModel(ListModel):
         if not path:
             return
 
-        if id==0:
+        if id==-1:
             profile = copy.deepcopy(self._working_profile)
             profile.setType(None)
             profile.setMachineTypeId(self._manager.getActiveMachineInstance().getMachineDefinition().getProfilesMachineId())
@@ -261,7 +261,7 @@ class ProfilesModel(ListModel):
                     settings_list.append({"name": setting.getLabel(), "value": value})
                 settings_list = sorted(settings_list, key = lambda setting:setting["name"])
             self.appendItem({
-                "id": 0,
+                "id": -1,
                 "name": catalog.i18nc("@item:inlistbox", "Current settings"),
                 "active": False,
                 "readOnly": True,

--- a/UM/Qt/Bindings/ProfilesModel.py
+++ b/UM/Qt/Bindings/ProfilesModel.py
@@ -198,7 +198,7 @@ class ProfilesModel(ListModel):
 
         #Restore active profile for this machine_instance.
         active_instance_name = self._manager.getActiveMachineInstance().getActiveProfileName()
-        active_profile = self._manager.findProfile(name)
+        active_profile = self._manager.findProfile(active_instance_name)
 
         self._manager.setActiveProfile(active_profile)
 

--- a/UM/Qt/Bindings/ProfilesModel.py
+++ b/UM/Qt/Bindings/ProfilesModel.py
@@ -306,6 +306,10 @@ class ProfilesModel(ListModel):
         for index in range(len(self.items)):
             self.setProperty(index, "active", id(active_profile) == self.items[index]["id"])
 
+        if self._add_working_profile:
+            #Update working profile settings
+            self._onProfilesChanged();
+
     def _onProfileNameChanged(self, profile):
         index = self.find("id", id(profile))
         if index != -1:

--- a/UM/Qt/Bindings/ProfilesModel.py
+++ b/UM/Qt/Bindings/ProfilesModel.py
@@ -95,19 +95,9 @@ class ProfilesModel(ListModel):
                 return { "status": "error", "message": catalog.i18nc("@info:status", "Failed to import profile from <filename>{0}</filename>: <message>{1}</message>", path, str(e)) }
             if profile: #Success!
                 profile.setReadOnly(False)
-                try:
-                    self._manager.addProfile(profile) #Add the new profile to the list of profiles.
-                except SettingsError.DuplicateProfileError as e:
-                    count = 2
-                    name = "{0} {1}".format(profile.getName(), count) #Try alternative profile names with a number appended to them.
-                    while self._manager.findProfile(name) != None:
-                        count += 1
-                        name = "{0} {1}".format(profile.getName(), count)
-                    profile.setName(name)
-                    self._manager.addProfile(profile)
-                    return { "status": "duplicate", "message": catalog.i18nc("@info:status", "Profile was imported as {0}", name) }
-                else:
-                    return { "status": "ok", "message": catalog.i18nc("@info:status", "Successfully imported profile {0}", profile.getName()) }
+                profile.setName(self._manager.makeUniqueProfileName(profile.getName())) #Ensure a unique name
+                self._manager.addProfile(profile) #Add the new profile to the list of profiles.
+                return { "status": "ok", "message": catalog.i18nc("@info:status", "Successfully imported profile {0}", profile.getName()) }
 
         #If it hasn't returned by now, none of the plugins loaded the profile successfully.
         return { "status": "error", "message": catalog.i18nc("@info:status", "Profile {0} has an unknown file type.", path) }

--- a/UM/Qt/Bindings/ProfilesModel.py
+++ b/UM/Qt/Bindings/ProfilesModel.py
@@ -2,6 +2,7 @@
 # Uranium is released under the terms of the AGPLv3 or higher.
 
 import copy
+import os.path
 
 from UM.Qt.ListModel import ListModel
 from UM.Application import Application
@@ -69,7 +70,7 @@ class ProfilesModel(ListModel):
             self._onProfilesChanged()
             self.addWorkingProfileChanged.emit()
 
-    ##  Whether to add a "Current Settings;8" entry.
+    ##  Whether to add a "Current Settings" entry.
     @pyqtProperty(bool, fset = setAddWorkingProfile, notify = addWorkingProfileChanged)
     def addWorkingProfile(self):
         return self._add_working_profile
@@ -114,7 +115,11 @@ class ProfilesModel(ListModel):
                 return { "status": "error", "message": catalog.i18nc("@info:status", "Failed to import profile from <filename>{0}</filename>: <message>{1}</message>", path, str(e)) }
             if profile: #Success!
                 profile.setReadOnly(False)
-                profile.setName(self._manager.makeUniqueProfileName(profile.getName())) #Ensure a unique name
+
+                #File name (without extension) trumps the name stored in the profile
+                file_name = os.path.basename(os.path.splitext(path)[0])
+                profile.setName(self._manager.makeUniqueProfileName(file_name))
+
                 if profile.getMachineTypeId():
                     #Make sure the profile is available for the currently selected printer
                     profile.setMachineTypeId(self._manager.getActiveMachineInstance().getMachineDefinition().getProfilesMachineId())
@@ -203,7 +208,7 @@ class ProfilesModel(ListModel):
         filters.insert(0, catalog.i18nc("@item:inlistbox", "All supported files") + "(" + " ".join(all_supported) + ")") #An entry to show all file extensions that are supported.
         filters.append(catalog.i18nc("@item:inlistbox", "All Files (*)")) #Also allow arbitrary files, if the user so prefers.
         return filters
-    
+
     ##  Gets a list of the possible file filters that the plugins have
     #   registered they can write.
     #
@@ -241,7 +246,7 @@ class ProfilesModel(ListModel):
 
     def _onWorkingProfileValueChanged(self, setting):
         self._onProfilesChanged()
-        
+
     def _onProfilesChanged(self):
         self.clear()
 

--- a/UM/Qt/Bindings/SettingCategoriesModel.py
+++ b/UM/Qt/Bindings/SettingCategoriesModel.py
@@ -77,6 +77,9 @@ class SettingCategoriesModel(ListModel):
         self.setProperty(index, "hiddenValuesCount", category.getHiddenValuesCount())
 
     def _onActiveProfileChanged(self):
+        if not self._machine_instance:
+            return
+
         for category in self._machine_instance.getMachineDefinition().getAllCategories():
             index = self.find("id", category.getKey())
             self.setProperty(index, "hiddenValuesCount", category.getHiddenValuesCount())

--- a/UM/Qt/Bindings/SettingsFromCategoryModel.py
+++ b/UM/Qt/Bindings/SettingsFromCategoryModel.py
@@ -44,7 +44,7 @@ class SettingsFromCategoryModel(ListModel, SignalEmitter):
 
         self._changed_setting = None
 
-        self._profile = self._machine_manager.getActiveProfile()
+        self._profile = self._machine_manager.getWorkingProfile()
         self._machine_manager.activeProfileChanged.connect(self._onProfileChanged)
         if self._profile is not None: # A profile is already set but we did not recieve the event.
             self._onProfileChanged()
@@ -165,7 +165,7 @@ class SettingsFromCategoryModel(ListModel, SignalEmitter):
         if self._profile:
             self._profile.settingValueChanged.disconnect(self._onSettingValueChanged)
 
-        self._profile = self._machine_manager.getActiveProfile()
+        self._profile = self._machine_manager.getWorkingProfile()
         if self._profile:
             self._profile.settingValueChanged.connect(self._onSettingValueChanged)
             self.updateSettings()

--- a/UM/Qt/Bindings/SettingsFromCategoryModel.py
+++ b/UM/Qt/Bindings/SettingsFromCategoryModel.py
@@ -76,24 +76,6 @@ class SettingsFromCategoryModel(ListModel, SignalEmitter):
             return
         setting = self._category.getSetting(key)
         if setting:
-            if self._profile.isReadOnly():
-                custom_profile_name = catalog.i18nc("@item:intext appended to customised profiles ({0} is old profile name)", "{0} (Customised)", self._profile.getName())
-                custom_profile = self._machine_manager.findProfile(custom_profile_name)
-                if not custom_profile:
-                    machine_instance = self._machine_manager.getActiveMachineInstance()
-
-                    custom_profile = deepcopy(self._profile)
-                    custom_profile.setReadOnly(False)
-                    custom_profile.setName(custom_profile_name)
-                    custom_profile.setMachineTypeName(machine_instance.getMachineDefinition().getId())
-                    custom_profile.setMachineVariantName(machine_instance.getMachineDefinition().getVariantName())
-                    custom_profile.setMachineInstanceName(machine_instance.getName())
-                    self._machine_manager.addProfile(custom_profile)
-
-                self._changed_setting = (key, value)
-                self._machine_manager.setActiveProfile(custom_profile)
-                return
-
             self._profile.setSettingValue(key, value)
             self.setProperty(index, "value", str(value))
             self.setProperty(index, "valid", setting.validate(setting.parseValue(value)))

--- a/UM/Qt/Bindings/SettingsFromCategoryModel.py
+++ b/UM/Qt/Bindings/SettingsFromCategoryModel.py
@@ -141,7 +141,7 @@ class SettingsFromCategoryModel(ListModel, SignalEmitter):
                 "depth": setting.getDepth(),
                 "warning_description": setting.getWarningDescription(),
                 "error_description": setting.getErrorDescription(),
-                "overridden": (not self._profile.isReadOnly()) and self._profile.hasSettingValue(setting.getKey()),
+                "overridden": (not self._profile.isReadOnly()) and self._profile.hasSettingValue(setting.getKey(), filter_defaults = True),
                 "enabled": setting.isEnabled(),
                 "filtered": False,
                 "global_only": setting.getGlobalOnly()
@@ -181,5 +181,5 @@ class SettingsFromCategoryModel(ListModel, SignalEmitter):
             value = self._profile.getSettingValue(key)
 
             self.setProperty(index, "value", str(value))
-            self.setProperty(index, "overridden", self._profile.hasSettingValue(key))
+            self.setProperty(index, "overridden", self._profile.hasSettingValue(key, filter_defaults = True))
             self.setProperty(index, "valid", setting.validate(value))

--- a/UM/Qt/qml/UM/Dialog.qml
+++ b/UM/Qt/qml/UM/Dialog.qml
@@ -47,6 +47,7 @@ Window {
         focus: base.visible;
 
         Keys.onEscapePressed: base.reject();
+        Keys.onReturnPressed: base.accept();
 
         Item {
             id: contentItem;

--- a/UM/Qt/qml/UM/Preferences/ManagementPage.qml
+++ b/UM/Qt/qml/UM/Preferences/ManagementPage.qml
@@ -16,6 +16,7 @@ PreferencesPage
     property bool detailsVisible: true;
 
     property variant currentItem: objectList.currentItem != null ? objectList.model.getItem(objectList.currentIndex) : null;
+    property string scrollviewCaption: "";
 
     default property alias details: detailsPane.children;
 
@@ -75,12 +76,25 @@ PreferencesPage
             bottom: parent.bottom;
         }
 
+        Label
+        {
+            id: captionLabel
+            anchors 
+            {
+                top: parent.top;
+                left: parent.left;
+            }
+            visible: scrollviewCaption != ""
+            text: scrollviewCaption
+        }
+
         ScrollView
         {
             id: objectListContainer
             anchors
             {
-                top: parent.top;
+                top: captionLabel.visible ? captionLabel.bottom : parent.top;
+                topMargin: captionLabel.visible ? UM.Theme.sizes.default_margin.height : 0;
                 bottom: parent.bottom;
                 left: parent.left;
             }

--- a/UM/Qt/qml/UM/Preferences/ManagementPage.qml
+++ b/UM/Qt/qml/UM/Preferences/ManagementPage.qml
@@ -15,6 +15,7 @@ PreferencesPage
     property string nameRole: "name";
     property bool detailsVisible: true;
 
+    property variant objectList: objectList;
     property variant currentItem: objectList.currentItem != null ? objectList.model.getItem(objectList.currentIndex) : null;
     property string scrollviewCaption: "";
 

--- a/UM/Qt/qml/UM/Preferences/PreferencesDialog.qml
+++ b/UM/Qt/qml/UM/Preferences/PreferencesDialog.qml
@@ -108,6 +108,11 @@ Dialog
         configPagesModel.remove(index)
     }
 
+    function getCurrentItem(key)
+    {
+        return stackView.currentItem
+    }
+
     Component.onCompleted:
     {
         //This uses insertPage here because ListModel is stupid and does not allow using qsTr() on elements.

--- a/UM/Qt/qml/UM/Preferences/ProfilesPage.qml
+++ b/UM/Qt/qml/UM/Preferences/ProfilesPage.qml
@@ -29,30 +29,38 @@ ManagementPage
         anchors.fill: parent
         spacing: UM.Theme.sizes.default_margin.height
 
-        Label { text: base.currentItem.name ? base.currentItem.name : ""; font: UM.Theme.fonts.large; width: parent.width; }
+        Label { id: profileName; text: base.currentItem.name ? base.currentItem.name : ""; font: UM.Theme.fonts.large; width: parent.width; }
 
-        Grid {
-            id: containerGrid
-            columns: 2
-            spacing: UM.Theme.sizes.default_margin.width
+        ScrollView {
+            anchors.left: parent.left
+            anchors.top: profileName.bottom
+            anchors.topMargin: UM.Theme.sizes.default_margin.height
+            anchors.right: parent.right
+            anchors.bottom: parent.bottom
 
-            Label { text: catalog.i18nc("@label", "Profile type"); width: 155}
-            Label { text: base.currentItem.readOnly ? catalog.i18nc("@label", "Starter profile (protected)") : catalog.i18nc("@label", "Custom profile"); }
+            Grid {
+                id: containerGrid
+                columns: 2
+                spacing: UM.Theme.sizes.default_margin.width
 
-            Column {
-                Repeater {
-                        model: base.currentItem.settings
-                        Label {
-                            text: modelData.name.toString();
-                            width: 155
-                            elide: Text.ElideMiddle;
-                        }
+                Label { text: catalog.i18nc("@label", "Profile type"); width: 155}
+                Label { text: base.currentItem.readOnly ? catalog.i18nc("@label", "Starter profile (protected)") : catalog.i18nc("@label", "Custom profile"); }
+
+                Column {
+                    Repeater {
+                            model: base.currentItem.settings
+                            Label {
+                                text: modelData.name.toString();
+                                width: 155
+                                elide: Text.ElideMiddle;
+                            }
+                    }
                 }
-            }
-            Column {
-                Repeater {
-                        model: base.currentItem.settings
-                        Label { text: modelData.value.toString(); }
+                Column {
+                    Repeater {
+                            model: base.currentItem.settings
+                            Label { text: modelData.value.toString(); }
+                    }
                 }
             }
         }

--- a/UM/Qt/qml/UM/Preferences/ProfilesPage.qml
+++ b/UM/Qt/qml/UM/Preferences/ProfilesPage.qml
@@ -43,7 +43,8 @@ ManagementPage
                 spacing: UM.Theme.sizes.default_margin.width
 
                 Label { text: catalog.i18nc("@label", "Profile type"); width: 155}
-                Label { text: base.currentItem.readOnly ? catalog.i18nc("@label", "Starter profile (protected)") : catalog.i18nc("@label", "Custom profile"); }
+                Label { text: base.currentItem.id == -1 ? catalog.i18nc("@label", "Current settings")  : 
+                              base.currentItem.readOnly ? catalog.i18nc("@label", "Starter profile (protected)") : catalog.i18nc("@label", "Custom profile"); }
 
                 Column {
                     Repeater {

--- a/UM/Qt/qml/UM/Preferences/ProfilesPage.qml
+++ b/UM/Qt/qml/UM/Preferences/ProfilesPage.qml
@@ -17,7 +17,7 @@ ManagementPage
 
     onAddObject: importDialog.open();
     onRemoveObject: confirmDialog.open();
-    onRenameObject: renameDialog.open();
+    onRenameObject: { renameDialog.open(); renameDialog.selectText(); }
 
     addText: catalog.i18nc("@action:button", "Import");
 
@@ -77,9 +77,7 @@ ManagementPage
         {
             id: renameDialog;
             object: base.currentItem != null ? base.currentItem.name : "";
-            onTextChanged: validName = ((!base.model.checkProfileExists(newName.trim()) || base.currentItem.name == newName.trim()) && newName.length != 0);
             onAccepted: base.model.renameProfile(base.currentItem.name, newName.trim());
-            validationError: "A profile with that name already exists!";
         }
         MessageDialog
         {

--- a/UM/Qt/qml/UM/Preferences/ProfilesPage.qml
+++ b/UM/Qt/qml/UM/Preferences/ProfilesPage.qml
@@ -25,9 +25,8 @@ ManagementPage
 
     scrollviewCaption: catalog.i18nc("@label %1 is printer name","Printer: %1").arg(UM.MachineManager.activeMachineInstance)
 
-    Flow {
+    Item {
         anchors.fill: parent
-        spacing: UM.Theme.sizes.default_margin.height
 
         Label { id: profileName; text: base.currentItem.name ? base.currentItem.name : ""; font: UM.Theme.fonts.large; width: parent.width; }
 
@@ -131,7 +130,7 @@ ManagementPage
             selectExisting: false;
             nameFilters: base.model.getFileNameFiltersWrite()
 
-            onAccepted: base.model.exportProfile(base.currentItem.name, fileUrl, selectedNameFilter)
+            onAccepted: base.model.exportProfile(base.currentItem.id, base.currentItem.name, fileUrl, selectedNameFilter)
         }
     }
 }

--- a/UM/Qt/qml/UM/Preferences/ProfilesPage.qml
+++ b/UM/Qt/qml/UM/Preferences/ProfilesPage.qml
@@ -13,7 +13,7 @@ ManagementPage
 
     title: catalog.i18nc("@title:tab", "Profiles");
 
-    model: UM.ProfilesModel { }
+    model: UM.ProfilesModel { addWorkingProfile: true }
 
     onAddObject: importDialog.open();
     onRemoveObject: confirmDialog.open();

--- a/UM/Qt/qml/UM/Preferences/ProfilesPage.qml
+++ b/UM/Qt/qml/UM/Preferences/ProfilesPage.qml
@@ -22,13 +22,15 @@ ManagementPage
     addText: catalog.i18nc("@action:button", "Import");
 
     removeEnabled: currentItem != null ? !currentItem.readOnly : false;
+    renameEnabled: currentItem != null ? !currentItem.readOnly : false;
 
     scrollviewCaption: catalog.i18nc("@label %1 is printer name","Printer: %1").arg(UM.MachineManager.activeMachineInstance)
 
     Item {
+        visible: base.currentItem != null
         anchors.fill: parent
 
-        Label { id: profileName; text: base.currentItem.name ? base.currentItem.name : ""; font: UM.Theme.fonts.large; width: parent.width; }
+        Label { id: profileName; text: base.currentItem ? base.currentItem.name : ""; font: UM.Theme.fonts.large; width: parent.width; }
 
         ScrollView {
             anchors.left: parent.left
@@ -43,12 +45,13 @@ ManagementPage
                 spacing: UM.Theme.sizes.default_margin.width
 
                 Label { text: catalog.i18nc("@label", "Profile type"); width: 155}
-                Label { text: base.currentItem.id == -1 ? catalog.i18nc("@label", "Current settings")  : 
+                Label { text: base.currentItem == null ? "" :
+                              base.currentItem.id == -1 ? catalog.i18nc("@label", "Current settings") :
                               base.currentItem.readOnly ? catalog.i18nc("@label", "Starter profile (protected)") : catalog.i18nc("@label", "Custom profile"); }
 
                 Column {
                     Repeater {
-                            model: base.currentItem.settings
+                            model: base.currentItem ? base.currentItem.settings : null
                             Label {
                                 text: modelData.name.toString();
                                 width: 155
@@ -58,7 +61,7 @@ ManagementPage
                 }
                 Column {
                     Repeater {
-                            model: base.currentItem.settings
+                            model: base.currentItem ? base.currentItem.settings : null
                             Label { text: modelData.value.toString(); }
                     }
                 }

--- a/UM/Qt/qml/UM/Preferences/ProfilesPage.qml
+++ b/UM/Qt/qml/UM/Preferences/ProfilesPage.qml
@@ -22,15 +22,13 @@ ManagementPage
     addText: catalog.i18nc("@action:button", "Import");
 
     removeEnabled: currentItem != null ? !currentItem.readOnly : false;
-    renameEnabled: currentItem != null ? !currentItem.readOnly : false;
 
     scrollviewCaption: catalog.i18nc("@label %1 is printer name","Printer: %1").arg(UM.MachineManager.activeMachineInstance)
 
     Item {
-        visible: base.currentItem != null
         anchors.fill: parent
 
-        Label { id: profileName; text: base.currentItem ? base.currentItem.name : ""; font: UM.Theme.fonts.large; width: parent.width; }
+        Label { id: profileName; text: base.currentItem.name ? base.currentItem.name : ""; font: UM.Theme.fonts.large; width: parent.width; }
 
         ScrollView {
             anchors.left: parent.left
@@ -45,13 +43,12 @@ ManagementPage
                 spacing: UM.Theme.sizes.default_margin.width
 
                 Label { text: catalog.i18nc("@label", "Profile type"); width: 155}
-                Label { text: base.currentItem == null ? "" :
-                              base.currentItem.id == -1 ? catalog.i18nc("@label", "Current settings") :
+                Label { text: base.currentItem.id == -1 ? catalog.i18nc("@label", "Current settings")  : 
                               base.currentItem.readOnly ? catalog.i18nc("@label", "Starter profile (protected)") : catalog.i18nc("@label", "Custom profile"); }
 
                 Column {
                     Repeater {
-                            model: base.currentItem ? base.currentItem.settings : null
+                            model: base.currentItem.settings
                             Label {
                                 text: modelData.name.toString();
                                 width: 155
@@ -61,7 +58,7 @@ ManagementPage
                 }
                 Column {
                     Repeater {
-                            model: base.currentItem ? base.currentItem.settings : null
+                            model: base.currentItem.settings
                             Label { text: modelData.value.toString(); }
                     }
                 }

--- a/UM/Qt/qml/UM/Preferences/ProfilesPage.qml
+++ b/UM/Qt/qml/UM/Preferences/ProfilesPage.qml
@@ -23,6 +23,8 @@ ManagementPage
 
     removeEnabled: currentItem != null ? !currentItem.readOnly : false;
 
+    scrollviewCaption: catalog.i18nc("@label %1 is printer name","Printer: %1").arg(UM.MachineManager.activeMachineInstance)
+
     Flow {
         anchors.fill: parent
         spacing: UM.Theme.sizes.default_margin.height

--- a/UM/Qt/qml/UM/Preferences/ProfilesPage.qml
+++ b/UM/Qt/qml/UM/Preferences/ProfilesPage.qml
@@ -77,14 +77,14 @@ ManagementPage
         {
             text: catalog.i18nc("@action:button", "Import");
             iconName: "document-import";
-            onClicked: exportDialog.open();
+            onClicked: importDialog.open();
         }
 
         Button
         {
             text: catalog.i18nc("@action:button", "Export");
             iconName: "document-export";
-            onClicked: importDialog.open();
+            onClicked: exportDialog.open();
         }
     }
 

--- a/UM/Qt/qml/UM/Preferences/ProfilesPage.qml
+++ b/UM/Qt/qml/UM/Preferences/ProfilesPage.qml
@@ -15,20 +15,25 @@ ManagementPage
 
     model: UM.ProfilesModel { addWorkingProfile: true }
 
-    onAddObject: importDialog.open();
+    onAddObject: { var selectedProfile = UM.MachineManager.createProfile(); base.selectProfile(selectedProfile); }
     onRemoveObject: confirmDialog.open();
     onRenameObject: { renameDialog.open(); renameDialog.selectText(); }
 
-    addText: catalog.i18nc("@action:button", "Import");
-
     removeEnabled: currentItem != null ? !currentItem.readOnly : false;
+    renameEnabled: currentItem != null ? !currentItem.readOnly : false;
 
     scrollviewCaption: catalog.i18nc("@label %1 is printer name","Printer: %1").arg(UM.MachineManager.activeMachineInstance)
 
+    signal selectProfile(string name)
+    onSelectProfile: {
+        objectList.currentIndex = objectList.model.find("name", name);
+    }
+
     Item {
+        visible: base.currentItem != null
         anchors.fill: parent
 
-        Label { id: profileName; text: base.currentItem.name ? base.currentItem.name : ""; font: UM.Theme.fonts.large; width: parent.width; }
+        Label { id: profileName; text: base.currentItem ? base.currentItem.name : ""; font: UM.Theme.fonts.large; width: parent.width; }
 
         ScrollView {
             anchors.left: parent.left
@@ -43,12 +48,13 @@ ManagementPage
                 spacing: UM.Theme.sizes.default_margin.width
 
                 Label { text: catalog.i18nc("@label", "Profile type"); width: 155}
-                Label { text: base.currentItem.id == -1 ? catalog.i18nc("@label", "Current settings")  : 
+                Label { text: base.currentItem == null ? "" :
+                              base.currentItem.id == -1 ? catalog.i18nc("@label", "Current settings") :
                               base.currentItem.readOnly ? catalog.i18nc("@label", "Starter profile (protected)") : catalog.i18nc("@label", "Custom profile"); }
 
                 Column {
                     Repeater {
-                            model: base.currentItem.settings
+                            model: base.currentItem ? base.currentItem.settings : null
                             Label {
                                 text: modelData.name.toString();
                                 width: 155
@@ -58,7 +64,7 @@ ManagementPage
                 }
                 Column {
                     Repeater {
-                            model: base.currentItem.settings
+                            model: base.currentItem ? base.currentItem.settings : null
                             Label { text: modelData.value.toString(); }
                     }
                 }
@@ -66,11 +72,20 @@ ManagementPage
         }
     }
 
-    buttons: Button
-    {
-        text: catalog.i18nc("@action:button", "Export");
-        iconName: "document-export";
-        onClicked: exportDialog.open();
+    buttons: Row {
+        Button
+        {
+            text: catalog.i18nc("@action:button", "Import");
+            iconName: "document-import";
+            onClicked: exportDialog.open();
+        }
+
+        Button
+        {
+            text: catalog.i18nc("@action:button", "Export");
+            iconName: "document-export";
+            onClicked: importDialog.open();
+        }
     }
 
     Item

--- a/UM/Qt/qml/UM/Preferences/RenameDialog.qml
+++ b/UM/Qt/qml/UM/Preferences/RenameDialog.qml
@@ -27,6 +27,11 @@ UM.Dialog
     property variant catalog: UM.I18nCatalog { name: "uranium"; }
 
     signal textChanged(string text);
+    signal selectText()
+    onSelectText: {
+        nameField.selectAll();
+        nameField.focus = true;
+    }
 
     Column {
         anchors.fill: parent;
@@ -53,6 +58,7 @@ UM.Dialog
             text: catalog.i18nc("@action:button", "Ok");
             onClicked: base.accept();
             enabled: base.validName;
+            isDefault: true;
         }
 
     ]

--- a/UM/Qt/qml/UM/Preferences/SettingVisibilityPage.qml
+++ b/UM/Qt/qml/UM/Preferences/SettingVisibilityPage.qml
@@ -10,6 +10,14 @@ import UM 1.1 as UM
 PreferencesPage {
     title: catalog.i18nc("@title:tab", "Setting Visibility");
 
+    signal scrollToSection( string key )
+    onScrollToSection: {
+        var index = Math.max(0, settingList.model.find("id", key));
+        var offsetY = settingList.itemAt(index).mapToItem(settingList, 0, 0).y;
+
+        scrollView.flickableItem.contentY = offsetY;
+    }
+
     function reset() {
     }
     resetEnabled: false;
@@ -32,6 +40,8 @@ PreferencesPage {
         }
 
         ScrollView {
+            id: scrollView
+
             anchors {
                 top: filter.bottom;
                 left: parent.left;

--- a/UM/Qt/qml/UM/Preferences/SettingVisibilityPage.qml
+++ b/UM/Qt/qml/UM/Preferences/SettingVisibilityPage.qml
@@ -10,12 +10,13 @@ import UM 1.1 as UM
 PreferencesPage {
     title: catalog.i18nc("@title:tab", "Setting Visibility");
 
+    property int scrollToIndex: 0
+
     signal scrollToSection( string key )
     onScrollToSection: {
-        var index = Math.max(0, settingList.model.find("id", key));
-        var offsetY = settingList.itemAt(index).mapToItem(settingList, 0, 0).y;
-
-        scrollView.flickableItem.contentY = offsetY;
+        scrollToIndex = Math.max(0, settingList.model.find("id", key));
+        //Delay finding the scroll offset until the scrollview has had time to fill up
+        scrollToTimer.start()
     }
 
     function reset() {
@@ -25,6 +26,14 @@ PreferencesPage {
     Item {
         id: base;
         anchors.fill: parent;
+
+        Timer {
+            id: scrollToTimer
+            interval: 1
+            repeat: false
+            onTriggered: scrollView.flickableItem.contentY = settingList.itemAt(scrollToIndex).mapToItem(settingList, 0, 0).y 
+        }
+
         TextField {
             id: filter;
 

--- a/UM/Qt/qml/UM/Settings/SettingView.qml
+++ b/UM/Qt/qml/UM/Settings/SettingView.qml
@@ -39,6 +39,7 @@ ScrollView
 
                 visible: model.visible;
 
+                property string categoryId: model.id;
                 property variant settingsModel: model.settings;
 
                 SidebarCategoryHeader
@@ -88,7 +89,7 @@ ScrollView
                         label: Label
                         {
                             text: control.text
-                            
+
                             horizontalAlignment: Text.AlignHCenter
                             font: UM.Theme.fonts.default
                             color: control.hovered? UM.Theme.colors.text_hover : UM.Theme.colors.text
@@ -182,7 +183,11 @@ ScrollView
                                     //: Settings context menu action
                                     text: catalog.i18nc("@action:menu","Configure setting visiblity...");
 
-                                    onTriggered: if(base.configureSettings) base.configureSettings.trigger();
+                                    onTriggered: {
+                                        preferences.visible = true;
+                                        preferences.setPage(2);
+                                        preferences.getCurrentItem().scrollToSection(categoryId);
+                                    }
                                 }
                             }
                         }

--- a/UM/Qt/qml/UM/Settings/SettingView.qml
+++ b/UM/Qt/qml/UM/Settings/SettingView.qml
@@ -76,8 +76,8 @@ ScrollView
                     anchors.top: categoryHeader.bottom
                     width: categoryHeader.width
 
-                    opacity: model.hiddenValuesCount > 0 ? 1 : 0
-                    height: model.hiddenValuesCount > 0 ? UM.Theme.sizes.lineHeight : 0
+                    opacity: categoryHeader.checked && model.hiddenValuesCount > 0 ? 1 : 0
+                    height: categoryHeader.checked && model.hiddenValuesCount > 0 ? UM.Theme.sizes.lineHeight : 0
 
                     text: catalog.i18ncp("@label", "{0} hidden setting uses a custom value", "{0} hidden settings use custom values", model.hiddenValuesCount)
                     onClicked: { UM.ActiveProfile.showHiddenValues(model.id) }

--- a/UM/Qt/qml/UM/Settings/SettingView.qml
+++ b/UM/Qt/qml/UM/Settings/SettingView.qml
@@ -69,27 +69,38 @@ ScrollView
                     }
                 }
 
-                Label
+                Button
                 {
-                    id: hiddenSettingsLabel;
+                    id: hiddenSettingsWarning
 
-                    anchors.top: categoryHeader.bottom;
-                    width: categoryHeader.width;
-                    horizontalAlignment: Text.AlignHCenter;
+                    anchors.top: categoryHeader.bottom
+                    width: categoryHeader.width
 
-                    text: catalog.i18ncp("@label", "{0} hidden setting uses a custom value", "{0} hidden settings use custom values", model.hiddenValuesCount);
+                    opacity: model.hiddenValuesCount > 0 ? 1 : 0
+                    height: model.hiddenValuesCount > 0 ? UM.Theme.sizes.lineHeight : 0
 
-                    opacity: model.hiddenValuesCount > 0 ? 1 : 0;
-                    height: model.hiddenValuesCount > 0 ? UM.Theme.sizes.lineHeight : 0;
+                    text: catalog.i18ncp("@label", "{0} hidden setting uses a custom value", "{0} hidden settings use custom values", model.hiddenValuesCount)
+                    onClicked: { UM.ActiveProfile.showHiddenValues(model.id) }
 
-                    font: UM.Theme.fonts.default;
+                    style: ButtonStyle
+                    {
+                        background: Rectangle {}
+                        label: Label
+                        {
+                            text: control.text
+                            
+                            horizontalAlignment: Text.AlignHCenter
+                            font: UM.Theme.fonts.default
+                            color: control.hovered? UM.Theme.colors.text_hover : UM.Theme.colors.text
+                        }
+                    }
                 }
 
                 Column
                 {
                     id: settings;
 
-                    anchors.top: hiddenSettingsLabel.bottom;
+                    anchors.top: hiddenSettingsWarning.bottom;
 
                     height: childrenHeight;
                     spacing: 0;

--- a/UM/Qt/qml/UM/Settings/SidebarCategoryHeader.qml
+++ b/UM/Qt/qml/UM/Settings/SidebarCategoryHeader.qml
@@ -40,6 +40,7 @@ Button {
         onClicked: {
             preferences.visible = true;
             preferences.setPage(2);
+            preferences.getCurrentItem().scrollToSection(model.id);
         }
     }
 }

--- a/UM/Resources.py
+++ b/UM/Resources.py
@@ -34,6 +34,8 @@ class Resources:
     MachineInstances = 9
     ## Location of setting profile files. Equal to $resources/profiles
     Profiles = 10
+    ## Location of working profiles for each machine instance. Equal to $resources/instance_profiles
+    MachineInstanceProfiles = 11
 
     ## Any custom resource types should be greater than this to prevent collisions with standard types.
     UserType = 128
@@ -239,12 +241,14 @@ class Resources:
         Themes: "themes",
         MachineDefinitions: "machines",
         MachineInstances: "machine_instances",
-        Profiles: "profiles"
+        Profiles: "profiles",
+        MachineInstanceProfiles: "instance_profiles"
     }
     __types_storage = {
         Resources: "",
         Preferences: "",
         MachineDefinitions: "machines",
         MachineInstances: "machine_instances",
-        Profiles: "profiles"
+        Profiles: "profiles",
+        MachineInstanceProfiles: "instance_profiles"
     }

--- a/UM/Settings/MachineDefinition.py
+++ b/UM/Settings/MachineDefinition.py
@@ -74,6 +74,9 @@ class MachineDefinition(SignalEmitter):
     def hasVariants(self):
         return len(self._machine_manager.getAllMachineVariants(self._id)) > 1
 
+    def hasMaterials(self):
+        return len(self._machine_manager.getAllMachineMaterials(self._id)) > 1
+
     ##  Get the machine mesh (in most cases platform)
     #   Todo: Might need to rename this to get machine mesh?
     def getPlatformMesh(self):

--- a/UM/Settings/MachineDefinition.py
+++ b/UM/Settings/MachineDefinition.py
@@ -74,9 +74,6 @@ class MachineDefinition(SignalEmitter):
     def hasVariants(self):
         return len(self._machine_manager.getAllMachineVariants(self._id)) > 1
 
-    def hasMaterials(self):
-        return len(self._machine_manager.getAllMachineMaterials(self._id)) > 1
-
     ##  Get the machine mesh (in most cases platform)
     #   Todo: Might need to rename this to get machine mesh?
     def getPlatformMesh(self):

--- a/UM/Settings/MachineDefinition.py
+++ b/UM/Settings/MachineDefinition.py
@@ -38,6 +38,7 @@ class MachineDefinition(SignalEmitter):
         self._author = ""
         self._visible = True
         self._pages = []
+        self._profiles_machine_id = ""
 
         self._machine_settings = []
         self._categories = []
@@ -49,6 +50,9 @@ class MachineDefinition(SignalEmitter):
 
     def getId(self):
         return self._id
+
+    def getProfilesMachineId(self):
+        return self._profiles_machine_id
 
     def getName(self):
         return self._name
@@ -109,6 +113,10 @@ class MachineDefinition(SignalEmitter):
             self._json_data.update(app_data)
 
         self._id = self._json_data["id"]
+        if "profiles_machine" in self._json_data:
+            self._profiles_machine_id = self._json_data["profiles_machine"]
+        else:
+            self._profiles_machine_id = self._id
         self._name = self._json_data["name"]
         self._visible = self._json_data.get("visible", True)
         self._variant_name = self._json_data.get("variant", "")

--- a/UM/Settings/MachineInstance.py
+++ b/UM/Settings/MachineInstance.py
@@ -108,6 +108,7 @@ class MachineInstance(SignalEmitter):
         self._machine_definition.loadAll()
 
         self._name = config.get("general", "name")
+        self._active_profile_name = config.get("general", "acitve_profile", fallback="")
 
         for key, value in config["machine_settings"].items():
             self._machine_setting_overrides[key] = value
@@ -118,6 +119,7 @@ class MachineInstance(SignalEmitter):
         config.add_section("general")
         config["general"]["name"] = self._name
         config["general"]["type"] = self._machine_definition.getId()
+        config["general"]["active_profile"] = self._active_profile_name
         config["general"]["version"] = str(self.MachineInstanceVersion)
         if self._machine_definition.getVariantName():
             config["general"]["variant"] = self._machine_definition.getVariantName()

--- a/UM/Settings/MachineInstance.py
+++ b/UM/Settings/MachineInstance.py
@@ -108,7 +108,7 @@ class MachineInstance(SignalEmitter):
         self._machine_definition.loadAll()
 
         self._name = config.get("general", "name")
-        self._active_profile_name = config.get("general", "acitve_profile", fallback="")
+        self._active_profile_name = config.get("general", "active_profile", fallback="")
 
         for key, value in config["machine_settings"].items():
             self._machine_setting_overrides[key] = value

--- a/UM/Settings/MachineInstance.py
+++ b/UM/Settings/MachineInstance.py
@@ -138,7 +138,7 @@ class MachineInstance(SignalEmitter):
         config.add_section("general")
         config["general"]["name"] = self._name
         config["general"]["type"] = self._machine_definition.getId()
-        config["general"]["active_profile"] = self._active_profile_name
+        config["general"]["active_profile"] = str(self._active_profile_name)
         config["general"]["version"] = str(self.MachineInstanceVersion)
         if self._machine_definition.getVariantName():
             config["general"]["variant"] = self._machine_definition.getVariantName()

--- a/UM/Settings/MachineInstance.py
+++ b/UM/Settings/MachineInstance.py
@@ -7,6 +7,7 @@ from UM.Settings import SettingsError
 from UM.Logger import Logger
 from UM.Signal import Signal, SignalEmitter
 from UM.SaveFile import SaveFile
+from UM.Settings.Profile import Profile
 
 ##    A machine instance is a sort of wrapper for a machine definition.
 #     Where machine defintion defines base values of a machine
@@ -29,6 +30,9 @@ class MachineInstance(SignalEmitter):
         self._active_profile_name = None
         self._active_material_name = None
 
+        self._working_profile = Profile(machine_manager)
+        self._working_profile.setType("machine_instance_profile")
+
     nameChanged = Signal()
 
     def getName(self):
@@ -38,7 +42,11 @@ class MachineInstance(SignalEmitter):
         if name != self._name:
             old_name = self._name
             self._name = name
+            self._working_profile.setName(name)
             self.nameChanged.emit(self, old_name)
+
+    def getWorkingProfile(self):
+        return self._working_profile
 
     def getActiveProfileName(self):
         return self._active_profile_name
@@ -118,8 +126,9 @@ class MachineInstance(SignalEmitter):
         self._machine_definition.loadAll()
 
         self._name = config.get("general", "name")
-        self._active_profile_name = config.get("general", "active_profile", fallback="")
+        self._working_profile.setName(self._name)
 
+        self._active_profile_name = config.get("general", "active_profile", fallback="")
         self._active_material_name = config.get("general", "material", fallback = "")
 
         for key, value in config["machine_settings"].items():

--- a/UM/Settings/MachineInstance.py
+++ b/UM/Settings/MachineInstance.py
@@ -42,7 +42,6 @@ class MachineInstance(SignalEmitter):
         if name != self._name:
             old_name = self._name
             self._name = name
-            self._working_profile.setName(name)
             self.nameChanged.emit(self, old_name)
 
     def getWorkingProfile(self):
@@ -126,7 +125,6 @@ class MachineInstance(SignalEmitter):
         self._machine_definition.loadAll()
 
         self._name = config.get("general", "name")
-        self._working_profile.setName(self._name)
 
         self._active_profile_name = config.get("general", "active_profile", fallback="")
         self._active_material_name = config.get("general", "material", fallback = "")

--- a/UM/Settings/MachineInstance.py
+++ b/UM/Settings/MachineInstance.py
@@ -27,6 +27,7 @@ class MachineInstance(SignalEmitter):
         self._machine_setting_overrides = {}
 
         self._active_profile_name = None
+        self._material_name = None
 
     nameChanged = Signal()
 
@@ -44,6 +45,15 @@ class MachineInstance(SignalEmitter):
 
     def setActiveProfileName(self, active_profile_name):
         self._active_profile_name = active_profile_name
+
+    def getMaterialName(self):
+        return self._material_name
+
+    def setMaterialName(self, material_name):
+        self._material_name = material_name
+
+    def hasMaterials(self):
+        return len(self._machine_manager.getAllMachineMaterials(self._name)) > 0
 
     def getMachineDefinition(self):
         return self._machine_definition
@@ -109,6 +119,8 @@ class MachineInstance(SignalEmitter):
 
         self._name = config.get("general", "name")
         self._active_profile_name = config.get("general", "active_profile", fallback="")
+
+        self._material_name = config.get("general", "material", fallback = "")
 
         for key, value in config["machine_settings"].items():
             self._machine_setting_overrides[key] = value

--- a/UM/Settings/MachineInstance.py
+++ b/UM/Settings/MachineInstance.py
@@ -27,7 +27,7 @@ class MachineInstance(SignalEmitter):
         self._machine_setting_overrides = {}
 
         self._active_profile_name = None
-        self._material_name = None
+        self._active_material_name = None
 
     nameChanged = Signal()
 
@@ -47,10 +47,10 @@ class MachineInstance(SignalEmitter):
         self._active_profile_name = active_profile_name
 
     def getMaterialName(self):
-        return self._material_name
+        return self._active_material_name
 
     def setMaterialName(self, material_name):
-        self._material_name = material_name
+        self._active_material_name = material_name
 
     def hasMaterials(self):
         return len(self._machine_manager.getAllMachineMaterials(self._name)) > 0
@@ -120,7 +120,7 @@ class MachineInstance(SignalEmitter):
         self._name = config.get("general", "name")
         self._active_profile_name = config.get("general", "active_profile", fallback="")
 
-        self._material_name = config.get("general", "material", fallback = "")
+        self._active_material_name = config.get("general", "material", fallback = "")
 
         for key, value in config["machine_settings"].items():
             self._machine_setting_overrides[key] = value
@@ -135,6 +135,8 @@ class MachineInstance(SignalEmitter):
         config["general"]["version"] = str(self.MachineInstanceVersion)
         if self._machine_definition.getVariantName():
             config["general"]["variant"] = self._machine_definition.getVariantName()
+        if self._active_material_name and self._active_material_name != "":
+            config["general"]["material"] = self._active_material_name
 
         config.add_section("machine_settings")
         for key, value in self._machine_setting_overrides.items():

--- a/UM/Settings/MachineManager.py
+++ b/UM/Settings/MachineManager.py
@@ -365,7 +365,8 @@ class MachineManager(SignalEmitter):
             base_name = catalog.i18nc("@item:profile name", "Custom profile")
         profile_name = base_name
         i = 1
-        while self.findProfile(profile_name, profile = None):
+        #Make sure there is no profile for any instance/variant/material with the same name
+        while self.findProfile(profile_name):
             i = i + 1
             profile_name = "%s #%d" % (base_name, i)
 
@@ -709,5 +710,5 @@ class MachineManager(SignalEmitter):
 
             if not profile.getMaterialName() and instance.hasMaterials():
                 #Apply partial material profile
-                material_profile = self.findProfile(instance.getMaterialName(), type="material", instance = instance)
+                material_profile = self.findProfile(instance.getMaterialName(), type = "material", instance = instance)
                 instance.getWorkingProfile().mergeSettingsFrom(material_profile, reset = False)

--- a/UM/Settings/MachineManager.py
+++ b/UM/Settings/MachineManager.py
@@ -547,7 +547,7 @@ class MachineManager(SignalEmitter):
                 instance.getWorkingProfile().loadFromFile(Resources.getStoragePath(Resources.MachineInstanceProfiles, file_name))
             except Exception as e:
                 Logger.log("w", "Could not load working profile: %s: %s", file_name, str(e))
-                _setDefaultVariantMaterialProfile(instance)
+                self._setDefaultVariantMaterialProfile(instance)
 
         self._protect_working_profile = True
 

--- a/UM/Settings/MachineManager.py
+++ b/UM/Settings/MachineManager.py
@@ -187,6 +187,9 @@ class MachineManager(SignalEmitter):
     def getProfiles(self, active_instance_profiles_only = True):
         if not active_instance_profiles_only:
             return self._profiles
+        
+        if not self._active_machine:
+            return self._profiles
 
         active_machine_type = self._active_machine.getMachineDefinition().getId()
         active_machine_variant = self._active_machine.getMachineDefinition().getVariantName()
@@ -214,7 +217,8 @@ class MachineManager(SignalEmitter):
         if profile in self._profiles:
             return
 
-        for p in self._profiles:
+        profiles = self.getProfiles()
+        for p in profiles:
             if p.getName() == profile.getName():
                 raise SettingsError.DuplicateProfileError(profile.getName())
 
@@ -388,7 +392,7 @@ class MachineManager(SignalEmitter):
                 if profile.isReadOnly():
                     continue
 
-                profile_name = profile.getName() + "@" + profile.getMachineInstance() 
+                profile_name = profile.getName() + "@" + profile.getMachineInstanceName() 
                 file_name = urllib.parse.quote_plus(profile_name) + ".cfg"
                 profile.saveToFile(Resources.getStoragePath(Resources.Profiles, file_name))
         except AttributeError:

--- a/UM/Settings/MachineManager.py
+++ b/UM/Settings/MachineManager.py
@@ -315,7 +315,8 @@ class MachineManager(SignalEmitter):
 
     def addProfileFromWorkingProfile(self):
         profile = copy.deepcopy(self._active_machine.getWorkingProfile())
-        profile.setName("Custom profile")
+        profile.setName(catalog.i18nc("@item:profile name", "Custom profile"))
+        
         #Make this profile available to all printers of the same type only
         profile.setMachineTypeId(self._active_profile.getMachineTypeId())
         self._profiles.append(profile)
@@ -355,10 +356,22 @@ class MachineManager(SignalEmitter):
 
         return None
 
+    def makeUniqueProfileName(self, base_name):
+        if base_name == "":
+            base_name = catalog.i18nc("@item:profile name", "Custom profile")
+        profile_name = base_name
+        i = 1
+        while self.findProfile(profile_name, active_instance_profiles_only = False):
+            i = i + 1
+            profile_name = "%s #%d" % (base_name, i)
+
+        return profile_name
+
     activeProfileChanged = Signal()
 
     def getWorkingProfile(self):
-        return self._active_machine.getWorkingProfile()
+        if self._active_machine:
+            return self._active_machine.getWorkingProfile()
 
     def getActiveProfile(self):
         return self._active_profile
@@ -501,17 +514,18 @@ class MachineManager(SignalEmitter):
 
         self._protect_working_profile = True
 
-        profile_name = self._active_machine.getActiveProfileName()
-        if profile_name == "":
-            profile_name = "Normal Quality"
+        if self._active_machine:
+            profile_name = self._active_machine.getActiveProfileName()
+            if profile_name == "":
+                profile_name = "Normal Quality"
 
-        profile = self.findProfile(self._active_machine.getActiveProfileName())
-        if profile:
-            self.setActiveProfile(profile)
-        else:
-            profiles = self.getProfiles()
-            if len(profiles) > 0:
-                self.setActiveProfile(profiles[0])
+            profile = self.findProfile(self._active_machine.getActiveProfileName())
+            if profile:
+                self.setActiveProfile(profile)
+            else:
+                profiles = self.getProfiles()
+                if len(profiles) > 0:
+                    self.setActiveProfile(profiles[0])
 
         self.profilesChanged.emit()
         self._protect_working_profile = False

--- a/UM/Settings/MachineManager.py
+++ b/UM/Settings/MachineManager.py
@@ -97,15 +97,16 @@ class MachineManager(SignalEmitter):
             profile_machine_variant = profile.getMachineVariantName()
             profile_machine_instance = profile.getMachineInstanceName()
 
-            if (profile_machine_instance and profile_machine_instance == instance_id) or \
-                    (profile_machine_variant and profile_machine_variant == machine_variant and profile_machine_type == machine_type) or \
-                    (profile_machine_type == machine_type):
+            if profile_machine_instance and profile_machine_instance == instance_id:
+                machine_materials.append(material)
+            elif profile_machine_variant == machine_variant and profile_machine_type == machine_type:
                 machine_materials.append(material)
 
         if len(machine_materials) > 0:
+            #This includes Ultigcode printers that have machine-specific material profiles (eg Ultimaker 2+)
             return machine_materials
         elif machine.getMachineDefinition().getSetting("machine_gcode_flavor").getDefaultValue() == "UltiGCode":
-            #UltiGCode printers don't use generic materials in Cura
+            #UltiGCode printers don't use the generic set of generic materials (eg Ultimaker 2)
             return []
         else:
             return generic_materials
@@ -231,9 +232,12 @@ class MachineManager(SignalEmitter):
             emit = True
 
         material_profile = self.findProfile(material, type = "material", instance = self._active_machine)
+        #This finds only profiles of type "material", which are partial profiles
         if material_profile:
             self._active_machine.getWorkingProfile().mergeSettingsFrom(material_profile, reset = False)
+            emit = True
 
+        #Update the UI if the material selection and/or settings have changed
         if emit:
             self.activeMachineInstanceChanged.emit()
 

--- a/UM/Settings/MachineManager.py
+++ b/UM/Settings/MachineManager.py
@@ -184,7 +184,10 @@ class MachineManager(SignalEmitter):
 
     profileNameChanged = Signal()
 
-    def getProfiles(self):
+    def getProfiles(self, active_instance_profiles_only = True):
+        if not active_instance_profiles_only:
+            return self._profiles
+
         active_machine_type = self._active_machine.getMachineDefinition().getId()
         active_machine_variant = self._active_machine.getMachineDefinition().getVariantName()
         active_machine_instance = self._active_machine.getName()
@@ -240,8 +243,10 @@ class MachineManager(SignalEmitter):
             except:
                 self.setActiveProfile(None)
 
-    def findProfile(self, name):
-        for profile in self._profiles:
+    def findProfile(self, name, active_instance_profiles_only = True):
+        profiles = self.getProfiles(active_instance_profiles_only);
+
+        for profile in profiles:
             if profile.getName() == name:
                 return profile
 

--- a/UM/Settings/MachineManager.py
+++ b/UM/Settings/MachineManager.py
@@ -341,7 +341,7 @@ class MachineManager(SignalEmitter):
         self._profiles.append(profile)
         self.profilesChanged.emit()
 
-        return profile.getName()
+        return profile
 
     def removeProfile(self, profile):
         if profile not in self._profiles:
@@ -425,8 +425,8 @@ class MachineManager(SignalEmitter):
                 if result == cancel_button:
                     return
                 elif result == create_button:
-                    profile_name = self.addProfileFromWorkingProfile()
-                    message = UM.Message.Message(catalog.i18nc("@info:status", "Added a new profile named \"{0}\"").format(profile_name))
+                    profile = self.addProfileFromWorkingProfile()
+                    message = UM.Message.Message(catalog.i18nc("@info:status", "Added a new profile named \"{0}\"").format(profile.getName()))
                     message.show()
                 elif result == update_button:
                     #Replace changed settings of the profile with the changed settings of the working profile

--- a/UM/Settings/MachineManager.py
+++ b/UM/Settings/MachineManager.py
@@ -213,7 +213,6 @@ class MachineManager(SignalEmitter):
 
         material_profile = self.findProfile(material, type="material")
         if material_profile:
-            print(material_profile.getChangedSettingValues())
             self._active_machine.getWorkingProfile().mergeSettingsFrom(material_profile, reset = False)
 
         self.activeMachineInstanceChanged.emit()
@@ -350,6 +349,10 @@ class MachineManager(SignalEmitter):
             
         self._active_profile = profile
         self._active_machine.setActiveProfileName(profile.getName())
+
+        #Reapply previously selected partial material profile
+        if self._active_machine.hasMaterials():
+            self.setActiveMaterial(self._active_machine.getMaterialName())
 
         self.activeProfileChanged.emit()
 

--- a/UM/Settings/MachineManager.py
+++ b/UM/Settings/MachineManager.py
@@ -197,6 +197,20 @@ class MachineManager(SignalEmitter):
                 self.setActiveProfile(profile) #default to first profile you can find
                 break
 
+        if self._active_machine.hasMaterials():
+            material = self._active_machine.getMaterialName()
+            available_materials = self.getAllMachineMaterials(self._active_machine.getName())
+            if not material or (len(available_materials) > 0 and material not in available_materials):
+                self._active_machine.setMaterialName(available_materials[0])
+
+        self.activeMachineInstanceChanged.emit()
+
+    def setActiveMaterial(self, material):
+        if not self._active_machine:
+            return
+
+        self._active_machine.setMaterialName(material)
+
         self.activeMachineInstanceChanged.emit()
 
     def setActiveMachineVariant(self, variant):
@@ -235,8 +249,6 @@ class MachineManager(SignalEmitter):
         active_machine_variant = self._active_machine.getMachineDefinition().getVariantName()
         active_machine_instance = self._active_machine.getName()
         active_machine_material = self._active_machine.getMaterialName()
-        # TEMP alert:
-        active_machine_material = "PLA"
 
         generic_profiles = []
         specific_profiles = []
@@ -250,7 +262,7 @@ class MachineManager(SignalEmitter):
             machine_variant = profile.getMachineVariantName()
             machine_instance = profile.getMachineInstanceName()
             material = profile.getMaterialName()
-            
+
             if machine_type and machine_type == active_machine_type or machine_type == "all":
                 if (not machine_instance) and (not machine_variant):
                     specific_profiles.append(profile)

--- a/UM/Settings/MachineManager.py
+++ b/UM/Settings/MachineManager.py
@@ -204,9 +204,9 @@ class MachineManager(SignalEmitter):
             if machine_type and machine_type == active_machine_type:
                 if (not machine_instance) and (not machine_variant):
                     filtered_profiles.append(profile)
-                elif (not machine_instance) or (machine_instance == active_machine_instance):
+                elif machine_instance and (machine_instance == active_machine_instance):
                     filtered_profiles.append(profile)
-                elif (not machine_instance) and (machine_variant == active_machine_variant):
+                elif machine_variant and (machine_variant == active_machine_variant):
                     filtered_profiles.append(profile)
             elif not machine_type:
                 filtered_profiles.append(profile)

--- a/UM/Settings/MachineManager.py
+++ b/UM/Settings/MachineManager.py
@@ -432,12 +432,6 @@ class MachineManager(SignalEmitter):
                     Logger.log("e", "An exception occurred loading Machine Instance: %s: %s", path, str(e))
                     continue
 
-                try:
-                    file_name = urllib.parse.quote_plus(instance.getName()) + ".curaprofile"
-                    instance.getWorkingProfile().loadFromFile(Resources.getStoragePath(Resources.MachineInstanceProfiles, file_name))
-                except Exception as e:
-                    Logger.log("w", "Could not load working profile: %s: %s", file_name, str(e))
-
                 if not self.findMachineInstance(instance.getName()):
                     self._machine_instances.append(instance)
                     instance.nameChanged.connect(self._onInstanceNameChanged)
@@ -475,6 +469,13 @@ class MachineManager(SignalEmitter):
                     if not self.findProfile(profile.getName(), variant_name = profile.getMachineVariantName(), material_name = profile.getMaterialName()):
                         self._profiles.append(profile)
                         profile.nameChanged.connect(self._onProfileNameChanged)
+
+        for instance in self._machine_instances:
+            try:
+                file_name = urllib.parse.quote_plus(instance.getName()) + ".curaprofile"
+                instance.getWorkingProfile().loadFromFile(Resources.getStoragePath(Resources.MachineInstanceProfiles, file_name))
+            except Exception as e:
+                Logger.log("w", "Could not load working profile: %s: %s", file_name, str(e))
 
         self._protect_working_profile = True
 

--- a/UM/Settings/MachineManager.py
+++ b/UM/Settings/MachineManager.py
@@ -88,7 +88,7 @@ class MachineManager(SignalEmitter):
             if not material or material in machine_materials:
                 continue
 
-            profile_machine_type = profile.getMachineTypeName()
+            profile_machine_type = profile.getMachineTypeId()
             profile_machine_variant = profile.getMachineVariantName()
             profile_machine_instance = profile.getMachineInstanceName()
 
@@ -235,30 +235,37 @@ class MachineManager(SignalEmitter):
         active_machine_variant = self._active_machine.getMachineDefinition().getVariantName()
         active_machine_instance = self._active_machine.getName()
         active_machine_material = self._active_machine.getMaterialName()
+        # TEMP alert:
+        active_machine_material = "PLA"
 
-        filtered_profiles = []
+        generic_profiles = []
+        specific_profiles = []
         for profile in self._profiles:
             profile_type = profile.getType()
             #Filter out "partial" profiles
             if profile_type == "material":
                 continue
 
-            machine_type = profile.getMachineTypeName()
+            machine_type = profile.getMachineTypeId()
             machine_variant = profile.getMachineVariantName()
             machine_instance = profile.getMachineInstanceName()
             material = profile.getMaterialName()
-
-            if machine_type and machine_type == active_machine_type:
+            
+            if machine_type and machine_type == active_machine_type or machine_type == "all":
                 if (not machine_instance) and (not machine_variant):
-                    filtered_profiles.append(profile)
-                elif machine_instance and (machine_instance == active_machine_instance):
-                    filtered_profiles.append(profile)
-                elif machine_variant and (machine_variant == active_machine_variant):
-                    filtered_profiles.append(profile)
+                    specific_profiles.append(profile)
+                elif not material or material == active_machine_material:
+                    if machine_instance and (machine_instance == active_machine_instance):
+                        specific_profiles.append(profile)
+                    elif machine_variant and (machine_variant == active_machine_variant):
+                        specific_profiles.append(profile)
             elif not machine_type:
-                filtered_profiles.append(profile)
+                generic_profiles.append(profile)
 
-        return filtered_profiles
+        if len(specific_profiles) > 0:
+            return specific_profiles
+        else:
+            return generic_profiles
 
     def addProfile(self, profile):
         if profile in self._profiles:

--- a/UM/Settings/MachineManager.py
+++ b/UM/Settings/MachineManager.py
@@ -79,7 +79,7 @@ class MachineManager(SignalEmitter):
         if not machine:
             return machine_materials
             
-        machine_type = machine.getMachineDefinition().getId()
+        machine_type = machine.getMachineDefinition().getProfilesMachineId()
         machine_variant = machine.getMachineDefinition().getVariantName()
 
         for profile in self._profiles:
@@ -266,7 +266,7 @@ class MachineManager(SignalEmitter):
         if not self._active_machine:
             return self._profiles
 
-        active_machine_type = self._active_machine.getMachineDefinition().getId()
+        active_machine_type = self._active_machine.getMachineDefinition().getProfilesMachineId()
         active_machine_variant = self._active_machine.getMachineDefinition().getVariantName()
         active_machine_instance = self._active_machine.getName()
         active_machine_material = self._active_machine.getMaterialName()

--- a/UM/Settings/MachineManager.py
+++ b/UM/Settings/MachineManager.py
@@ -153,8 +153,8 @@ class MachineManager(SignalEmitter):
         self._machine_instances.remove(instance)
         instance.nameChanged.disconnect(self._onInstanceNameChanged)
 
+        file_name = urllib.parse.quote_plus(instance.getName())
         try:
-            file_name = urllib.parse.quote_plus(instance.getName())
             path = Resources.getStoragePath(Resources.MachineInstances, file_name + ".cfg")
             os.remove(path)
             path = Resources.getStoragePath(Resources.MachineInstanceProfiles, file_name + ".cfg")
@@ -328,9 +328,8 @@ class MachineManager(SignalEmitter):
         self._profiles.remove(profile)
         profile.nameChanged.disconnect(self._onProfileNameChanged)
 
+        path = Resources.getStoragePath(Resources.Profiles, urllib.parse.quote_plus(profile.getName()) + ".cfg")
         try:
-            profile_file_name = profile.getName() + "@" + profile.getMachineInstanceName()
-            path = Resources.getStoragePath(Resources.Profiles, urllib.parse.quote_plus(profile_file_name) + ".cfg")
             os.remove(path)
         except FileNotFoundError:
             pass
@@ -545,10 +544,7 @@ class MachineManager(SignalEmitter):
                 if profile.isReadOnly():
                     continue
 
-                profile_file_name = profile.getName()
-                if profile.getMachineInstanceName():
-                    profile_file_name += "@" + profile.getMachineInstanceName()
-                file_name = urllib.parse.quote_plus(profile_file_name) + ".cfg"
+                file_name = urllib.parse.quote_plus(profile.getName()) + ".cfg"
                 profile.saveToFile(Resources.getStoragePath(Resources.Profiles, file_name))
         except AttributeError:
             pass
@@ -649,8 +645,7 @@ class MachineManager(SignalEmitter):
             if profile.isReadOnly() or profile.getMachineInstanceName() != old_name:
                 continue
 
-            profile_file_name = profile.getName() + "@" + old_name
-            file_name = urllib.parse.quote_plus(profile_file_name) + ".cfg"
+            file_name = urllib.parse.quote_plus(profile.getName()) + ".cfg"
             try:
                 path = Resources.getStoragePath(Resources.Profiles, file_name)
                 os.remove(path)
@@ -662,10 +657,9 @@ class MachineManager(SignalEmitter):
         self.machineInstanceNameChanged.emit(instance)
 
     def _onProfileNameChanged(self, profile, old_name):
-        profile_file_name = old_name + "@" + profile.getMachineInstanceName()
-        file_name = urllib.parse.quote_plus(profile_file_name) + ".cfg"
+        file_name = urllib.parse.quote_plus(old_name) + ".cfg"
+        path = Resources.getStoragePath(Resources.Profiles, file_name)
         try:
-            path = Resources.getStoragePath(Resources.Profiles, file_name)
             os.remove(path)
         except FileNotFoundError:
             pass

--- a/UM/Settings/MachineManager.py
+++ b/UM/Settings/MachineManager.py
@@ -554,7 +554,7 @@ class MachineManager(SignalEmitter):
     def saveProfiles(self):
         try:
             for profile in self._profiles:
-                if profile.isReadOnly():
+                if profile.isReadOnly() or not profile.hasChangedSettings():
                     continue
 
                 file_name = urllib.parse.quote_plus(profile.getName()) + ".cfg"

--- a/UM/Settings/MachineManager.py
+++ b/UM/Settings/MachineManager.py
@@ -351,7 +351,7 @@ class MachineManager(SignalEmitter):
         profiles = self.getProfiles(type = type, instance = instance);
 
         for profile in profiles:
-            if profile.getName() == name:
+            if profile.getName().lower() == name.lower():
                 if (variant_name and not profile.getMachineVariantName() == variant_name) or \
                         (material_name and not profile.getMaterialName() == material_name) or \
                         (type and not profile.getType() == type):

--- a/UM/Settings/MachineManager.py
+++ b/UM/Settings/MachineManager.py
@@ -149,6 +149,14 @@ class MachineManager(SignalEmitter):
 
         self._updateSettingVisibility(setting_visibility)
 
+        profile = self.findProfile(machine.getActiveProfileName())
+        if profile:
+            self.setActiveProfile(profile)
+        else:
+            for profile in self._profiles:
+                self.setActiveProfile(profile) #default to first profile you can find
+                break
+
         self.activeMachineInstanceChanged.emit()
 
     def setActiveMachineVariant(self, variant):
@@ -254,9 +262,9 @@ class MachineManager(SignalEmitter):
         self.activeProfileChanged.emit()
 
     def loadAll(self):
+        self.loadProfiles()
         self.loadMachineDefinitions()
         self.loadMachineInstances()
-        self.loadProfiles()
         self.loadVisibility()
 
     def addMachineDefinition(self, definition):

--- a/UM/Settings/MachineManager.py
+++ b/UM/Settings/MachineManager.py
@@ -356,22 +356,23 @@ class MachineManager(SignalEmitter):
 
             read_only = dir != storage_path
 
-            for file_name in os.listdir(dir):
-                path = os.path.join(dir, file_name)
+            for root, dirs, files in os.walk(dir):
+                for file_name in files:
+                    path = os.path.join(root, file_name)
 
-                if os.path.isdir(path):
-                    continue
+                    if os.path.isdir(path):
+                        continue
 
-                profile = Profile(self, read_only)
-                try:
-                    profile.loadFromFile(path)
-                except Exception as e:
-                    Logger.log("e", "An exception occurred loading Profile %s: %s", path, str(e))
-                    continue
+                    profile = Profile(self, read_only)
+                    try:
+                        profile.loadFromFile(path)
+                    except Exception as e:
+                        Logger.log("e", "An exception occurred loading Profile %s: %s", path, str(e))
+                        continue
 
-                if not self.findProfile(profile.getName()):
-                    self._profiles.append(profile)
-                    profile.nameChanged.connect(self._onProfileNameChanged)
+                    if not self.findProfile(profile.getName()):
+                        self._profiles.append(profile)
+                        profile.nameChanged.connect(self._onProfileNameChanged)
 
         self.profilesChanged.emit()
 

--- a/UM/Settings/MachineManager.py
+++ b/UM/Settings/MachineManager.py
@@ -316,10 +316,8 @@ class MachineManager(SignalEmitter):
     def addProfileFromWorkingProfile(self):
         profile = copy.deepcopy(self._active_machine.getWorkingProfile())
         profile.setName("Custom profile")
+        #Make this profile available to all printers of the same type only
         profile.setMachineTypeId(self._active_profile.getMachineTypeId())
-        profile.setMachineVariantName(self._active_profile.getMachineVariantName())
-        profile.setMachineInstanceName(self._active_profile.getMachineInstanceName())
-        profile.setMaterialName(self._active_profile.getMaterialName())
         self._profiles.append(profile)
         self.profilesChanged.emit()
 

--- a/UM/Settings/MachineManager.py
+++ b/UM/Settings/MachineManager.py
@@ -234,7 +234,8 @@ class MachineManager(SignalEmitter):
         profile.nameChanged.disconnect(self._onProfileNameChanged)
 
         try:
-            path = Resources.getStoragePath(Resources.Profiles, urllib.parse.quote_plus(profile.getName()) + ".cfg")
+            profile_file_name = profile.getName() + "@" + profile.getMachineInstanceName()
+            path = Resources.getStoragePath(Resources.Profiles, urllib.parse.quote_plus(profile_file_name) + ".cfg")
             os.remove(path)
         except FileNotFoundError:
             pass
@@ -392,8 +393,8 @@ class MachineManager(SignalEmitter):
                 if profile.isReadOnly():
                     continue
 
-                profile_name = profile.getName() + "@" + profile.getMachineInstanceName()
-                file_name = urllib.parse.quote_plus(profile_name) + ".cfg"
+                profile_file_name = profile.getName() + "@" + profile.getMachineInstanceName()
+                file_name = urllib.parse.quote_plus(profile_file_name) + ".cfg"
                 profile.saveToFile(Resources.getStoragePath(Resources.Profiles, file_name))
         except AttributeError:
             pass
@@ -487,10 +488,26 @@ class MachineManager(SignalEmitter):
         except FileNotFoundError:
             pass
 
+        #Update machine instance name for all profiles attached to this machine instance
+        for profile in self._profiles:
+            if profile.isReadOnly() or profile.getMachineInstanceName() != old_name:
+                continue
+
+            profile_file_name = profile.getName() + "@" + old_name
+            file_name = urllib.parse.quote_plus(profile_file_name) + ".cfg"
+            try:
+                path = Resources.getStoragePath(Resources.Profiles, file_name)
+                os.remove(path)
+            except FileNotFoundError:
+                pass
+
+            profile.setMachineInstanceName(instance.getName())
+
         self.machineInstanceNameChanged.emit(instance)
 
     def _onProfileNameChanged(self, profile, old_name):
-        file_name = urllib.parse.quote_plus(old_name) + ".cfg"
+        profile_file_name = old_name + "@" + profile.getMachineInstanceName()
+        file_name = urllib.parse.quote_plus(profile_file_name) + ".cfg"
         try:
             path = Resources.getStoragePath(Resources.Profiles, file_name)
             os.remove(path)

--- a/UM/Settings/MachineManager.py
+++ b/UM/Settings/MachineManager.py
@@ -402,7 +402,9 @@ class MachineManager(SignalEmitter):
                 if profile.isReadOnly():
                     continue
 
-                profile_file_name = profile.getName() + "@" + profile.getMachineInstanceName()
+                profile_file_name = profile.getName()
+                if profile.getMachineInstanceName():
+                    profile_file_name += "@" + profile.getMachineInstanceName()
                 file_name = urllib.parse.quote_plus(profile_file_name) + ".cfg"
                 profile.saveToFile(Resources.getStoragePath(Resources.Profiles, file_name))
         except AttributeError:

--- a/UM/Settings/MachineManager.py
+++ b/UM/Settings/MachineManager.py
@@ -235,7 +235,7 @@ class MachineManager(SignalEmitter):
         #This finds only profiles of type "material", which are partial profiles
         if material_profile:
             self._active_machine.getWorkingProfile().mergeSettingsFrom(material_profile, reset = False)
-            emit = True
+            #NB: Don't emit on behalf of this profile merge; that would result in an infinit loop
 
         #Update the UI if the material selection and/or settings have changed
         if emit:

--- a/UM/Settings/MachineManager.py
+++ b/UM/Settings/MachineManager.py
@@ -66,6 +66,14 @@ class MachineManager(SignalEmitter):
 
         return variants
 
+    def getAllMachineMaterials(self, machine_id):
+        materials = []
+        for definition in self._machine_definitions:
+            if definition.getId() == machine_id:
+                materials.append(definition)
+
+        return materials
+
     def findMachineDefinition(self, machine_id, variant_name = None):
         for definition in self._machine_definitions:
             if definition.getId() == machine_id:

--- a/UM/Settings/MachineManager.py
+++ b/UM/Settings/MachineManager.py
@@ -5,6 +5,8 @@ import urllib
 import os
 import json
 
+from PyQt5.QtWidgets import QMessageBox
+
 from UM.Signal import Signal, SignalEmitter
 from UM.Resources import Resources
 from UM.Logger import Logger
@@ -343,8 +345,17 @@ class MachineManager(SignalEmitter):
         if profile not in self._profiles or self._active_profile == profile:
             return
 
+        #TODO: only ask the user if there are custom settings to be saved
+        result = QMessageBox.question(None, catalog.i18nc("@title:window", "Replace profile"),
+                    catalog.i18nc("@label", "Selecting the {0} profile replaces your current settings. Do you want to save your settings in a custom profile?").format(profile.getName()), 
+                    QMessageBox.Cancel | QMessageBox.Yes | QMessageBox.No)
+        if result == QMessageBox.Cancel:
+            return
+        elif result == QMessageBox.Yes:
+            #TODO: store working profile in new custom profile
+            pass
+
         #Replace working profile with a copy of the new profile
-        #TODO: warn user, allow cancel
         self._active_machine.getWorkingProfile().mergeSettingsFrom(profile, reset = True)
             
         self._active_profile = profile

--- a/UM/Settings/MachineManager.py
+++ b/UM/Settings/MachineManager.py
@@ -206,7 +206,10 @@ class MachineManager(SignalEmitter):
             material = self._active_machine.getMaterialName()
             available_materials = self.getAllMachineMaterials(self._active_machine.getName())
             if not material or (len(available_materials) > 0 and material not in available_materials):
-                self._active_machine.setMaterialName(available_materials[0])
+                if "PLA" in available_materials:
+                    self._active_machine.setMaterialName("PLA")
+                else:
+                    self._active_machine.setMaterialName(available_materials[0])
 
         self.activeMachineInstanceChanged.emit()
         self._protect_working_profile = False
@@ -473,7 +476,22 @@ class MachineManager(SignalEmitter):
                         self._profiles.append(profile)
                         profile.nameChanged.connect(self._onProfileNameChanged)
 
+        self._protect_working_profile = True
+
+        profile_name = self._active_machine.getActiveProfileName()
+        if profile_name == "":
+            profile_name = "Normal Quality"
+
+        profile = self.findProfile(self._active_machine.getActiveProfileName())
+        if profile:
+            self.setActiveProfile(profile)
+        else:
+            profiles = self.getProfiles()
+            if len(profiles) > 0:
+                self.setActiveProfile(profiles[0])
+
         self.profilesChanged.emit()
+        self._protect_working_profile = False
 
     def loadVisibility(self):
         preference = Preferences.getInstance().getValue("machines/setting_visibility")

--- a/UM/Settings/MachineManager.py
+++ b/UM/Settings/MachineManager.py
@@ -187,7 +187,7 @@ class MachineManager(SignalEmitter):
     def getProfiles(self, active_instance_profiles_only = True):
         if not active_instance_profiles_only:
             return self._profiles
-        
+
         if not self._active_machine:
             return self._profiles
 
@@ -203,7 +203,7 @@ class MachineManager(SignalEmitter):
 
             if machine_type and machine_type == active_machine_type:
                 if (not machine_instance) and (not machine_variant):
-                    filtered_profiles.append(profile)                
+                    filtered_profiles.append(profile)
                 elif (not machine_instance) or (machine_instance == active_machine_instance):
                     filtered_profiles.append(profile)
                 elif (not machine_instance) and (machine_variant == active_machine_variant):
@@ -392,7 +392,7 @@ class MachineManager(SignalEmitter):
                 if profile.isReadOnly():
                     continue
 
-                profile_name = profile.getName() + "@" + profile.getMachineInstanceName() 
+                profile_name = profile.getName() + "@" + profile.getMachineInstanceName()
                 file_name = urllib.parse.quote_plus(profile_name) + ".cfg"
                 profile.saveToFile(Resources.getStoragePath(Resources.Profiles, file_name))
         except AttributeError:

--- a/UM/Settings/MachineManager.py
+++ b/UM/Settings/MachineManager.py
@@ -328,6 +328,9 @@ class MachineManager(SignalEmitter):
 
     activeProfileChanged = Signal()
 
+    def getWorkingProfile(self):
+        return self._active_machine.getWorkingProfile()
+
     def getActiveProfile(self):
         return self._active_profile
 
@@ -335,15 +338,16 @@ class MachineManager(SignalEmitter):
         if profile not in self._profiles or self._active_profile == profile:
             return
 
+        self._active_machine.getWorkingProfile().mergeSettingsFrom(profile, reset = True)
         self._active_profile = profile
         self._active_machine.setActiveProfileName(profile.getName())
 
         self.activeProfileChanged.emit()
 
     def loadAll(self):
-        self.loadProfiles()
         self.loadMachineDefinitions()
         self.loadMachineInstances()
+        self.loadProfiles()
         self.loadVisibility()
 
     def addMachineDefinition(self, definition):

--- a/UM/Settings/MachineManager.py
+++ b/UM/Settings/MachineManager.py
@@ -39,7 +39,6 @@ class MachineManager(SignalEmitter):
 
         Preferences.getInstance().addPreference("machines/setting_visibility", "")
         Preferences.getInstance().addPreference("machines/active_instance", "")
-        Preferences.getInstance().addPreference("machines/active_profile", "Normal Quality")
 
     def getApplicationName(self):
         return self._application_name
@@ -348,14 +347,6 @@ class MachineManager(SignalEmitter):
                     self._profiles.append(profile)
                     profile.nameChanged.connect(self._onProfileNameChanged)
 
-        profile = self.findProfile(Preferences.getInstance().getValue("machines/active_profile"))
-        if profile:
-            self.setActiveProfile(profile)
-        else:
-            if Preferences.getInstance().getValue("machines/active_profile") == "":
-                for profile in self._profiles:
-                    self.setActiveProfile(profile) #default to first profile you can find
-                    break
         self.profilesChanged.emit()
 
     def loadVisibility(self):
@@ -380,7 +371,6 @@ class MachineManager(SignalEmitter):
 
     def saveProfiles(self):
         try:
-            Preferences.getInstance().setValue("machines/active_profile", self._active_profile.getName())
             for profile in self._profiles:
                 if profile.isReadOnly():
                     continue

--- a/UM/Settings/MachineManager.py
+++ b/UM/Settings/MachineManager.py
@@ -397,6 +397,12 @@ class MachineManager(SignalEmitter):
                     Logger.log("e", "An exception occurred loading Machine Instance: %s: %s", path, str(e))
                     continue
 
+                try:
+                    file_name = urllib.parse.quote_plus(instance.getName()) + ".curaprofile"
+                    instance.getWorkingProfile().loadFromFile(Resources.getStoragePath(Resources.MachineInstanceProfiles, file_name))
+                except Exception as e:
+                    Logger.log("w", "Could not load working profile: %s: %s", file_name, str(e))
+
                 if not self.findMachineInstance(instance.getName()):
                     self._machine_instances.append(instance)
                     instance.nameChanged.connect(self._onInstanceNameChanged)
@@ -456,6 +462,8 @@ class MachineManager(SignalEmitter):
         for instance in self._machine_instances:
             file_name = urllib.parse.quote_plus(instance.getName()) + ".cfg"
             instance.saveToFile(Resources.getStoragePath(Resources.MachineInstances, file_name))
+            file_name = urllib.parse.quote_plus(instance.getName()) + ".curaprofile"
+            instance.getWorkingProfile().saveToFile(Resources.getStoragePath(Resources.MachineInstanceProfiles, file_name))
 
     def saveProfiles(self):
         try:
@@ -553,9 +561,11 @@ class MachineManager(SignalEmitter):
                 setting.setVisible(False)
 
     def _onInstanceNameChanged(self, instance, old_name):
-        file_name = urllib.parse.quote_plus(old_name) + ".cfg"
+        file_name = urllib.parse.quote_plus(old_name)
         try:
-            path = Resources.getStoragePath(Resources.MachineInstances, file_name)
+            path = Resources.getStoragePath(Resources.MachineInstances, file_name + ".cfg")
+            os.remove(path)
+            path = Resources.getStoragePath(Resources.MachineInstanceProfiles, file_name + ".curaprofile")
             os.remove(path)
         except FileNotFoundError:
             pass

--- a/UM/Settings/Profile.py
+++ b/UM/Settings/Profile.py
@@ -279,7 +279,7 @@ class Profile(SignalEmitter):
             Logger.log("e", "Failed to write profile to %s: %s", file, str(e))
             return str(e)
         return None
-    
+
     ##  Serialise this profile to a string.
     def serialise(self):
         stream = io.StringIO() #ConfigParser needs to write to a stream.
@@ -298,7 +298,7 @@ class Profile(SignalEmitter):
         parser.add_section("settings") #Write each changed setting in a settings section.
         for setting_key in self._changed_settings:
             parser.set("settings", setting_key , str(self._changed_settings[setting_key]))
-        
+
         parser.write(stream) #Actually serialise it to the stream.
         return stream.getvalue()
 

--- a/UM/Settings/Profile.py
+++ b/UM/Settings/Profile.py
@@ -11,6 +11,9 @@ from UM.Logger import Logger
 from UM.Settings.Validators.ResultCodes import ResultCodes
 from UM.SaveFile import SaveFile
 
+from UM.i18n import i18nCatalog
+catalog = i18nCatalog("uranium")
+
 ##  Provides a collection of setting values
 #
 #   The profile class handles setting values for "user" settings. User settings are settings
@@ -31,7 +34,7 @@ class Profile(SignalEmitter):
         self._machine_manager = machine_manager
         self._changed_settings = {}
         self._changed_settings_defaults = {}
-        self._name = "Unknown Profile"
+        self._name = catalog.i18nc("@label", "Current Settings")
         self._type = None
         self._machine_type_id = None
         self._machine_variant_name = None

--- a/UM/Settings/Profile.py
+++ b/UM/Settings/Profile.py
@@ -122,7 +122,7 @@ class Profile(SignalEmitter):
     #
     #   \note If the setting is not a user-settable setting, this method will do nothing.
     def setSettingValue(self, key, value):
-        Logger.log('d' , "Setting value of setting %s to %s",key,value)
+        Logger.log('d' , "Setting value of %s to %s on profile %s",key,value,self._name)
 
         if not self._active_instance:
             #Active profile is not yet set, so we can't check against machine definition or default values.

--- a/UM/Settings/Profile.py
+++ b/UM/Settings/Profile.py
@@ -124,7 +124,13 @@ class Profile(SignalEmitter):
     def setSettingValue(self, key, value):
         Logger.log('d' , "Setting value of setting %s to %s",key,value)
 
-        if not self._active_instance or not self._active_instance.getMachineDefinition().isUserSetting(key):
+        if not self._active_instance:
+            #Active profile is not yet set, so we can't check against machine definition or default values.
+            #This happens when loading profiles on first start of Cura.
+            self._changed_settings[key] = value
+            return
+
+        if not self._active_instance.getMachineDefinition().isUserSetting(key):
             Logger.log("w", "Tried to set value of non-user setting %s", key)
             return
 

--- a/UM/Settings/Profile.py
+++ b/UM/Settings/Profile.py
@@ -25,6 +25,11 @@ catalog = i18nCatalog("uranium")
 #   profile eg a name, which is used as a human-readable identifier and a read only property. 
 #   Read only profiles are profiles that should not be modified because they are read from system 
 #   locations that cannot be written to, for example /usr/share on Linux systems.
+#
+#   Each machine instance has a single "working profile" which has the current settings for this
+#   machine instance. This working profile is different in that it can also stores the settings 
+#   of the profile(s) it was based on. This is done so settings can be reset to the value of the
+#   profile the working profile was based on.
 class Profile(SignalEmitter):
     ProfileVersion = 1
 
@@ -122,7 +127,7 @@ class Profile(SignalEmitter):
     #
     #   \note If the setting is not a user-settable setting, this method will do nothing.
     def setSettingValue(self, key, value):
-        Logger.log('d' , "Setting value of %s to %s on profile %s",key,value,self._name)
+        Logger.log("d", "Setting value of %s to %s on profile %s", key, value, self._name)
 
         if not self._active_instance:
             #Active profile is not yet set, so we can't check against machine definition or default values.
@@ -240,7 +245,7 @@ class Profile(SignalEmitter):
                 return False
             valid = setting.validate(value)
             if valid == ResultCodes.min_value_error or valid == ResultCodes.max_value_error or valid == ResultCodes.not_valid_error:
-                Logger.log("w", "The setting %s has an invalid value of %s",key,value)
+                Logger.log("w", "The setting %s has an invalid value of %s", key, value)
                 return True
 
         return False

--- a/UM/Settings/Profile.py
+++ b/UM/Settings/Profile.py
@@ -235,7 +235,10 @@ class Profile(SignalEmitter):
     ##  Validate all settings and check if any setting has an error.
     def hasErrorValue(self):
         for key, value in self._changed_settings.items():
-            valid = self._active_instance.getMachineDefinition().getSetting(key).validate(value)
+            setting = self._active_instance.getMachineDefinition().getSetting(key)
+            if not setting:
+                return False
+            valid = setting.validate(value)
             if valid == ResultCodes.min_value_error or valid == ResultCodes.max_value_error or valid == ResultCodes.not_valid_error:
                 Logger.log("w", "The setting %s has an invalid value of %s",key,value)
                 return True

--- a/UM/Settings/Profile.py
+++ b/UM/Settings/Profile.py
@@ -34,7 +34,9 @@ class Profile(SignalEmitter):
         self._machine_type_name = None
         self._machine_variant_name = None
         self._machine_instance_name = None
+        self._material_name = None
         self._read_only = read_only
+        self._type = None
 
         self._active_instance = None
         self._machine_manager.activeMachineInstanceChanged.connect(self._onActiveInstanceChanged)
@@ -64,6 +66,10 @@ class Profile(SignalEmitter):
     def isReadOnly(self):
         return self._read_only
 
+    ##  Retrieve the type of this profile.
+    def getType(self):
+        return self._type
+
     ##  Retrieve the name of the machine type.
     def getMachineTypeName(self):
         return self._machine_type_name
@@ -87,6 +93,14 @@ class Profile(SignalEmitter):
     ##  Set the name of the machine type.
     def setMachineInstanceName(self, machine_instance):
         self._machine_instance_name = machine_instance
+
+    ##  Retrieve the name of the material.
+    def getMaterialName(self):
+        return self._material_name
+
+    ##  Set the name of the machine type.
+    def setMaterialName(self, material):
+        self._material_name = material
 
     ##  Emitted whenever a setting value changes.
     #
@@ -256,12 +270,18 @@ class Profile(SignalEmitter):
             raise SettingsError.InvalidVersionError(origin)
 
         self._name = parser.get("general", "name")
+        if "type" in parser["general"]:
+            self._type = parser.get("general", "type")
         if "machine_type" in parser["general"]:
             self._machine_type_name = parser.get("general", "machine_type")
         if "machine_variant" in parser["general"]:
             self._machine_variant_name = parser.get("general", "machine_variant")
         if "machine_instance" in parser["general"]:
             self._machine_instance_name = parser.get("general", "machine_instance")
+        if "material" in parser["general"]:
+            self._material_name = parser.get("general", "material")
+        elif self._type == "material" and "name" in parser["general"]:
+            self._material_name = parser.get("general", "name")
 
         if parser.has_section("settings"):
             for key, value in parser["settings"].items():
@@ -288,12 +308,16 @@ class Profile(SignalEmitter):
         parser.add_section("general") #Write a general section.
         parser.set("general", "version", str(self.ProfileVersion))
         parser.set("general", "name", self._name)
+        if self._type:
+            parser.set("general", "type", self._type)
         if self._machine_type_name:
             parser.set("general", "machine_type", self._machine_type_name)
         if self._machine_variant_name:
             parser.set("general", "machine_variant", self._machine_variant_name)
         if self._machine_instance_name:
             parser.set("general", "machine_instance", self._machine_instance_name)
+        if self._material_name and not self._type:
+            parser.set("general", "material", self._material_name)
 
         parser.add_section("settings") #Write each changed setting in a settings section.
         for setting_key in self._changed_settings:

--- a/UM/Settings/Profile.py
+++ b/UM/Settings/Profile.py
@@ -258,13 +258,18 @@ class Profile(SignalEmitter):
         return False
 
     ##  Check whether this profile has a value for a certain setting.
-    def hasSettingValue(self, key):
-        return key in self._changed_settings and ( key not in self._changed_settings_defaults or self._changed_settings[key] != self._changed_settings_defaults[key])
+    #   /param key The key for the setting to check
+    #   /param filter_defaults Don't include setting if its value equals the default setting for this profile
+    def hasSettingValue(self, key, filter_defaults = False):
+        if filter_defaults:
+            return key in self._changed_settings and ( key not in self._changed_settings_defaults or self._changed_settings[key] != self._changed_settings_defaults[key])
+        else:
+            return key in self._changed_settings
 
     ## Check whether this profile has any changed settings that are different from the default.
     def hasChangedSettings(self):
         for key in self._changed_settings:
-            if self.hasSettingValue(key):
+            if self.hasSettingValue(key, filter_defaults = True):
                 return True
 
     ##  Remove a setting value from this profile, resetting it to its default value.

--- a/UM/Settings/Profile.py
+++ b/UM/Settings/Profile.py
@@ -251,13 +251,14 @@ class Profile(SignalEmitter):
     ## Merge settings from another profile
     def mergeSettingsFrom(self, profile, reset = False):
         if reset:
-            _changed_settings = {}
-            _changed_settings_defaults = {}
-            
-        settings = profile.getAllSettingValues()
-        for (key, value) in settings:
-            _changed_settings[key] = value
-            _changed_settings_defaults[key] = value
+            self._changed_settings = {}
+            self._changed_settings_defaults = {}
+
+        settings = profile.getChangedSettings()
+
+        for key, value in settings.items():
+            self._changed_settings[key] = value
+            self._changed_settings_defaults[key] = value
 
     ##  Load a serialised profile from a file.
     #

--- a/UM/Settings/Profile.py
+++ b/UM/Settings/Profile.py
@@ -31,7 +31,7 @@ class Profile(SignalEmitter):
         self._machine_manager = machine_manager
         self._changed_settings = {}
         self._name = "Unknown Profile"
-        self._machine_type_name = None
+        self._machine_type_id = None
         self._machine_variant_name = None
         self._machine_instance_name = None
         self._material_name = None
@@ -71,12 +71,12 @@ class Profile(SignalEmitter):
         return self._type
 
     ##  Retrieve the name of the machine type.
-    def getMachineTypeName(self):
-        return self._machine_type_name
+    def getMachineTypeId(self):
+        return self._machine_type_id
 
     ##  Set the name of the machine type.
-    def setMachineTypeName(self, machine_type):
-        self._machine_type_name = machine_type
+    def setMachineTypeId(self, machine_type):
+        self._machine_type_id = machine_type
 
     ##  Retrieve the name of the machine variant.
     def getMachineVariantName(self):
@@ -273,7 +273,7 @@ class Profile(SignalEmitter):
         if "type" in parser["general"]:
             self._type = parser.get("general", "type")
         if "machine_type" in parser["general"]:
-            self._machine_type_name = parser.get("general", "machine_type")
+            self._machine_type_id = parser.get("general", "machine_type")
         if "machine_variant" in parser["general"]:
             self._machine_variant_name = parser.get("general", "machine_variant")
         if "machine_instance" in parser["general"]:
@@ -310,8 +310,8 @@ class Profile(SignalEmitter):
         parser.set("general", "name", self._name)
         if self._type:
             parser.set("general", "type", self._type)
-        if self._machine_type_name:
-            parser.set("general", "machine_type", self._machine_type_name)
+        if self._machine_type_id:
+            parser.set("general", "machine_type", self._machine_type_id)
         if self._machine_variant_name:
             parser.set("general", "machine_variant", self._machine_variant_name)
         if self._machine_instance_name:

--- a/UM/Settings/Profile.py
+++ b/UM/Settings/Profile.py
@@ -255,6 +255,9 @@ class Profile(SignalEmitter):
             self._changed_settings = {}
             self._changed_settings_defaults = {}
 
+        if not profile:
+            return
+
         settings = profile.getChangedSettings()
 
         for key, value in settings.items():

--- a/UM/Settings/Profile.py
+++ b/UM/Settings/Profile.py
@@ -188,6 +188,11 @@ class Profile(SignalEmitter):
     def getChangedSettings(self):
         return self._changed_settings
 
+    ##  Reset the settings that have a value set in this profile to a new set.
+    def setChangedSettings(self, settings):
+        self._changed_settings = settings
+        self._dirty = True
+
     ##  Get a dictionary of all setting values.
     #
     #   \param kwargs Keyword arguments.

--- a/UM/Settings/Profile.py
+++ b/UM/Settings/Profile.py
@@ -129,7 +129,8 @@ class Profile(SignalEmitter):
         if not setting:
             return
 
-        if value == setting.getDefaultValue() or value == str(setting.getDefaultValue()):
+        if value == setting.getDefaultValue() or value == str(setting.getDefaultValue()) and not self._type:
+            #Note: partial profiles can have values that equal the default setting
             if key in self._changed_settings:
                 del self._changed_settings[key]
                 self.settingValueChanged.emit(key)

--- a/UM/Settings/Profile.py
+++ b/UM/Settings/Profile.py
@@ -39,7 +39,7 @@ class Profile(SignalEmitter):
         self._machine_manager = machine_manager
         self._changed_settings = {}
         self._changed_settings_defaults = {}
-        self._name = catalog.i18nc("@label", "Current Settings")
+        self._name = catalog.i18nc("@label", "Current settings")
         self._type = None
         self._machine_type_id = None
         self._machine_variant_name = None

--- a/UM/Settings/Profile.py
+++ b/UM/Settings/Profile.py
@@ -235,7 +235,13 @@ class Profile(SignalEmitter):
 
     ##  Check whether this profile has a value for a certain setting.
     def hasSettingValue(self, key):
-        return key in self._changed_settings
+        return key in self._changed_settings and ( key not in self._changed_settings_defaults or self._changed_settings[key] != self._changed_settings_defaults[key])
+
+    ## Check whether this profile has any changed settings that are different from the default.
+    def hasChangedSettings(self):
+        for key in self._changed_settings:
+            if self.hasSettingValue(key):
+                return True
 
     ##  Remove a setting value from this profile, resetting it to its default value.
     def resetSettingValue(self, key):

--- a/UM/Settings/Profile.py
+++ b/UM/Settings/Profile.py
@@ -56,7 +56,7 @@ class Profile(SignalEmitter):
     def setName(self, name):
         if name != self._name:
             old_name = self._name
-            self._name = name
+            self._name = self._machine_manager.makeUniqueProfileName(name)
             self.nameChanged.emit(self, old_name)
 
     ##  Set whether this profile should be considered a read only profile.

--- a/UM/Settings/Setting.py
+++ b/UM/Settings/Setting.py
@@ -441,7 +441,7 @@ class Setting(SignalEmitter):
 
         def local_function(profile = None):
             if not profile:
-                profile = self._machine_manager.getActiveProfile()
+                profile = self._machine_manager.getWorkingProfile()
 
             if not profile:
                 return None
@@ -471,7 +471,7 @@ class Setting(SignalEmitter):
         if self._profile:
             self._profile.settingValueChanged.disconnect(self._onSettingValueChanged)
 
-        self._profile = self._machine_manager.getActiveProfile()
+        self._profile = self._machine_manager.getWorkingProfile()
         if self._profile:
             self._profile.settingValueChanged.connect(self._onSettingValueChanged)
 

--- a/UM/Settings/SettingOverrideDecorator.py
+++ b/UM/Settings/SettingOverrideDecorator.py
@@ -78,7 +78,7 @@ class SettingOverrideDecorator(SceneNodeDecorator, SignalEmitter):
             if self.getNode().callDecoration("getProfile"):
                 return self.getNode().callDecoration("getProfile").getSettingValue(key)
 
-            return Application.getInstance().getMachineManager().getActiveProfile().getSettingValue(key)
+            return Application.getInstance().getMachineManager().getWorkingProfile().getSettingValue(key)
 
         if key in self._temp_values:
             return self._temp_values[key]

--- a/UM/Settings/SettingsCategory.py
+++ b/UM/Settings/SettingsCategory.py
@@ -78,7 +78,7 @@ class SettingsCategory(SignalEmitter):
         count = 0
         if self._machine_manager.getActiveProfile():
             for setting in self.getAllSettings():
-                if not setting.isVisible() and self._machine_manager.getActiveProfile().hasSettingValue(setting.getKey()):
+                if not setting.isVisible() and self._machine_manager.getWorkingProfile().hasSettingValue(setting.getKey()):
                     count += 1
 
         return count

--- a/UM/Settings/SettingsCategory.py
+++ b/UM/Settings/SettingsCategory.py
@@ -76,7 +76,7 @@ class SettingsCategory(SignalEmitter):
     ##  Get the number of settings in this category that are not visible and have a custom value set.
     def getHiddenValuesCount(self):
         count = 0
-        if self._machine_manager.getActiveProfile():
+        if self._machine_manager.getWorkingProfile():
             for setting in self.getAllSettings():
                 if not setting.isVisible() and self._machine_manager.getWorkingProfile().hasSettingValue(setting.getKey()):
                     count += 1

--- a/UM/Settings/SettingsCategory.py
+++ b/UM/Settings/SettingsCategory.py
@@ -57,7 +57,7 @@ class SettingsCategory(SignalEmitter):
     
     def getDepth(self):
         return self._depth
-    
+
     def setVisible(self, visible):
         if visible != self._visible:
             self._visible = visible
@@ -78,7 +78,7 @@ class SettingsCategory(SignalEmitter):
         count = 0
         if self._machine_manager.getWorkingProfile():
             for setting in self.getAllSettings():
-                if not setting.isVisible() and self._machine_manager.getWorkingProfile().hasSettingValue(setting.getKey()):
+                if not setting.isVisible() and self._machine_manager.getWorkingProfile().hasSettingValue(setting.getKey(), filter_defaults = False):
                     count += 1
 
         return count


### PR DESCRIPTION
This is a reimagining of how profiles work in Cura. Instead of automatically creating new profiles when the user tries to change a setting on a "readonly" profile and having multiple changed profiles, there is only one "working profile" per machine type. This is more akin to how Legacy Cura worked.

This PR also implements different profiles for different printer types, variants (nozzle sizes in the UI) and materials. Finally it contains numerous little UX improvements related to profiles.

Also see Cura PR: https://github.com/Ultimaker/Cura/pull/618

Fixes or contributes to:
CURA-547
CURA-430 (hopefully)
CURA-805
CURA-199
CURA-402
CURA-583
CURA-626
CURA-24
CURA-751
CURA-569
CURA-568
CURA-432
