### PR TITLE
Introduce UM.Qt.Bindings.ContainerProxy class

### DIFF
--- a/UM/Qt/Bindings/ActiveProfileProxy.py
+++ b/UM/Qt/Bindings/ActiveProfileProxy.py
@@ -5,7 +5,6 @@ from PyQt5.QtCore import pyqtSlot, pyqtProperty, pyqtSignal, QObject, QVariant, 
 
 from UM.Application import Application
 from UM.PluginRegistry import PluginRegistry
-#from UM.Logger import deprecated
 
 from . import ContainerProxy
 

--- a/UM/Qt/Bindings/ActiveToolProxy.py
+++ b/UM/Qt/Bindings/ActiveToolProxy.py
@@ -22,7 +22,6 @@ class ActiveToolProxy(QObject):
         self._properties_proxy = ContainerProxy.ContainerProxy(self._properties)
 
     activeToolChanged = pyqtSignal()
-    #propertyChanged = pyqtSignal()
 
     @pyqtProperty(bool, notify = activeToolChanged)
     def valid(self):

--- a/UM/Qt/Bindings/ActiveToolProxy.py
+++ b/UM/Qt/Bindings/ActiveToolProxy.py
@@ -6,6 +6,8 @@ from PyQt5.QtCore import pyqtSlot, pyqtProperty, pyqtSignal, QObject, QUrl
 from UM.Application import Application
 from UM.PluginRegistry import PluginRegistry
 
+from . import ContainerProxy
+
 import os.path
 
 class ActiveToolProxy(QObject):
@@ -17,6 +19,7 @@ class ActiveToolProxy(QObject):
         self._onActiveToolChanged()
 
         self._properties = { }
+        self._properties_proxy = ContainerProxy.ContainerProxy(self._properties)
 
     activeToolChanged = pyqtSignal()
     #propertyChanged = pyqtSignal()
@@ -47,9 +50,9 @@ class ActiveToolProxy(QObject):
             action()
 
     propertiesChanged = pyqtSignal()
-    @pyqtProperty("QVariantMap", notify = propertiesChanged)
+    @pyqtProperty(QObject, notify = propertiesChanged)
     def properties(self):
-        return self._properties;
+        return self._properties_proxy;
 
     @pyqtSlot(str, "QVariant")
     def setProperty(self, property, value):

--- a/UM/Qt/Bindings/ContainerProxy.py
+++ b/UM/Qt/Bindings/ContainerProxy.py
@@ -1,5 +1,14 @@
 from PyQt5.QtCore import QObject, pyqtSlot, pyqtSignal
 
+# This class wraps a Python container and provides access to its elements
+#
+# It is primarily intended as a reasonably fast wrapper around containers
+# that need to be updated and need to notify QML of their changes.
+#
+# To use it, define a property that returns a QObject with a notify signal.
+# From the property getter, return an instance of this object. Whenever the
+# contents of the container change, simply emit the notify signal, do not
+# recreate the proxy.
 class ContainerProxy(QObject):
     def __init__(self, container, parent = None):
         super().__init__(parent)

--- a/UM/Qt/Bindings/ContainerProxy.py
+++ b/UM/Qt/Bindings/ContainerProxy.py
@@ -1,0 +1,19 @@
+from PyQt5.QtCore import QObject, pyqtSlot, pyqtSignal
+
+class ContainerProxy(QObject):
+    def __init__(self, container, parent = None):
+        super().__init__(parent)
+
+        self._container = container
+
+    @pyqtSlot(str, result = "QVariant")
+    def getValue(self, value):
+        return self._container.get(value, None)
+
+    @pyqtSlot(str, "QVariant")
+    def setValue(self, key, value):
+        self._container[key] = value
+
+    @pyqtSlot(result = int)
+    def getCount(self):
+        return len(self._container)

--- a/plugins/Tools/RotateTool/RotateTool.qml
+++ b/plugins/Tools/RotateTool/RotateTool.qml
@@ -56,7 +56,7 @@ Item
 
         style: UM.Theme.styles.checkbox;
 
-        checked: UM.ActiveTool.properties.RotationSnap;
+        checked: UM.ActiveTool.properties.getValue("RotationSnap");
         onClicked: UM.ActiveTool.setProperty("RotationSnap", checked);
     }
 }

--- a/plugins/Tools/ScaleTool/ScaleTool.qml
+++ b/plugins/Tools/ScaleTool/ScaleTool.qml
@@ -68,7 +68,7 @@ Item
 
             style: UM.Theme.styles.checkbox;
 
-            checked: UM.ActiveTool.properties.ScaleSnap;
+            checked: UM.ActiveTool.properties.getValue("ScaleSnap");
             onClicked: {
                 UM.ActiveTool.setProperty("ScaleSnap", checked);
                 if (snapScalingCheckbox.checked){
@@ -86,7 +86,7 @@ Item
 
             style: UM.Theme.styles.checkbox;
 
-            checked: !UM.ActiveTool.properties.NonUniformScale;
+            checked: !UM.ActiveTool.properties.getValue("NonUniformScale");
             onClicked: UM.ActiveTool.setProperty("NonUniformScale", !checked);
         }
     }
@@ -136,7 +136,7 @@ Item
             height: UM.Theme.sizes.setting_control.height;
             property string unit: "mm";
             style: UM.Theme.styles.text_field;
-            text: UM.ActiveTool.properties.ObjectWidth
+            text: UM.ActiveTool.properties.getValue("ObjectWidth")
             validator: DoubleValidator
             {
                 bottom: 0.1
@@ -151,7 +151,7 @@ Item
             height: UM.Theme.sizes.setting_control.height;
             property string unit: "mm";
             style: UM.Theme.styles.text_field;
-            text: UM.ActiveTool.properties.ObjectDepth
+            text: UM.ActiveTool.properties.getValue("ObjectDepth")
             validator: DoubleValidator
             {
                 bottom: 0.1
@@ -166,7 +166,7 @@ Item
             height: UM.Theme.sizes.setting_control.height;
             property string unit: "mm";
             style: UM.Theme.styles.text_field;
-            text: UM.ActiveTool.properties.ObjectHeight
+            text: UM.ActiveTool.properties.getValue("ObjectHeight")
             validator: DoubleValidator
             {
                 bottom: 0.1
@@ -183,10 +183,10 @@ Item
             height: UM.Theme.sizes.setting_control.height;
             property string unit: "%";
             style: UM.Theme.styles.text_field;
-            text: base.getPercentage(UM.ActiveTool.properties.ScaleX)
+            text: base.getPercentage(UM.ActiveTool.properties.getValue("ScaleX"))
             validator: DoubleValidator
             {
-                bottom: 100 * (0.1 / (UM.ActiveTool.properties.ObjectWidth / UM.ActiveTool.properties.ScaleX));
+                bottom: 100 * (0.1 / (UM.ActiveTool.properties.getValue("ObjectWidth") / UM.ActiveTool.properties.getValue("ScaleX")));
                 locale: "en_US"
             }
 
@@ -199,10 +199,10 @@ Item
             height: UM.Theme.sizes.setting_control.height;
             property string unit: "%";
             style: UM.Theme.styles.text_field;
-            text: base.getPercentage(UM.ActiveTool.properties.ScaleZ)
+            text: base.getPercentage(UM.ActiveTool.properties.getValue("ScaleZ"))
             validator: DoubleValidator
             {
-                bottom: 100 * (0.1 / (UM.ActiveTool.properties.ObjectDepth / UM.ActiveTool.properties.ScaleZ));
+                bottom: 100 * (0.1 / (UM.ActiveTool.properties.getValue("ObjectDepth") / UM.ActiveTool.properties.getValue("ScaleZ")));
                 locale: "en_US"
             }
 
@@ -215,10 +215,10 @@ Item
             height: UM.Theme.sizes.setting_control.height;
             property string unit: "%";
             style: UM.Theme.styles.text_field;
-            text: base.getPercentage(UM.ActiveTool.properties.ScaleY)
+            text: base.getPercentage(UM.ActiveTool.properties.getValue("ScaleY"))
             validator: DoubleValidator
             {
-                bottom: 100 * (0.1 / (UM.ActiveTool.properties.ObjectHeight / UM.ActiveTool.properties.ScaleY))
+                bottom: 100 * (0.1 / (UM.ActiveTool.properties.getValue("ObjectHeight") / UM.ActiveTool.properties.getValue("ScaleY")))
                 locale: "en_US"
             }
 


### PR DESCRIPTION
This is a way to handle Python containers in QML without the performance penalties of constantly converting to QVariantMap/QVariantList. 