### PR TITLE
Support UM2 with Olsson block upgrade

### DIFF
--- a/UM/Qt/Bindings/MachineManagerProxy.py
+++ b/UM/Qt/Bindings/MachineManagerProxy.py
@@ -132,14 +132,24 @@ class MachineManagerProxy(QObject):
 
         instance.setMachineSettingValue(key, value)
 
+    @pyqtSlot(result = str)
+    def getMachineDefinitionType(self):
+        instance = self._manager.getActiveMachineInstance()
+        if not instance:
+            return ""
+
+        return instance.getMachineDefinition().getId()
+
     @pyqtSlot(str)
     def setMachineDefinitionType(self, type_name):
         instance = self._manager.getActiveMachineInstance()
         if not instance:
             return
 
-        variant_name = instance.getMachineDefinition().getVariantName()
-        machine_definition = self._manager.findMachineDefinition(type_name, variant_name)
+        machine_definition = self._manager.findMachineDefinition(type_name, "0.4 mm")
+        if not machine_definition:
+            variant_name = instance.getMachineDefinition().getVariantName()
+            machine_definition = self._manager.findMachineDefinition(type_name, variant_name)
         if not machine_definition:
             return
 

--- a/UM/Qt/Bindings/MachineManagerProxy.py
+++ b/UM/Qt/Bindings/MachineManagerProxy.py
@@ -132,6 +132,20 @@ class MachineManagerProxy(QObject):
 
         instance.setMachineSettingValue(key, value)
 
+    @pyqtSlot(str)
+    def setMachineDefinitionType(self, type_name):
+        instance = self._manager.getActiveMachineInstance()
+        if not instance:
+            return
+
+        variant_name = instance.getMachineDefinition().getVariantName()
+        machine_definition = self._manager.findMachineDefinition(type_name, variant_name)
+        if not machine_definition:
+            return
+
+        instance.setMachineDefinition(machine_definition)
+        self._manager.activeMachineInstanceChanged.emit()
+
     @pyqtSlot(result = str)
     def createProfile(self):
         profile = self._manager.addProfileFromWorkingProfile()

--- a/UM/Qt/Bindings/MachineManagerProxy.py
+++ b/UM/Qt/Bindings/MachineManagerProxy.py
@@ -146,7 +146,9 @@ class MachineManagerProxy(QObject):
         if not instance:
             return
 
-        machine_definition = self._manager.findMachineDefinition(type_name, "0.4 mm")
+        prefered_variant = instance.getMachineDefinition().getPreference("prefered_variant")
+        if prefered_variant:
+            machine_definition = self._manager.findMachineDefinition(type_name, prefered_variant)
         if not machine_definition:
             variant_name = instance.getMachineDefinition().getVariantName()
             machine_definition = self._manager.findMachineDefinition(type_name, variant_name)

--- a/UM/Settings/MachineDefinition.py
+++ b/UM/Settings/MachineDefinition.py
@@ -44,6 +44,8 @@ class MachineDefinition(SignalEmitter):
         self._machine_settings = []
         self._categories = []
 
+        self._preferences = {}
+
         self._json_data = None
         self._loaded = False
 
@@ -69,6 +71,9 @@ class MachineDefinition(SignalEmitter):
 
     def getPath(self):
         return self._path
+
+    def getPreference(self, key):
+        return self._preferences[key] if key in self._preferences else None
 
     def isVisible(self):
         return self._visible
@@ -170,6 +175,7 @@ class MachineDefinition(SignalEmitter):
 
             self._machine_settings = inherits_from._machine_settings
             self._categories = inherits_from._categories
+            self._preferences = inherits_from._preferences
 
         if "machine_settings" in self._json_data:
             for key, value in self._json_data["machine_settings"].items():
@@ -194,6 +200,10 @@ class MachineDefinition(SignalEmitter):
                     continue
 
                 setting.fillByDict(value)
+
+        if "machine_preferences" in self._json_data:
+            for key, value in self._json_data["machine_preferences"].items():
+                self._preferences[key] = value
 
         self.settingsLoaded.emit()
 


### PR DESCRIPTION
Adds a "Select Upgraded Parts" wizard page when adding an UM2 or UM2 Extended, allowing the user to select the Olsson block upgrade.

The change in Uranium is necessary to switch the machine definition of an existing machine instance to switch it from "ultimaker2" to "ultimaker2_olsson" in the wizard.

Also see https://github.com/Ultimaker/Cura/pull/636
Fixes CURA-91
