### PR TITLE
Fix performance issues

### DIFF
--- a/UM/Decorators.py
+++ b/UM/Decorators.py
@@ -1,0 +1,32 @@
+# Copyright (c) 2016 Ultimaker B.V.
+# Uranium is released under the terms of the AGPLv3 or higher.
+
+import copy
+import warnings
+
+from UM.Logger import Logger
+
+##  Decorator that can be used to indicate a method has been deprecated
+#
+#   \param message The message to display when the method is called. Should include a suggestion about what to use.
+#   \param since A version since when this method has been deprecated.
+def deprecated(message, since = "Unknown"):
+    def deprecated_decorator(function):
+        def deprecated_function(*args, **kwargs):
+            warning = "{0} is deprecated (since {1}): {2}".format(function, since, message)
+            Logger.log("w", warning)
+            warnings.warn(warning, DeprecationWarning, stacklevel=2)
+            return function(*args, **kwargs)
+        return deprecated_function
+    return deprecated_decorator
+
+##  Decorator to ensure the returned value is always a copy and never a direct reference
+#
+#   "Everything is a Reference" is not nice when dealing with value-types like a Vector or Matrix.
+#   Since you hardly ever want to manipulate internal state of for example a SceneNode, most getters
+#   should return a copy instead of the actual object. This decorator ensures that happens.
+def ascopy(function):
+    def copy_function(*args, **kwargs):
+        return copy.deepcopy(function(*args, **kwargs))
+
+    return copy_function

--- a/UM/Logger.py
+++ b/UM/Logger.py
@@ -5,12 +5,13 @@ from UM.PluginObject import PluginObject
 
 import warnings
 
-def deprecated(message):
+def deprecated(message, since = "Unknown"):
     def deprecated_decorator(function):
         def deprecated_function(*args, **kwargs):
-            warnings.warn(message, DeprecationWarning, stacklevel=2)
-            function(*args, **kwargs)
-
+            warning = "{0} is deprecated (since {1}): {2}".format(function, since, message)
+            Logger.log("w", warning)
+            warnings.warn(warning, DeprecationWarning, stacklevel=2)
+            return function(*args, **kwargs)
         return deprecated_function
     return deprecated_decorator
 

--- a/UM/Logger.py
+++ b/UM/Logger.py
@@ -3,18 +3,6 @@
 
 from UM.PluginObject import PluginObject
 
-import warnings
-
-def deprecated(message, since = "Unknown"):
-    def deprecated_decorator(function):
-        def deprecated_function(*args, **kwargs):
-            warning = "{0} is deprecated (since {1}): {2}".format(function, since, message)
-            Logger.log("w", warning)
-            warnings.warn(warning, DeprecationWarning, stacklevel=2)
-            return function(*args, **kwargs)
-        return deprecated_function
-    return deprecated_decorator
-
 class Logger:
     ##  Add a logger to the list.
     #   \param logger \type{Logger}

--- a/UM/Logger.py
+++ b/UM/Logger.py
@@ -3,6 +3,16 @@
 
 from UM.PluginObject import PluginObject
 
+import warnings
+
+def deprecated(message):
+    def deprecated_decorator(function):
+        def deprecated_function(*args, **kwargs):
+            warnings.warn(message, DeprecationWarning, stacklevel=2)
+            function(*args, **kwargs)
+
+        return deprecated_function
+    return deprecated_decorator
 
 class Logger:
     ##  Add a logger to the list.

--- a/UM/Qt/Bindings/ProfilesModel.py
+++ b/UM/Qt/Bindings/ProfilesModel.py
@@ -40,8 +40,6 @@ class ProfilesModel(ListModel):
 
         self._manager = Application.getInstance().getMachineManager()
         self._working_profile = self._manager.getWorkingProfile()
-        if self._working_profile:
-            self._working_profile.settingValueChanged.connect(self._onWorkingProfileValueChanged)
 
         self._manager.profilesChanged.connect(self._onProfilesChanged)
         self._manager.activeMachineInstanceChanged.connect(self._onMachineInstanceChanged)
@@ -223,11 +221,7 @@ class ProfilesModel(ListModel):
         return filters
 
     def _onMachineInstanceChanged(self):
-        if self._working_profile:
-            self._working_profile.settingValueChanged.disconnect(self._onWorkingProfileValueChanged)
         self._working_profile = self._manager.getWorkingProfile()
-        if self._working_profile:
-            self._working_profile.settingValueChanged.connect(self._onWorkingProfileValueChanged)
 
         self._onProfilesChanged()
 
@@ -243,9 +237,6 @@ class ProfilesModel(ListModel):
                 break
 
         self._manager.setActiveProfile(active_profile)
-
-    def _onWorkingProfileValueChanged(self, setting):
-        self._onProfilesChanged()
 
     def _onProfilesChanged(self):
         self.clear()

--- a/UM/Qt/Bindings/SettingCategoriesModel.py
+++ b/UM/Qt/Bindings/SettingCategoriesModel.py
@@ -63,6 +63,8 @@ class SettingCategoriesModel(ListModel):
     def _onActiveMachineChanged(self):
         self._beginReset()
 
+        self._items = []
+
         if self._machine_instance:
             for category in self._machine_instance.getMachineDefinition().getAllCategories():
                 category.visibleChanged.disconnect(self._onCategoryVisibleChanged)

--- a/UM/Qt/Bindings/SettingCategoriesModel.py
+++ b/UM/Qt/Bindings/SettingCategoriesModel.py
@@ -1,7 +1,7 @@
 # Copyright (c) 2015 Ultimaker B.V.
 # Uranium is released under the terms of the AGPLv3 or higher.
 
-from PyQt5.QtCore import Qt, QCoreApplication, pyqtSlot
+from PyQt5.QtCore import Qt, QCoreApplication, pyqtSlot, pyqtProperty, pyqtSignal
 
 from UM.Qt.ListModel import ListModel
 from UM.Resources import Resources
@@ -32,17 +32,25 @@ class SettingCategoriesModel(ListModel):
         self.addRoleName(self.SettingsRole, "settings")
         self.addRoleName(self.HiddenValuesCountRole, "hiddenValuesCount") # Probably need a better name for this
 
+        self._resetting = False
+
     @pyqtSlot(str)
     def filter(self, text):
         for item in self.items:
             item["settings"].filter(text)
 
+    resettingChanged = pyqtSignal()
+    @pyqtProperty(bool, notify = resettingChanged)
+    def resetting(self):
+        return self._resetting;
+
     @pyqtSlot()
     def reload(self):
-        self.clear()
+        self._beginReset()
+        self._items = []
         if self._machine_instance:
             for category in self._machine_instance.getMachineDefinition().getAllCategories():
-                self.appendItem({
+                self._items.append({
                     "id": category.getKey(),
                     "name": category.getLabel(),
                     "icon": category.getIcon(),
@@ -50,9 +58,11 @@ class SettingCategoriesModel(ListModel):
                     "settings": SettingsFromCategoryModel.SettingsFromCategoryModel(category),
                     "hiddenValuesCount": category.getHiddenValuesCount()
                 })
+        self._endReset()
 
     def _onActiveMachineChanged(self):
-        self.clear()
+        self._beginReset()
+
         if self._machine_instance:
             for category in self._machine_instance.getMachineDefinition().getAllCategories():
                 category.visibleChanged.disconnect(self._onCategoryVisibleChanged)
@@ -71,6 +81,8 @@ class SettingCategoriesModel(ListModel):
                 })
                 category.visibleChanged.connect(self._onCategoryVisibleChanged)
 
+        self._endReset()
+
     def _onCategoryVisibleChanged(self, category):
         index = self.find("id", category.getKey())
         self.setProperty(index, "visible", category.isVisible())
@@ -83,3 +95,13 @@ class SettingCategoriesModel(ListModel):
         for category in self._machine_instance.getMachineDefinition().getAllCategories():
             index = self.find("id", category.getKey())
             self.setProperty(index, "hiddenValuesCount", category.getHiddenValuesCount())
+
+    def _beginReset(self):
+        self.beginResetModel()
+        self._resetting = True
+        self.resettingChanged.emit()
+
+    def _endReset(self):
+        self._resetting = False
+        self.resettingChanged.emit()
+        self.endResetModel()

--- a/UM/Qt/Bindings/SettingsFromCategoryModel.py
+++ b/UM/Qt/Bindings/SettingsFromCategoryModel.py
@@ -124,11 +124,13 @@ class SettingsFromCategoryModel(ListModel, SignalEmitter):
                 self.setProperty(index, "filtered", True)
 
     def updateSettings(self):
-        self.clear()
+        self.beginResetModel()
+        self._items = []
+
         for setting in self._category.getAllSettings():
             value = self._profile.getSettingValue(setting.getKey())
 
-            self.appendItem({
+            self._items.append({
                 "name": setting.getLabel(),
                 "description": setting.getDescription(),
                 "type": setting.getType(),
@@ -149,6 +151,8 @@ class SettingsFromCategoryModel(ListModel, SignalEmitter):
             setting.visibleChanged.connect(self._onSettingVisibleChanged)
             setting.enabledChanged.connect(self._onSettingEnabledChanged)
 
+        self.endResetModel()
+
     def _onSettingVisibleChanged(self, setting):
         if setting:
             index = self.find("key", setting.getKey())
@@ -168,6 +172,7 @@ class SettingsFromCategoryModel(ListModel, SignalEmitter):
         self._profile = self._machine_manager.getWorkingProfile()
         if self._profile:
             self._profile.settingValueChanged.connect(self._onSettingValueChanged)
+
             self.updateSettings()
 
             if self._changed_setting:

--- a/UM/Qt/Bindings/Theme.py
+++ b/UM/Qt/Bindings/Theme.py
@@ -72,7 +72,7 @@ class Theme(QObject):
     @pyqtSlot(str, result = "QUrl")
     def getImage(self, image_name):
         if image_name in self._images:
-            return self._sizes[image_name]
+            return self._images[image_name]
 
         Logger.log("w", "No image %s defined in Theme", image_name)
         return QUrl()

--- a/UM/Qt/Bindings/Theme.py
+++ b/UM/Qt/Bindings/Theme.py
@@ -64,28 +64,28 @@ class Theme(QObject):
     def styles(self):
         return self._styles
 
-    @deprecated("Use getIcon for performance reasons")
     @pyqtProperty("QVariantMap", notify = themeLoaded)
+    @deprecated("Use getIcon for performance reasons", "2.1")
     def icons(self):
         return self._icons
 
-    @deprecated("Use getImage for performance reasons")
     @pyqtProperty("QVariantMap", notify = themeLoaded)
+    @deprecated("Use getImage for performance reasons", "2.1")
     def images(self):
         return self._images
 
-    @deprecated("Use getColor for performance reasons")
     @pyqtProperty("QVariantMap", notify = themeLoaded)
+    @deprecated("Use getColor for performance reasons", "2.1")
     def colors(self):
         return self._colors
 
-    @deprecated("Use getFont for performance reasons")
     @pyqtProperty("QVariantMap", notify = themeLoaded)
+    @deprecated("Use getFont for performance reasons", "2.1")
     def fonts(self):
         return self._fonts
 
-    @deprecated("Use getSize for performance reasons")
     @pyqtProperty("QVariantMap", notify = themeLoaded)
+    @deprecated("Use getSize for performance reasons", "2.1")
     def sizes(self):
         return self._sizes
 

--- a/UM/Qt/Bindings/Theme.py
+++ b/UM/Qt/Bindings/Theme.py
@@ -10,7 +10,7 @@ import os
 import os.path
 import sys
 
-from UM.Logger import Logger
+from UM.Logger import Logger, deprecated
 from UM.Resources import Resources
 
 class Theme(QObject):
@@ -36,26 +36,47 @@ class Theme(QObject):
 
     themeLoaded = pyqtSignal()
 
+    @pyqtSlot(str, result = "QColor")
+    def getColor(self, color):
+        return self._colors.get(color, QColor())
+
+    @pyqtSlot(str, result = "QSizeF")
+    def getSize(self, size):
+        return self._sizes.get(size, QSizeF())
+
+    @pyqtSlot(str, result = "QUrl")
+    def getIcon(self, icon_name):
+        return self._icons.get(icon_name, "")
+
+    @pyqtSlot(str, result = "QFont")
+    def getFont(self, font_name):
+        return self._fonts.get(font_name, QFont())
+
     @pyqtProperty(QObject, notify = themeLoaded)
     def styles(self):
         return self._styles
 
+    @deprecated("Use getIcon for performance reasons")
     @pyqtProperty("QVariantMap", notify = themeLoaded)
     def icons(self):
         return self._icons
 
+    @deprecated("Use getImage for performance reasons")
     @pyqtProperty("QVariantMap", notify = themeLoaded)
     def images(self):
         return self._images
 
+    @deprecated("Use getColor for performance reasons")
     @pyqtProperty("QVariantMap", notify = themeLoaded)
     def colors(self):
         return self._colors
 
+    @deprecated("Use getFont for performance reasons")
     @pyqtProperty("QVariantMap", notify = themeLoaded)
     def fonts(self):
         return self._fonts
 
+    @deprecated("Use getSize for performance reasons")
     @pyqtProperty("QVariantMap", notify = themeLoaded)
     def sizes(self):
         return self._sizes

--- a/UM/Qt/Bindings/Theme.py
+++ b/UM/Qt/Bindings/Theme.py
@@ -68,6 +68,14 @@ class Theme(QObject):
         Logger.log("w", "No icon %s defined in Theme", icon_name)
         return QUrl()
 
+    @pyqtSlot(str, result = "QUrl")
+    def getImage(self, image_name):
+        if image_name in self._images:
+            return self._sizes[image_name]
+
+        Logger.log("w", "No image %s defined in Theme", image_name)
+        return QUrl()
+
     @pyqtSlot(str, result = "QFont")
     def getFont(self, font_name):
         if font_name in self._fonts:

--- a/UM/Qt/Bindings/Theme.py
+++ b/UM/Qt/Bindings/Theme.py
@@ -10,10 +10,11 @@ import os
 import os.path
 import sys
 
-from UM.Logger import Logger, deprecated
+from UM.Logger import Logger
 from UM.Resources import Resources
 from UM.Preferences import Preferences
 from UM.Application import Application
+from UM.Decorators import deprecated
 
 class Theme(QObject):
     def __init__(self, engine, parent = None):

--- a/UM/Qt/Bindings/Theme.py
+++ b/UM/Qt/Bindings/Theme.py
@@ -12,6 +12,8 @@ import sys
 
 from UM.Logger import Logger, deprecated
 from UM.Resources import Resources
+from UM.Preferences import Preferences
+from UM.Application import Application
 
 class Theme(QObject):
     def __init__(self, engine, parent = None):
@@ -32,7 +34,13 @@ class Theme(QObject):
         self._em_height = int(QFontMetrics(QCoreApplication.instance().font()).ascent())
         self._em_width = self._em_height;
 
-        self._initializeDefaults()
+        Preferences.getInstance().addPreference("general/theme", Application.getInstance().getApplicationName())
+
+        try:
+            theme_path = Resources.getPath(Resources.Themes, Preferences.getInstance().getValue("general/theme"))
+            self.load(theme_path)
+        except FileNotFoundError:
+            pass
 
     themeLoaded = pyqtSignal()
 
@@ -83,6 +91,9 @@ class Theme(QObject):
 
     @pyqtSlot(str)
     def load(self, path):
+        if path == self._path:
+            return
+
         self._path = path
 
         with open(os.path.join(self._path, "theme.json")) as f:

--- a/UM/Qt/Bindings/Theme.py
+++ b/UM/Qt/Bindings/Theme.py
@@ -46,19 +46,35 @@ class Theme(QObject):
 
     @pyqtSlot(str, result = "QColor")
     def getColor(self, color):
-        return self._colors.get(color, QColor())
+        if color in self._colors:
+            return self._colors[color]
+
+        Logger.log("w", "No color %s defined in Theme", color)
+        return QColor()
 
     @pyqtSlot(str, result = "QSizeF")
     def getSize(self, size):
-        return self._sizes.get(size, QSizeF())
+        if size in self._sizes:
+            return self._sizes[size]
+
+        Logger.log("w", "No size %s defined in Theme", size)
+        return QSizeF()
 
     @pyqtSlot(str, result = "QUrl")
     def getIcon(self, icon_name):
-        return self._icons.get(icon_name, "")
+        if icon_name in self._icons:
+            return self._icons[icon_name]
+
+        Logger.log("w", "No icon %s defined in Theme", icon_name)
+        return QUrl()
 
     @pyqtSlot(str, result = "QFont")
     def getFont(self, font_name):
-        return self._fonts.get(font_name, QFont())
+        if font_name in self._fonts:
+            return self._fonts[font_name]
+
+        Logger.log("w", "No font %s defined in Theme", font_name)
+        return QFont()
 
     @pyqtProperty(QObject, notify = themeLoaded)
     def styles(self):

--- a/UM/Qt/qml/UM/MessageStack.qml
+++ b/UM/Qt/qml/UM/MessageStack.qml
@@ -21,15 +21,15 @@ ListView {
     delegate: Rectangle
     {
         id: message
-        width: UM.Theme.sizes.message.width
-        property int labelHeight: messageLabel.height + (UM.Theme.sizes.default_margin.height * 2)
-        property int progressBarHeight: totalProgressBar.height + UM.Theme.sizes.default_margin.height
+        width: UM.Theme.getSize("message").width
+        property int labelHeight: messageLabel.height + (UM.Theme.getSize("default_margin").height * 2)
+        property int progressBarHeight: totalProgressBar.height + UM.Theme.getSize("default_margin").height
         height: model.progress == null ? message.labelHeight : message.labelHeight + message.progressBarHeight
         anchors.horizontalCenter: parent.horizontalCenter;
 
-        color: UM.Theme.colors.message_background
-        border.width: UM.Theme.sizes.default_lining.width
-        border.color: UM.Theme.colors.lining
+        color: UM.Theme.getColor("message_background")
+        border.width: UM.Theme.getSize("default_lining").width
+        border.color: UM.Theme.getColor("lining")
 
         property variant actions: model.actions;
         property variant model_id: model.id
@@ -38,16 +38,16 @@ ListView {
             id: messageLabel
             anchors {
                 left: parent.left;
-                leftMargin: UM.Theme.sizes.default_margin.width;
+                leftMargin: UM.Theme.getSize("default_margin").width;
 
                 top: model.progress != null ? parent.top : undefined;
-                topMargin: UM.Theme.sizes.default_margin.width;
+                topMargin: UM.Theme.getSize("default_margin").width;
 
                 right: actionButtons.left;
-                rightMargin: UM.Theme.sizes.default_margin.width;
+                rightMargin: UM.Theme.getSize("default_margin").width;
 
                 verticalCenter: model.progress != null ? undefined : parent.verticalCenter;
-                bottomMargin: UM.Theme.sizes.default_margin.width;
+                bottomMargin: UM.Theme.getSize("default_margin").width;
             }
 
             function getProgressText(){
@@ -56,8 +56,8 @@ ListView {
             }
 
             text: model.progress > 0 ? messageLabel.getProgressText() : model.text == undefined ? '' : model.text
-            color: UM.Theme.colors.message_text;
-            font: UM.Theme.fonts.default;
+            color: UM.Theme.getColor("message_text;")
+            font: UM.Theme.getFont("default;")
             wrapMode: Text.Wrap;
 
             ProgressBar {
@@ -75,26 +75,26 @@ ListView {
                 style: UM.Theme.styles.progressbar
 
                 anchors.top: parent.bottom;
-                anchors.topMargin: UM.Theme.sizes.default_margin.width;
+                anchors.topMargin: UM.Theme.getSize("default_margin").width;
             }
         }
 
         Button {
             id: closeButton;
-            width: UM.Theme.sizes.message_close.width;
-            height: UM.Theme.sizes.message_close.height;
+            width: UM.Theme.getSize("message_close").width;
+            height: UM.Theme.getSize("message_close").height;
             anchors {
                 right: parent.right;
-                rightMargin: UM.Theme.sizes.default_margin.width / 2;
+                rightMargin: UM.Theme.getSize("default_margin").width / 2;
                 top: parent.top;
-                topMargin: UM.Theme.sizes.default_margin.width / 2;
+                topMargin: UM.Theme.getSize("default_margin").width / 2;
             }
             UM.RecolorImage {
                 anchors.fill: parent;
                 sourceSize.width: width
                 sourceSize.height: width
-                color: UM.Theme.colors.message_dismiss
-                source: UM.Theme.icons.cross2;
+                color: UM.Theme.getColor("message_dismiss")
+                source: UM.Theme.getIcon("cross2;")
             }
 
             onClicked: UM.Models.visibleMessagesModel.hideMessage(model.id)
@@ -102,7 +102,7 @@ ListView {
             enabled: model.dismissable
             style: ButtonStyle {
                 background: Rectangle {
-                    color: UM.Theme.colors.message_background
+                    color: UM.Theme.getColor("message_background")
                 }
             }
         }
@@ -113,7 +113,7 @@ ListView {
 
             anchors {
                 right: parent.right;
-                rightMargin: UM.Theme.sizes.default_margin.width * 2;
+                rightMargin: UM.Theme.getSize("default_margin").width * 2;
                 verticalCenter: parent.verticalCenter;
             }
 
@@ -126,24 +126,24 @@ ListView {
                     text: model.name
                     style: ButtonStyle {
                         background: Item{
-                            property int standardWidth: UM.Theme.sizes.message_button.width
-                            property int responsiveWidth: messageStackButtonText.width + UM.Theme.sizes.default_margin.width
+                            property int standardWidth: UM.Theme.getSize("message_button").width
+                            property int responsiveWidth: messageStackButtonText.width + UM.Theme.getSize("default_margin").width
                             implicitWidth: responsiveWidth > standardWidth ? responsiveWidth : standardWidth
-                            implicitHeight: UM.Theme.sizes.message_button.height
+                            implicitHeight: UM.Theme.getSize("message_button").height
                             Rectangle {
                                 id: messageStackButtonBackground
                                 width: parent.width
                                 height: parent.height
-                                color: control.pressed ? UM.Theme.colors.button_active : 
-                                       control.hovered ? UM.Theme.colors.button_hover : UM.Theme.colors.button
+                                color: control.pressed ? UM.Theme.getColor("button_active") :
+                                       control.hovered ? UM.Theme.getColor("button_hover") : UM.Theme.getColor("button")
                                 Behavior on color { ColorAnimation { duration: 50; } }
                             }
                             Label {
                                 id: messageStackButtonText
                                 anchors.centerIn: parent
                                 text: control.text
-                                color: UM.Theme.colors.button_text
-                                font: UM.Theme.fonts.default
+                                color: UM.Theme.getColor("button_text")
+                                font: UM.Theme.getFont("default")
                             }
                         }
                         label: Label{

--- a/UM/Qt/qml/UM/MessageStack.qml
+++ b/UM/Qt/qml/UM/MessageStack.qml
@@ -56,8 +56,8 @@ ListView {
             }
 
             text: model.progress > 0 ? messageLabel.getProgressText() : model.text == undefined ? '' : model.text
-            color: UM.Theme.getColor("message_text;")
-            font: UM.Theme.getFont("default;")
+            color: UM.Theme.getColor("message_text")
+            font: UM.Theme.getFont("default")
             wrapMode: Text.Wrap;
 
             ProgressBar {
@@ -94,7 +94,7 @@ ListView {
                 sourceSize.width: width
                 sourceSize.height: width
                 color: UM.Theme.getColor("message_dismiss")
-                source: UM.Theme.getIcon("cross2;")
+                source: UM.Theme.getIcon("cross2")
             }
 
             onClicked: UM.Models.visibleMessagesModel.hideMessage(model.id)

--- a/UM/Qt/qml/UM/Preferences/MachinesPage.qml
+++ b/UM/Qt/qml/UM/Preferences/MachinesPage.qml
@@ -25,9 +25,9 @@ ManagementPage {
 
     Flow {
         anchors.fill: parent;
-        spacing: UM.Theme.sizes.default_margin.height;
+        spacing: UM.Theme.getSize("default_margin").height;
 
-        Label { text: base.currentItem.name ? base.currentItem.name : ""; font: UM.Theme.fonts.large; width: parent.width; }
+        Label { text: base.currentItem.name ? base.currentItem.name : ""; font: UM.Theme.getFont("large"); width: parent.width; }
 
         Label { text: catalog.i18nc("@label", "Type"); width: parent.width * 0.2; }
         Label { text: base.currentItem.typeName ? base.currentItem.typeName : ""; width: parent.width * 0.7; }

--- a/UM/Qt/qml/UM/Preferences/ManagementPage.qml
+++ b/UM/Qt/qml/UM/Preferences/ManagementPage.qml
@@ -95,7 +95,7 @@ PreferencesPage
             anchors
             {
                 top: captionLabel.visible ? captionLabel.bottom : parent.top;
-                topMargin: captionLabel.visible ? UM.Theme.sizes.default_margin.height : 0;
+                topMargin: captionLabel.visible ? UM.Theme.getSize("default_margin").height : 0;
                 bottom: parent.bottom;
                 left: parent.left;
             }

--- a/UM/Qt/qml/UM/Preferences/ManagementPage.qml
+++ b/UM/Qt/qml/UM/Preferences/ManagementPage.qml
@@ -71,7 +71,7 @@ PreferencesPage
         anchors
         {
             top: buttons.bottom;
-            topMargin: UM.Theme.sizes.default_margin.height;
+            topMargin: UM.Theme.getSize("default_margin").height;
             left: parent.left;
             right: parent.right;
             bottom: parent.bottom;
@@ -122,7 +122,7 @@ PreferencesPage
                     Label
                     {
                         anchors.left: parent.left;
-                        anchors.leftMargin: UM.Theme.sizes.default_margin.width;
+                        anchors.leftMargin: UM.Theme.getSize("default_margin").width;
                         text: model.name
                         color: parent.ListView.isCurrentItem ? palette.highlightedText : palette.text;
                     }
@@ -150,7 +150,7 @@ PreferencesPage
             anchors
             {
                 left: objectListContainer.right;
-                leftMargin: UM.Theme.sizes.default_margin.width;
+                leftMargin: UM.Theme.getSize("default_margin").width;
                 top: parent.top;
                 bottom: parent.bottom;
                 right: parent.right;

--- a/UM/Qt/qml/UM/Preferences/PluginsPage.qml
+++ b/UM/Qt/qml/UM/Preferences/PluginsPage.qml
@@ -50,7 +50,7 @@ PreferencesPage
                     text: model.name
                     onClicked: plugin_list.model.setEnabled(model.name, checked)
                     tooltip: model.description
-                    width: preferencesPage.width / 6 * 4 < UM.Theme.sizes.setting_text_maxwidth.width ? preferencesPage.width / 5 * 4 : UM.Theme.sizes.setting_text_maxwidth.width
+                    width: preferencesPage.width / 6 * 4 < UM.Theme.getSize("setting_text_maxwidth").width ? preferencesPage.width / 5 * 4 : UM.Theme.getSize("setting_text_maxwidth").width
                     style: ButtonStyle
                     {
                         background: Rectangle

--- a/UM/Qt/qml/UM/Preferences/PreferencesDialog.qml
+++ b/UM/Qt/qml/UM/Preferences/PreferencesDialog.qml
@@ -49,8 +49,7 @@ Dialog
             {
                 if(base.currentPage != row)
                 {
-                    stackView.pop()
-                    stackView.push(configPagesModel.get(row).item);
+                    stackView.replace(configPagesModel.get(row).item);
                     base.currentPage = row;
                 }
             }
@@ -67,8 +66,32 @@ Dialog
 
             initialItem: Item { property bool resetEnabled: false; }
 
-            delegate: StackViewDelegate {
-                pushTransition: StackViewTransition { }
+            delegate: StackViewDelegate
+            {
+                function transitionFinished(properties)
+                {
+                    properties.exitItem.opacity = 1
+                }
+
+                pushTransition: StackViewTransition
+                {
+                    PropertyAnimation
+                    {
+                        target: enterItem
+                        property: "opacity"
+                        from: 0
+                        to: 1
+                        duration: 100
+                    }
+                    PropertyAnimation
+                    {
+                        target: exitItem
+                        property: "opacity"
+                        from: 1
+                        to: 0
+                        duration: 100
+                    }
+                }
             }
         }
 
@@ -94,8 +117,9 @@ Dialog
         pagesList.selection.clear();
         pagesList.selection.select(index);
 
-        stackView.pop()
-        stackView.push(configPagesModel.get(index).item);
+        stackView.replace(configPagesModel.get(index).item);
+
+        base.currentPage = index
     }
 
     function insertPage(index, name, item)
@@ -116,22 +140,12 @@ Dialog
     Component.onCompleted:
     {
         //This uses insertPage here because ListModel is stupid and does not allow using qsTr() on elements.
-        insertPage(0, catalog.i18nc("@title:tab", "General"), generalPage);
-        insertPage(1, catalog.i18nc("@title:tab", "Settings"), settingVisibilityPage);
-        insertPage(2, catalog.i18nc("@title:tab", "Printers"), machinesPage);
-        insertPage(3, catalog.i18nc("@title:tab", "Profiles"), profilesPage);
-        insertPage(4, catalog.i18nc("@title:tab", "Plugins"), pluginsPage);
+        insertPage(0, catalog.i18nc("@title:tab", "General"), Qt.resolvedUrl("GeneralPage.qml"));
+        insertPage(1, catalog.i18nc("@title:tab", "Settings"), Qt.resolvedUrl("SettingVisibilityPage.qml"));
+        insertPage(2, catalog.i18nc("@title:tab", "Printers"), Qt.resolvedUrl("MachinesPage.qml"));
+        insertPage(3, catalog.i18nc("@title:tab", "Profiles"), Qt.resolvedUrl("ProfilesPage.qml"));
+        insertPage(4, catalog.i18nc("@title:tab", "Plugins"), Qt.resolvedUrl("PluginsPage.qml"));
 
         setPage(0)
-    }
-
-    Item
-    {
-        visible: false
-        GeneralPage { id: generalPage }
-        SettingVisibilityPage { id: settingVisibilityPage }
-        MachinesPage { id: machinesPage }
-        ProfilesPage { id: profilesPage }
-        PluginsPage { id: pluginsPage }
     }
 }

--- a/UM/Qt/qml/UM/Preferences/PreferencesDialog.qml
+++ b/UM/Qt/qml/UM/Preferences/PreferencesDialog.qml
@@ -16,8 +16,8 @@ Dialog
     id: base;
 
     title: catalog.i18nc("@title:window", "Preferences")
-    minimumWidth: UM.Theme.sizes.modal_window_minimum.width;
-    minimumHeight: UM.Theme.sizes.modal_window_minimum.height;
+    minimumWidth: UM.Theme.getSize("modal_window_minimum").width;
+    minimumHeight: UM.Theme.getSize("modal_window_minimum").height;
 
     property int currentPage: 0;
 
@@ -36,7 +36,7 @@ Dialog
                 bottom: parent.bottom;
             }
 
-            width: 7 * UM.Theme.sizes.line.width;
+            width: 7 * UM.Theme.getSize("line").width;
 
             alternatingRowColors: false;
             headerVisible: false;

--- a/UM/Qt/qml/UM/Preferences/PreferencesToolTip.qml
+++ b/UM/Qt/qml/UM/Preferences/PreferencesToolTip.qml
@@ -17,7 +17,7 @@ Rectangle{
     property int yPos
     SystemPalette{id: palette}
     opacity: 0
-    width: UM.Theme.sizes.tooltip.width
+    width: UM.Theme.getSize("tooltip").width
     x: xPos
     y: yPos
 
@@ -30,8 +30,8 @@ Rectangle{
             standardPlacement()
         }
         else {
-            toolTip.xPos = _xPos + UM.Theme.sizes.default_margin.width
-            toolTip.yPos = _yPos + UM.Theme.sizes.default_margin.height
+            toolTip.xPos = _xPos + UM.Theme.getSize("default_margin").width
+            toolTip.yPos = _yPos + UM.Theme.getSize("default_margin").height
         }
         toolTipTimer.restart()
     }
@@ -46,7 +46,7 @@ Rectangle{
         toolTip.anchors.top = base.top
         toolTip.anchors.topMargin = base.height - settingsScrollView.height
         toolTip.anchors.right = base.right
-        toolTip.anchors.rightMargin = UM.Theme.sizes.default_margin.width
+        toolTip.anchors.rightMargin = UM.Theme.getSize("default_margin").width
     }
 
     Timer {
@@ -66,7 +66,7 @@ Rectangle{
     }
 
     Label {
-        width: parent.width - UM.Theme.sizes.default_margin.width
+        width: parent.width - UM.Theme.getSize("default_margin").width
         wrapMode: Text.Wrap
         text: parent.text
         renderType: Text.NativeRendering
@@ -76,8 +76,8 @@ Rectangle{
             z: parent.z - 1
             anchors.verticalCenter: parent.verticalCenter
             anchors.horizontalCenter: parent.horizontalCenter
-            width: UM.Theme.sizes.tooltip.width
-            height: parent.height + UM.Theme.sizes.default_margin.width
+            width: UM.Theme.getSize("tooltip").width
+            height: parent.height + UM.Theme.getSize("default_margin").width
             color: palette.light
             border.color: "black"
         }

--- a/UM/Qt/qml/UM/Preferences/ProfilesPage.qml
+++ b/UM/Qt/qml/UM/Preferences/ProfilesPage.qml
@@ -33,19 +33,19 @@ ManagementPage
         visible: base.currentItem != null
         anchors.fill: parent
 
-        Label { id: profileName; text: base.currentItem ? base.currentItem.name : ""; font: UM.Theme.fonts.large; width: parent.width; }
+        Label { id: profileName; text: base.currentItem ? base.currentItem.name : ""; font: UM.Theme.getFont("large"); width: parent.width; }
 
         ScrollView {
             anchors.left: parent.left
             anchors.top: profileName.bottom
-            anchors.topMargin: UM.Theme.sizes.default_margin.height
+            anchors.topMargin: UM.Theme.getSize("default_margin").height
             anchors.right: parent.right
             anchors.bottom: parent.bottom
 
             Grid {
                 id: containerGrid
                 columns: 2
-                spacing: UM.Theme.sizes.default_margin.width
+                spacing: UM.Theme.getSize("default_margin").width
 
                 Label { text: catalog.i18nc("@label", "Profile type"); width: 155}
                 Label { text: base.currentItem == null ? "" :

--- a/UM/Qt/qml/UM/Preferences/SettingVisibilityPage.qml
+++ b/UM/Qt/qml/UM/Preferences/SettingVisibilityPage.qml
@@ -70,7 +70,7 @@ PreferencesPage {
                     delegate: Item {
                         id: delegateItem;
 
-                        width: base.width - UM.Theme.sizes.default_margin.width * 2;
+                        width: base.width - UM.Theme.getSize("default_margin").width * 2;
                         height: childrenRect.height;
 
                         ToolButton {
@@ -89,11 +89,11 @@ PreferencesPage {
                                 }
                                 label: Row
                                 {
-                                    spacing: UM.Theme.sizes.default_margin.width;
+                                    spacing: UM.Theme.getSize("default_margin").width;
                                     Image
                                     {
                                         anchors.verticalCenter: parent.verticalCenter;
-                                        source: control.checked ? UM.Theme.icons.arrow_right : UM.Theme.icons.arrow_bottom;
+                                        source: control.checked ? UM.Theme.getIcon("arrow_right") : UM.Theme.getIcon("arrow_bottom")
                                     }
                                     Label
                                     {
@@ -139,7 +139,7 @@ PreferencesPage {
 
                                 delegate: UM.TooltipArea
                                 {
-                                    x: model.depth * UM.Theme.sizes.default_margin.width;
+                                    x: model.depth * UM.Theme.getSize("default_margin").width;
                                     text: model.description;
 
                                     width: childrenRect.width;

--- a/UM/Qt/qml/UM/Settings/SettingCheckBox.qml
+++ b/UM/Qt/qml/UM/Settings/SettingCheckBox.qml
@@ -8,6 +8,71 @@ import QtQuick.Controls.Styles 1.1
 
 import UM 1.0 as UM
 
+MouseArea
+{
+    id: base;
+
+    signal valueChanged(bool value);
+
+    property bool checked:
+    {
+        if(value == "True")
+        {
+            return true;
+        }
+        else if(value == "False")
+        {
+            return false;
+        }
+        else
+        {
+            return value;
+        }
+    }
+
+    onClicked: valueChanged(!checked);
+
+    hoverEnabled: true;
+
+    Rectangle
+    {
+        anchors
+        {
+            top: parent.top
+            bottom: parent.bottom
+            left: parent.left
+        }
+        width: height
+
+        color:
+        {
+            if(base.containsMouse || base.activeFocus)
+            {
+                return itemStyle.controlHighlightColor
+            }
+            else
+            {
+                return itemStyle.controlColor
+            }
+        }
+        border.width: itemStyle.controlBorderWidth;
+        border.color: base.containsMouse ? itemStyle.controlBorderHighlightColor : itemStyle.controlBorderColor;
+
+        UM.RecolorImage {
+            anchors.verticalCenter: parent.verticalCenter
+            anchors.horizontalCenter: parent.horizontalCenter
+            width: parent.width/2.5
+            height: parent.height/2.5
+            sourceSize.width: width
+            sourceSize.height: width
+            color: UM.Theme.getColor("checkbox_mark");
+            source: UM.Theme.getIcon("check")
+            opacity: base.checked
+            Behavior on opacity { NumberAnimation { duration: 100; } }
+        }
+    }
+}
+/*
 CheckBox
 {
     signal valueChanged(bool value);
@@ -38,37 +103,6 @@ CheckBox
     {
         background: Item { }
         label: Label{ }
-        indicator: Rectangle
-        {
-            implicitWidth:  control.height;
-            implicitHeight: control.height;
-
-            color:
-            {
-                if(control.hovered || base.activeFocus)
-                {
-                    return itemStyle.controlHighlightColor
-                }
-                else
-                {
-                    return itemStyle.controlColor
-                }
-            }
-            border.width: itemStyle.controlBorderWidth;
-            border.color: control.hovered ? itemStyle.controlBorderHighlightColor : itemStyle.controlBorderColor;
-
-            UM.RecolorImage {
-                anchors.verticalCenter: parent.verticalCenter
-                anchors.horizontalCenter: parent.horizontalCenter
-                width: parent.width/2.5
-                height: parent.height/2.5
-                sourceSize.width: width
-                sourceSize.height: width
-                color: UM.Theme.getColor("checkbox_mark");
-                source: UM.Theme.getIcon("check")
-                opacity: control.checked
-                Behavior on opacity { NumberAnimation { duration: 100; } }
-            }
-        }
+        indicator:
     }
-}
+}*/

--- a/UM/Qt/qml/UM/Settings/SettingCheckBox.qml
+++ b/UM/Qt/qml/UM/Settings/SettingCheckBox.qml
@@ -64,8 +64,8 @@ CheckBox
                 height: parent.height/2.5
                 sourceSize.width: width
                 sourceSize.height: width
-                color: UM.Theme.colors.checkbox_mark
-                source: UM.Theme.icons.check
+                color: UM.Theme.getColor("checkbox_mark");
+                source: UM.Theme.getIcon("check")
                 opacity: control.checked
                 Behavior on opacity { NumberAnimation { duration: 100; } }
             }

--- a/UM/Qt/qml/UM/Settings/SettingComboBox.qml
+++ b/UM/Qt/qml/UM/Settings/SettingComboBox.qml
@@ -71,9 +71,9 @@ ComboBox
                 anchors.rightMargin: itemStyle.controlBorderWidth * 2;
                 anchors.verticalCenter: parent.verticalCenter;
 
-                source: UM.Theme.icons.arrow_bottom
-                width: UM.Theme.sizes.standard_arrow.width
-                height: UM.Theme.sizes.standard_arrow.height
+                source: UM.Theme.getIcon("arrow_bottom")
+                width: UM.Theme.getSize("standard_arrow").width
+                height: UM.Theme.getSize("standard_arrow").height
                 sourceSize.width: width + 5
                 sourceSize.height: width + 5
 

--- a/UM/Qt/qml/UM/Settings/SettingItem.qml
+++ b/UM/Qt/qml/UM/Settings/SettingItem.qml
@@ -8,7 +8,7 @@ import QtQuick.Controls.Styles 1.1
 
 import UM 1.1 as UM
 
-Rectangle {
+Item {
     id: base;
 
     property string name;
@@ -109,6 +109,7 @@ Rectangle {
 
         anchors {
             right: controlContainer.left
+            rightMargin: UM.Theme.getSize("default_margin").width / 2;
             verticalCenter: parent.verticalCenter;
         }
         visible: base.overridden

--- a/UM/Qt/qml/UM/Settings/SettingItem.qml
+++ b/UM/Qt/qml/UM/Settings/SettingItem.qml
@@ -73,11 +73,11 @@ Rectangle {
     Rectangle{
         visible: base.depth > 1 ? true : false
         id: separationLine
-        width: UM.Theme.sizes.default_lining.width
+        width: UM.Theme.getSize("default_lining").width
         height: label.height
-        color: UM.Theme.colors.setting_control_depth_line
+        color: UM.Theme.getColor("setting_control_depth_line");
         anchors.right: label.left
-        anchors.rightMargin: UM.Theme.sizes.setting_control_depth_margin.width / 2
+        anchors.rightMargin: UM.Theme.getSize("setting_control_depth_margin").width / 2
         anchors.verticalCenter: parent.verticalCenter
         z: parent.z + 1
     }
@@ -88,12 +88,12 @@ Rectangle {
         property int depth: base.depth - 1
 
         anchors.left: parent.left;
-        anchors.leftMargin: base.indent ? (UM.Theme.sizes.section_icon_column.width + 5) + (label.depth * UM.Theme.sizes.setting_control_depth_margin.width) : 0
+        anchors.leftMargin: base.indent ? (UM.Theme.getSize("section_icon_column").width + 5) + (label.depth * UM.Theme.getSize("setting_control_depth_margin").width) : 0
         anchors.right: base.overridden? revertButton.left : controlContainer.left;
         anchors.rightMargin: base.style.spacing;
         anchors.verticalCenter: parent.verticalCenter
 
-        height: UM.Theme.sizes.section.height;
+        height: UM.Theme.getSize("section").height;
         verticalAlignment: Text.AlignVCenter;
 
         text: base.name

--- a/UM/Qt/qml/UM/Settings/SettingItem.qml
+++ b/UM/Qt/qml/UM/Settings/SettingItem.qml
@@ -137,8 +137,6 @@ Rectangle {
         property variant itemStyle: base.style
         visible: status == Loader.Ready
 
-        asynchronous: true;
-
         function notifyReset()
         {
             if(item && item.notifyReset)

--- a/UM/Qt/qml/UM/Settings/SettingItem.qml
+++ b/UM/Qt/qml/UM/Settings/SettingItem.qml
@@ -137,6 +137,8 @@ Rectangle {
         property variant itemStyle: base.style
         visible: status == Loader.Ready
 
+        asynchronous: true;
+
         function notifyReset()
         {
             if(item && item.notifyReset)

--- a/UM/Qt/qml/UM/Settings/SettingItem.qml
+++ b/UM/Qt/qml/UM/Settings/SettingItem.qml
@@ -6,7 +6,7 @@ import QtQuick.Layouts 1.1
 import QtQuick.Controls 1.1
 import QtQuick.Controls.Styles 1.1
 
-import UM 1.0 as UM
+import UM 1.1 as UM
 
 Rectangle {
     id: base;
@@ -103,38 +103,27 @@ Rectangle {
         font: base.style.labelFont;
     }
 
-    Button {
-        id: revertButton
+    UM.SimpleButton
+    {
+        id: revertButton;
 
         anchors {
             right: controlContainer.left
             verticalCenter: parent.verticalCenter;
         }
         visible: base.overridden
-        tooltip: catalog.i18nc("@info:tooltip", "Reset to Default")
 
-        height: parent.height - base.style.controlBorderWidth;
+        height: parent.height / 2;
         width: height;
+
+        backgroundColor: hovered ? base.style.controlHighlightColor : base.style.controlColor;
+
+        color: hovered ? UM.Theme.getColor("setting_control_button_hover") : UM.Theme.getColor("setting_control_button")
+        iconSource: UM.Theme.getIcon("reset")
 
         onClicked: {
             base.resetRequested()
             controlContainer.notifyReset();
-        }
-
-        style: ButtonStyle {
-            background: Rectangle {
-                color: control.hovered ? base.style.controlHighlightColor : base.style.controlColor;
-                UM.RecolorImage {
-                    anchors.verticalCenter: parent.verticalCenter
-                    anchors.horizontalCenter: parent.horizontalCenter
-                    width: parent.width/2
-                    height: parent.height/2
-                    sourceSize.width: width
-                    sourceSize.height: width
-                    color: control.hovered ? UM.Theme.colors.setting_control_button_hover : UM.Theme.colors.setting_control_button
-                    source: UM.Theme.icons.reset
-                }
-            }
         }
     }
 

--- a/UM/Qt/qml/UM/Settings/SettingTextField.qml
+++ b/UM/Qt/qml/UM/Settings/SettingTextField.qml
@@ -1,107 +1,114 @@
 // Copyright (c) 2015 Ultimaker B.V.
 // Uranium is released under the terms of the AGPLv3 or higher.
 
-import QtQuick 2.1
-import QtQuick.Layouts 1.1
-import QtQuick.Controls 1.1
-import QtQuick.Controls.Styles 1.1
+import QtQuick 2.2
+import QtQuick.Controls 1.2
 
-import ".." as UM
+import UM 1.1 as UM
 
-TextField
+Rectangle
 {
     id: base;
 
     signal valueChanged(string value);
-    property bool focusVar: false
 
-    validator: RegExpValidator { regExp: /[0-9.-]+/ }
+    property alias hovered: mouseArea.containsMouse;
 
-    onTextChanged: if(base.activeFocus) { valueChanged(text); }
+    border.width: itemStyle.controlBorderWidth;
+    border.color: hovered ? itemStyle.controlBorderHighlightColor : itemStyle.controlBorderColor
 
     property variant parentValue: value
 
-    Binding
-    {
-        //Rounds a floating point number to 4 decimals. This prevents floating
-        //point rounding errors.
-        //
-        //input:    The number to round.
-        //decimals: The number of decimals (digits after the radix) to round to.
-        //return:   The rounded number.
-        function roundFloat(input, decimals)
+    color: {
+        switch(valid) //From parent loader
         {
-            //First convert to fixed-point notation to round the number to 4 decimals and not introduce new floating point errors.
-            //Then convert to a string (is implicit). The fixed-point notation will be something like "3.200".
-            //Then remove any trailing zeroes and the radix.
-            return input.toFixed(decimals).replace(/\.?0*$/, ""); //Match on periods, if any ( \.? ), followed by any number of zeros ( 0* ), then the end of string ( $ ).
+            case 0:
+                return itemStyle.validationErrorColor;
+            case 1:
+                return itemStyle.validationErrorColor;
+            case 2:
+                return itemStyle.validationErrorColor;
+            case 3:
+                return itemStyle.validationWarningColor;
+            case 4:
+                return itemStyle.validationWarningColor;
+            case 5:
+                return itemStyle.validationOkColor;
+
+            default:
+                return itemStyle.controlTextColor;
+        }
+    }
+
+    Rectangle
+    {
+        anchors.fill: parent;
+        anchors.margins: itemStyle.controlBorderWidth;
+        color: itemStyle.controlHighlightColor;
+        opacity: !base.hovered ? 0 : valid == 5 ? 1.0 : 0.35;
+    }
+
+    Label
+    {
+        anchors.right: parent.right;
+        anchors.rightMargin: itemStyle.unitRightMargin;
+        anchors.verticalCenter: parent.verticalCenter;
+
+        text: unit; //From parent loader
+        color: itemStyle.unitColor
+        font: itemStyle.unitFont;
+    }
+
+    MouseArea
+    {
+        id: mouseArea
+        anchors.fill: parent;
+        hoverEnabled: true;
+        cursorShape: Qt.IBeamCursor
+    }
+
+    TextInput
+    {
+        id: input
+
+        anchors
+        {
+            left: parent.left
+            leftMargin: itemStyle.unitRightMargin
+            right: parent.right
+            verticalCenter: parent.verticalCenter
         }
 
-        target: base
-        property: "text"
-        value: parseFloat(base.parentValue) ? roundFloat(parseFloat(base.parentValue), 4) : base.parentValue //If it's a float, round to four decimals.
-        when: !base.activeFocus
-    }
+        Keys.onReleased: if(text != base.parentValue) base.valueChanged(text);
+        onEditingFinished: if(text != base.parentValue) base.valueChanged(text);
 
-    function notifyReset()
-    {
-        // The reset of this setting field was called so this is the item that has the focus.
-        // This ensures that all values are correctly updated when inheritance is in play.
-        forceActiveFocus()
-        base.text = base.parentValue;
-    }
-
-    style: TextFieldStyle
-    {
-        textColor: itemStyle.controlTextColor;
+        color: itemStyle.controlTextColor;
         font: itemStyle.controlFont;
-        background: Rectangle
+
+        selectByMouse: true;
+
+        validator: RegExpValidator { regExp: /[0-9.,-]+/ }
+
+        Binding
         {
-            implicitHeight: control.height;
-            implicitWidth: control.width;
-
-            border.width: itemStyle.controlBorderWidth;
-            border.color: control.hovered ? itemStyle.controlBorderHighlightColor : itemStyle.controlBorderColor
-
-            color: {
-                switch(valid) //From parent loader
-                {
-                    case 0:
-                        return itemStyle.validationErrorColor;
-                    case 1:
-                        return itemStyle.validationErrorColor;
-                    case 2:
-                        return itemStyle.validationErrorColor;
-                    case 3:
-                        return itemStyle.validationWarningColor;
-                    case 4:
-                        return itemStyle.validationWarningColor;
-                    case 5:
-                        return itemStyle.validationOkColor;
-
-                    default:
-                        return itemStyle.controlTextColor;
-                }
-            }
-
-            Rectangle
-            {
-                anchors.fill: parent;
-                anchors.margins: itemStyle.controlBorderWidth;
-                color: itemStyle.controlHighlightColor;
-                opacity: !control.hovered ? 0 : valid == 5 ? 1.0 : 0.35;
-            }
-
-            Label
-            {
-                anchors.right: parent.right;
-                anchors.rightMargin: itemStyle.unitRightMargin;
-                anchors.verticalCenter: parent.verticalCenter;
-
-                text: unit; //From parent loader
-                color: itemStyle.unitColor; //From parent loader
-                font: itemStyle.unitFont;
-            }
+            target: input
+            property: "text"
+            value: parseFloat(base.parentValue) ? roundFloat(parseFloat(base.parentValue), 4) : base.parentValue //If it's a float, round to four decimals.
+            when: !activeFocus
         }
+    }
+
+    //Rounds a floating point number to 4 decimals. This prevents floating
+    //point rounding errors.
+    //
+    //input:    The number to round.
+    //decimals: The number of decimals (digits after the radix) to round to.
+    //return:   The rounded number.
+    function roundFloat(input, decimals)
+    {
+        //First convert to fixed-point notation to round the number to 4 decimals and not introduce new floating point errors.
+        //Then convert to a string (is implicit). The fixed-point notation will be something like "3.200".
+        //Then remove any trailing zeroes and the radix.
+        return input.toFixed(decimals).replace(/\.?0*$/, ""); //Match on periods, if any ( \.? ), followed by any number of zeros ( 0* ), then the end of string ( $ ).
     }
 }

--- a/UM/Qt/qml/UM/Settings/SettingTextField.qml
+++ b/UM/Qt/qml/UM/Settings/SettingTextField.qml
@@ -17,7 +17,7 @@ Rectangle
     border.width: itemStyle.controlBorderWidth;
     border.color: hovered ? itemStyle.controlBorderHighlightColor : itemStyle.controlBorderColor
 
-    property variant parentValue: value
+    property variant parentValue: value //From parent loader
 
     color: {
         switch(valid) //From parent loader

--- a/UM/Qt/qml/UM/Settings/SettingUnknown.qml
+++ b/UM/Qt/qml/UM/Settings/SettingUnknown.qml
@@ -11,8 +11,7 @@ import ".." as UM
 Label {
     signal valueChanged(string value);
 
-    property variant value;
-    property string unit;
+    property bool hovered: false;
 
     text: value + " " + unit;
 }

--- a/UM/Qt/qml/UM/Settings/SettingView.qml
+++ b/UM/Qt/qml/UM/Settings/SettingView.qml
@@ -154,9 +154,7 @@ ScrollView
                             onLoaded:
                             {
                                 item.name = model.name;
-                                //item.description = model.description;
                                 item.unit = model.unit;
-                                item.value = model.valid;
                                 item.depth = model.depth;
                                 item.type = model.type;
                                 item.key = model.key;

--- a/UM/Qt/qml/UM/Settings/SettingView.qml
+++ b/UM/Qt/qml/UM/Settings/SettingView.qml
@@ -50,7 +50,7 @@ ScrollView
                     height: UM.Theme.getSize("section").height;
 
                     text: model.name;
-                    iconSource: UM.Theme.icons[model.icon];
+                    iconSource: UM.Theme.getIcon(model.icon);
                     checkable: true;
 
                     property bool previousChecked: false

--- a/UM/Qt/qml/UM/Settings/SettingView.qml
+++ b/UM/Qt/qml/UM/Settings/SettingView.qml
@@ -158,7 +158,7 @@ ScrollView
                             style: UM.Theme.styles.setting_item;
 
                             onItemValueChanged: delegateItem.settingsModel.setSettingValue(model.key, value);
-                            onContextMenuRequested: contextMenu.popup();
+                            onContextMenuRequested: { contextMenu.key = model.key; contextMenu.popup(); }
                             onResetRequested: delegateItem.settingsModel.resetSettingValue(model.key)
 
                             onShowTooltip:
@@ -167,29 +167,6 @@ ScrollView
                                 base.showTooltip(item, position, "<b>"+model.name+"</b><br/>"+model.description)
                             }
                             onHideTooltip: base.hideTooltip()
-
-                            Menu
-                            {
-                                id: contextMenu;
-
-                                MenuItem
-                                {
-                                    //: Settings context menu action
-                                    text: catalog.i18nc("@action:menu","Hide this setting");
-                                    onTriggered: delegateItem.settingsModel.hideSetting(model.key);
-                                }
-                                MenuItem
-                                {
-                                    //: Settings context menu action
-                                    text: catalog.i18nc("@action:menu","Configure setting visiblity...");
-
-                                    onTriggered: {
-                                        preferences.visible = true;
-                                        preferences.setPage(2);
-                                        preferences.getCurrentItem().scrollToSection(categoryId);
-                                    }
-                                }
-                            }
                         }
                     }
 
@@ -227,5 +204,26 @@ ScrollView
         }
 
         UM.I18nCatalog { id: catalog; name: "uranium"; }
+
+        Menu
+        {
+            id: contextMenu;
+
+            property string key;
+
+            MenuItem
+            {
+                //: Settings context menu action
+                text: catalog.i18nc("@action:menu","Hide this setting");
+                onTriggered: delegateItem.settingsModel.hideSetting(key);
+            }
+            MenuItem
+            {
+                //: Settings context menu action
+                text: catalog.i18nc("@action:menu","Configure setting visiblity...");
+
+                onTriggered: if(base.configureSettings) base.configureSettings.trigger(key);
+            }
+        }
     }
 }

--- a/UM/Qt/qml/UM/Settings/SettingView.qml
+++ b/UM/Qt/qml/UM/Settings/SettingView.qml
@@ -166,7 +166,6 @@ ScrollView
                                     item.options = model.options;
                                 }
 
-                                settings.itemsLoaded += 1;
                             }
 
                             Binding

--- a/UM/Qt/qml/UM/Settings/SettingView.qml
+++ b/UM/Qt/qml/UM/Settings/SettingView.qml
@@ -19,7 +19,6 @@ ScrollView
     signal showTooltip(Item item, point location, string text);
     signal hideTooltip();
 
-
     property variant expandedCategories: []
 
     Column
@@ -53,6 +52,8 @@ ScrollView
                     iconSource: UM.Theme.getIcon(model.icon);
                     checkable: true;
 
+                    property string key: model.id;
+
                     property bool previousChecked: false
                     checked: base.expandedCategories.indexOf(model.id) != -1;
                     onClicked:
@@ -68,6 +69,8 @@ ScrollView
                         }
                         base.expandedCategories = categories;
                     }
+
+                    onConfigureSettingVisibility: if(base.configureSettings) base.configureSettings.trigger(categoryHeader);
                 }
 
                 UM.SimpleButton
@@ -195,7 +198,7 @@ ScrollView
                             {
                                 target: item;
                                 onItemValueChanged: delegateItem.settingsModel.setSettingValue(model.key, value);
-                                onContextMenuRequested: { contextMenu.key = model.key; contextMenu.popup(); }
+                                onContextMenuRequested: { contextMenu.key = delegateItem.categoryId; contextMenu.popup(); }
                                 onResetRequested: delegateItem.settingsModel.resetSettingValue(model.key);
                                 onShowTooltip: base.showTooltip(settingLoader, Qt.point(0, settingLoader.height / 2), "<b>"+model.name+"</b><br/>"+model.description)
                                 onHideTooltip: base.hideTooltip();
@@ -255,7 +258,7 @@ ScrollView
                 //: Settings context menu action
                 text: catalog.i18nc("@action:menu","Configure setting visiblity...");
 
-                onTriggered: if(base.configureSettings) base.configureSettings.trigger(key);
+                onTriggered: if(base.configureSettings) base.configureSettings.trigger(contextMenu);
             }
         }
     }

--- a/UM/Qt/qml/UM/Settings/SettingView.qml
+++ b/UM/Qt/qml/UM/Settings/SettingView.qml
@@ -70,30 +70,29 @@ ScrollView
                     }
                 }
 
-                Button
+                UM.SimpleButton
                 {
                     id: hiddenSettingsWarning
 
                     anchors.top: categoryHeader.bottom
                     width: categoryHeader.width
 
-                    opacity: categoryHeader.checked && model.hiddenValuesCount > 0 ? 1 : 0
-                    height: categoryHeader.checked && model.hiddenValuesCount > 0 ? UM.Theme.getSize("lineHeight").height : 0
+                    backgroundColor: UM.Theme.getColor("sidebar");
 
-                    text: catalog.i18ncp("@label", "{0} hidden setting uses a custom value", "{0} hidden settings use custom values", model.hiddenValuesCount)
+                    opacity: categoryHeader.checked && model.hiddenValuesCount > 0 ? 1 : 0
+                    height: categoryHeader.checked && model.hiddenValuesCount > 0 ? UM.Theme.getSize("setting").height : 0
+
                     onClicked: { UM.ActiveProfile.showHiddenValues(model.id) }
 
-                    style: ButtonStyle
-                    {
-                        background: Rectangle {}
-                        label: Label
-                        {
-                            text: control.text
+                    Label {
+                        anchors.fill: parent;
 
-                            horizontalAlignment: Text.AlignHCenter
-                            font: UM.Theme.getFont("default")
-                            color: control.hovered ? UM.Theme.getColor("text_hover") : UM.Theme.getColor("text")
-                        }
+                        horizontalAlignment: Text.AlignHCenter
+                        verticalAlignment: Text.AlignVCenter
+
+                        text: catalog.i18ncp("@label", "{0} hidden setting uses a custom value", "{0} hidden settings use custom values", model.hiddenValuesCount)
+                        font: UM.Theme.getFont("default")
+                        color: parent.hovered ? UM.Theme.getColor("text_hover") : UM.Theme.getColor("text")
                     }
                 }
 

--- a/UM/Qt/qml/UM/Settings/SettingView.qml
+++ b/UM/Qt/qml/UM/Settings/SettingView.qml
@@ -25,7 +25,7 @@ ScrollView
     Column
     {
         id: contents
-        spacing: UM.Theme.sizes.default_lining.height;
+        spacing: UM.Theme.getSize("default_lining").height;
 
         Repeater
         {
@@ -46,8 +46,8 @@ ScrollView
                 {
                     id: categoryHeader;
                     activeFocusOnTab: false
-                    width: UM.Theme.sizes.sidebar.width;
-                    height: UM.Theme.sizes.section.height;
+                    width: UM.Theme.getSize("sidebar").width;
+                    height: UM.Theme.getSize("section").height;
 
                     text: model.name;
                     iconSource: UM.Theme.icons[model.icon];
@@ -78,7 +78,7 @@ ScrollView
                     width: categoryHeader.width
 
                     opacity: categoryHeader.checked && model.hiddenValuesCount > 0 ? 1 : 0
-                    height: categoryHeader.checked && model.hiddenValuesCount > 0 ? UM.Theme.sizes.lineHeight : 0
+                    height: categoryHeader.checked && model.hiddenValuesCount > 0 ? UM.Theme.getSize("lineHeight").height : 0
 
                     text: catalog.i18ncp("@label", "{0} hidden setting uses a custom value", "{0} hidden settings use custom values", model.hiddenValuesCount)
                     onClicked: { UM.ActiveProfile.showHiddenValues(model.id) }
@@ -91,8 +91,8 @@ ScrollView
                             text: control.text
 
                             horizontalAlignment: Text.AlignHCenter
-                            font: UM.Theme.fonts.default
-                            color: control.hovered? UM.Theme.colors.text_hover : UM.Theme.colors.text
+                            font: UM.Theme.getFont("default")
+                            color: control.hovered ? UM.Theme.getColor("text_hover") : UM.Theme.getColor("text")
                         }
                     }
                 }
@@ -133,9 +133,9 @@ ScrollView
                         {
                             id: item;
 
-                            width: UM.Theme.sizes.sidebar.width - UM.Theme.sizes.default_margin.width * 2
+                            width: UM.Theme.getSize("sidebar").width - UM.Theme.getSize("default_margin").width * 2
 
-                            height: settingVisible ? UM.Theme.sizes.setting.height + UM.Theme.sizes.default_lining.height : 0;
+                            height: settingVisible ? UM.Theme.getSize("setting").height + UM.Theme.getSize("default_lining").height : 0;
                             Behavior on height { NumberAnimation { duration: 75; } }
                             opacity: settingVisible ? 1 : 0;
                             Behavior on opacity { NumberAnimation { duration: 75; } }

--- a/UM/Qt/qml/UM/Settings/SidebarCategoryHeader.qml
+++ b/UM/Qt/qml/UM/Settings/SidebarCategoryHeader.qml
@@ -6,7 +6,7 @@ import QtQuick.Controls 1.1
 import QtQuick.Controls.Styles 1.1
 import QtQuick.Layouts 1.1
 
-import UM 1.0 as UM
+import UM 1.1 as UM
 
 Button {
     id: base;
@@ -15,7 +15,7 @@ Button {
 
     style: UM.Theme.styles.sidebar_category;
 
-    MouseArea {
+    UM.SimpleButton {
         id: settingsButton
 
         visible: base.hovered || settingsButton.hovered
@@ -26,15 +26,8 @@ Button {
         anchors.right: parent.right
         anchors.rightMargin: UM.Theme.getSize("setting_preferences_button_margin").width
 
-        UM.RecolorImage {
-            anchors.fill: parent;
-
-            sourceSize.width: width
-            sourceSize.height: width
-
-            color: parent.containsMouse ? UM.Theme.getColor("setting_control_button_hover") : UM.Theme.getColor("setting_control_button");
-            source: UM.Theme.getIcon("settings");
-        }
+        color: hovered ? UM.Theme.getColor("setting_control_button_hover") : UM.Theme.getColor("setting_control_button");
+        iconSource: UM.Theme.getIcon("settings");
 
         onClicked: {
             preferences.visible = true;

--- a/UM/Qt/qml/UM/Settings/SidebarCategoryHeader.qml
+++ b/UM/Qt/qml/UM/Settings/SidebarCategoryHeader.qml
@@ -15,6 +15,8 @@ Button {
 
     style: UM.Theme.styles.sidebar_category;
 
+    signal configureSettingVisibility()
+
     UM.SimpleButton {
         id: settingsButton
 
@@ -30,9 +32,7 @@ Button {
         iconSource: UM.Theme.getIcon("settings");
 
         onClicked: {
-            preferences.visible = true;
-            preferences.setPage(2);
-            preferences.getCurrentItem().scrollToSection(model.id);
+            base.configureSettingVisibility()
         }
     }
 }

--- a/UM/Qt/qml/UM/Settings/SidebarCategoryHeader.qml
+++ b/UM/Qt/qml/UM/Settings/SidebarCategoryHeader.qml
@@ -11,32 +11,31 @@ import UM 1.0 as UM
 Button {
     id: base;
 
-    Layout.preferredHeight: UM.Theme.sizes.section.height;
-    Layout.preferredWidth: UM.Theme.sizes.sidebar.width;
-
     property variant color;
+
     style: UM.Theme.styles.sidebar_category;
 
-    Button{
+    MouseArea {
         id: settingsButton
+
         visible: base.hovered || settingsButton.hovered
         height: base.height * 0.6
         width: base.height * 0.6
+
         anchors.verticalCenter: parent.verticalCenter
         anchors.right: parent.right
-        anchors.rightMargin: UM.Theme.sizes.setting_preferences_button_margin.width
-        style: ButtonStyle {
-            background: UM.RecolorImage {
-                id: settingsImage
-                width: control.width
-                height: control.height
-                sourceSize.width: width
-                sourceSize.height: width
-                color: control.hovered ? UM.Theme.colors.setting_control_button_hover : UM.Theme.colors.setting_control_button
-                source: UM.Theme.icons.settings
-            }
-            label: Label{}
+        anchors.rightMargin: UM.Theme.getSize("setting_preferences_button_margin").width
+
+        UM.RecolorImage {
+            anchors.fill: parent;
+
+            sourceSize.width: width
+            sourceSize.height: width
+
+            color: parent.containsMouse ? UM.Theme.getColor("setting_control_button_hover") : UM.Theme.getColor("setting_control_button");
+            source: UM.Theme.getIcon("settings");
         }
+
         onClicked: {
             preferences.visible = true;
             preferences.setPage(2);

--- a/UM/Qt/qml/UM/SimpleButton.qml
+++ b/UM/Qt/qml/UM/SimpleButton.qml
@@ -1,0 +1,34 @@
+// Copyright (c) 2015 Ultimaker B.V.
+// Uranium is released under the terms of the AGPLv3 or higher.
+
+import QtQuick 2.1
+
+MouseArea
+{
+    id: base
+
+    hoverEnabled: true;
+
+    property alias color: image.color;
+    property alias backgroundColor: background.color;
+    property alias iconSource: image.source;
+
+    property alias hovered: base.containsMouse;
+
+    Rectangle {
+        id: background;
+        anchors.fill: parent;
+        color: "transparent";
+    }
+
+    RecolorImage {
+        id: image;
+
+        anchors.fill: parent;
+
+        sourceSize.width: width
+        sourceSize.height: width
+
+        color: "black";
+    }
+}

--- a/UM/Qt/qml/UM/SimpleButton.qml
+++ b/UM/Qt/qml/UM/SimpleButton.qml
@@ -30,5 +30,7 @@ MouseArea
         sourceSize.height: width
 
         color: "black";
+
+        visible: source != "";
     }
 }

--- a/UM/Qt/qml/UM/Wizard.qml
+++ b/UM/Qt/qml/UM/Wizard.qml
@@ -23,8 +23,8 @@ UM.Dialog
     signal nextClicked()
     signal backClicked()
 
-    minimumWidth: UM.Theme.sizes.modal_window_minimum.width
-    minimumHeight: UM.Theme.sizes.modal_window_minimum.height
+    minimumWidth: UM.Theme.getSize("modal_window_minimum").width
+    minimumHeight: UM.Theme.getSize("modal_window_minimum").height
 
     function appendPage(page, title)
     {
@@ -60,7 +60,7 @@ UM.Dialog
         {
             id: wizardProgress
             visible: pagesModel.count > 1 ? true : false
-            width: visible ? UM.Theme.sizes.wizard_progress.width : 0;
+            width: visible ? UM.Theme.getSize("wizard_progress").width : 0;
             anchors.top: parent.top
             anchors.bottom: parent.bottom
             color: palette.light
@@ -117,12 +117,12 @@ UM.Dialog
                         visible: title != pagesModel.get(pagesModel.count - 1).title ? true : false
                         UM.RecolorImage {
                             id: downArrow
-                            width: UM.Theme.sizes.standard_arrow.width
-                            height: UM.Theme.sizes.standard_arrow.height
+                            width: UM.Theme.getSize("standard_arrow").width
+                            height: UM.Theme.getSize("standard_arrow").height
                             sourceSize.width: width
                             sourceSize.height: width
                             color: palette.mid
-                            source: UM.Theme.icons.arrow_bottom
+                            source: UM.Theme.getIcon("arrow_bottom")
                         }
                     }
                 }
@@ -132,7 +132,7 @@ UM.Dialog
                 model: ListModel { id: pagesModel; }
                 delegate: wizardDelegate
                 anchors.fill: parent
-                anchors.topMargin: UM.Theme.sizes.default_margin.height
+                anchors.topMargin: UM.Theme.getSize("default_margin").height
             }
         }
 
@@ -144,11 +144,11 @@ UM.Dialog
                 top: parent.top
                 bottom: parent.bottom;
                 left: wizardProgress.right;
-                leftMargin: UM.Theme.sizes.default_margin.width;
+                leftMargin: UM.Theme.getSize("default_margin").width;
                 right: parent.right;
             }
 
-            width: parent.width - wizardProgress.width - (2 *  UM.Theme.sizes.default_margin.width)
+            width: parent.width - wizardProgress.width - (2 *  UM.Theme.getSize("default_margin").width)
             source: pagesModel.get(base.currentPage).page;
 
             Binding {

--- a/UM/Qt/qml/UM/qmldir
+++ b/UM/Qt/qml/UM/qmldir
@@ -15,3 +15,5 @@ SettingView 1.0 Settings/SettingView.qml
 SidebarCategoryHeader 1.0 Settings/SidebarCategoryHeader.qml
 
 TooltipArea 1.1 TooltipArea.qml
+
+SimpleButton 1.1 SimpleButton.qml

--- a/UM/Settings/Profile.py
+++ b/UM/Settings/Profile.py
@@ -255,7 +255,7 @@ class Profile(SignalEmitter):
             setting = self._active_instance.getMachineDefinition().getSetting(key)
             if not setting:
                 return False
-            valid = setting.validate(value)
+            valid = setting.validate(setting.parseValue(value))
             if valid == ResultCodes.min_value_error or valid == ResultCodes.max_value_error or valid == ResultCodes.not_valid_error:
                 Logger.log("w", "The setting %s has an invalid value of %s", key, value)
                 return True

--- a/plugins/Tools/RotateTool/RotateTool.qml
+++ b/plugins/Tools/RotateTool/RotateTool.qml
@@ -8,15 +8,15 @@ import UM 1.1 as UM
 
 Item
 {
-    width: Math.max(14 * UM.Theme.sizes.line.width, childrenRect.width);
-    height: Math.max(4.5 * UM.Theme.sizes.line.height, childrenRect.height);
+    width: Math.max(14 * UM.Theme.getSize("line").width, childrenRect.width);
+    height: Math.max(4.5 * UM.Theme.getSize("line").height, childrenRect.height);
     UM.I18nCatalog { id: catalog; name:"uranium"}
     Button
     {
         id: resetRotationButton
 
         anchors.left: parent.left;
-        anchors.leftMargin: UM.Theme.sizes.default_margin.width;
+        anchors.leftMargin: UM.Theme.getSize("default_margin").width;
 
         //: Reset Rotation tool button
         text: catalog.i18nc("@action:button","Reset")
@@ -33,7 +33,7 @@ Item
         id: layFlatButton
 
         anchors.left: resetRotationButton.right;
-        anchors.leftMargin: UM.Theme.sizes.default_margin.width;
+        anchors.leftMargin: UM.Theme.getSize("default_margin").width;
 
         //: Lay Flat tool button
         text: catalog.i18nc("@action:button","Lay flat")
@@ -47,9 +47,9 @@ Item
     CheckBox
     {
         anchors.left: parent.left;
-        anchors.leftMargin: UM.Theme.sizes.default_margin.width;
+        anchors.leftMargin: UM.Theme.getSize("default_margin").width;
         anchors.top: resetRotationButton.bottom;
-        anchors.topMargin: UM.Theme.sizes.default_margin.width;
+        anchors.topMargin: UM.Theme.getSize("default_margin").width;
 
         //: Snap Rotation checkbox
         text: catalog.i18nc("@action:checkbox","Snap Rotation");

--- a/plugins/Tools/ScaleTool/ScaleTool.qml
+++ b/plugins/Tools/ScaleTool/ScaleTool.qml
@@ -9,8 +9,8 @@ import UM 1.1 as UM
 Item
 {
     id: base
-    width: Math.max(23 * UM.Theme.sizes.line.width, childrenRect.width);
-    height: Math.max(9.5 * UM.Theme.sizes.line.height, childrenRect.height);
+    width: Math.max(23 * UM.Theme.getSize("line").width, childrenRect.width);
+    height: Math.max(9.5 * UM.Theme.getSize("line").height, childrenRect.height);
     UM.I18nCatalog { id: catalog; name:"uranium"}
 
     function getPercentage(scale){
@@ -22,7 +22,7 @@ Item
         id: resetScaleButton
 
         anchors.top: scaleToMaxButton.bottom;
-        anchors.topMargin: UM.Theme.sizes.default_margin.height;
+        anchors.topMargin: UM.Theme.getSize("default_margin").height;
         z: 1
 
         //: Reset scale tool button
@@ -53,12 +53,12 @@ Item
         id: checkboxes;
 
         anchors.left: resetScaleButton.right;
-        anchors.leftMargin: UM.Theme.sizes.default_margin.width;
+        anchors.leftMargin: UM.Theme.getSize("default_margin").width;
         anchors.right: parent.right;
         anchors.top: textfields.bottom;
-        anchors.topMargin: UM.Theme.sizes.default_margin.height;
+        anchors.topMargin: UM.Theme.getSize("default_margin").height;
 
-        spacing: UM.Theme.sizes.default_margin.height;
+        spacing: UM.Theme.getSize("default_margin").height;
 
         CheckBox
         {
@@ -110,44 +110,44 @@ Item
         }
 
         anchors.left: resetScaleButton.right;
-        anchors.leftMargin: UM.Theme.sizes.default_margin.width;
+        anchors.leftMargin: UM.Theme.getSize("default_margin").width;
         anchors.top: parent.top;
 
         columns: 3;
         flow: Grid.TopToBottom;
-        spacing: UM.Theme.sizes.default_margin.width / 2;
+        spacing: UM.Theme.getSize("default_margin").width / 2;
 
         Label
         {
-            height: UM.Theme.sizes.setting_control.height;
+            height: UM.Theme.getSize("setting_control").height;
             text: "X";
-            font: UM.Theme.fonts.default;
-            color: UM.Theme.colors.text;
+            font: UM.Theme.getFont("default");
+            color: UM.Theme.getColor("text");
             verticalAlignment: Text.AlignVCenter;
         }
 
         Label
         {
-            height: UM.Theme.sizes.setting_control.height;
+            height: UM.Theme.getSize("setting_control").height;
             text: "Y";
-            font: UM.Theme.fonts.default;
-            color: UM.Theme.colors.text;
+            font: UM.Theme.getFont("default");
+            color: UM.Theme.getColor("text");
             verticalAlignment: Text.AlignVCenter;
         }
 
         Label
         {
-            height: UM.Theme.sizes.setting_control.height;
+            height: UM.Theme.getSize("setting_control").height;
             text: "Z";
-            font: UM.Theme.fonts.default;
-            color: UM.Theme.colors.text;
+            font: UM.Theme.getFont("default");
+            color: UM.Theme.getColor("text");
             verticalAlignment: Text.AlignVCenter;
         }
 
         TextField
         {
-            width: UM.Theme.sizes.setting_control.width;
-            height: UM.Theme.sizes.setting_control.height;
+            width: UM.Theme.getSize("setting_control").width;
+            height: UM.Theme.getSize("setting_control").height;
             property string unit: "mm";
             style: UM.Theme.styles.text_field;
             text: UM.ActiveTool.properties.getValue("ObjectWidth").toFixed(4).replace(/\.?0*$/, "")
@@ -162,8 +162,8 @@ Item
         }
         TextField
         {
-            width: UM.Theme.sizes.setting_control.width;
-            height: UM.Theme.sizes.setting_control.height;
+            width: UM.Theme.getSize("setting_control").width;
+            height: UM.Theme.getSize("setting_control").height;
             property string unit: "mm";
             style: UM.Theme.styles.text_field;
             text: parent.roundFloat(UM.ActiveTool.properties.getValue("ObjectDepth"), 4)
@@ -178,8 +178,8 @@ Item
         }
         TextField
         {
-            width: UM.Theme.sizes.setting_control.width;
-            height: UM.Theme.sizes.setting_control.height;
+            width: UM.Theme.getSize("setting_control").width;
+            height: UM.Theme.getSize("setting_control").height;
             property string unit: "mm";
             style: UM.Theme.styles.text_field;
             text: parent.roundFloat(UM.ActiveTool.properties.getValue("ObjectHeight"), 4)
@@ -196,8 +196,8 @@ Item
         TextField
         {
             id: xPercentage
-            width: UM.Theme.sizes.setting_control.width;
-            height: UM.Theme.sizes.setting_control.height;
+            width: UM.Theme.getSize("setting_control").width;
+            height: UM.Theme.getSize("setting_control").height;
             property string unit: "%";
             style: UM.Theme.styles.text_field;
             text: parent.roundFloat(base.getPercentage(UM.ActiveTool.properties.getValue("ScaleX")), 4)
@@ -212,8 +212,8 @@ Item
         TextField
         {
             id: zPercentage
-            width: UM.Theme.sizes.setting_control.width;
-            height: UM.Theme.sizes.setting_control.height;
+            width: UM.Theme.getSize("setting_control").width;
+            height: UM.Theme.getSize("setting_control").height;
             property string unit: "%";
             style: UM.Theme.styles.text_field;
             text: parent.roundFloat(base.getPercentage(UM.ActiveTool.properties.getValue("ScaleZ")), 4)
@@ -229,8 +229,8 @@ Item
         TextField
         {
             id: yPercentage
-            width: UM.Theme.sizes.setting_control.width;
-            height: UM.Theme.sizes.setting_control.height;
+            width: UM.Theme.getSize("setting_control").width;
+            height: UM.Theme.getSize("setting_control").height;
             property string unit: "%";
             style: UM.Theme.styles.text_field;
             text: parent.roundFloat(base.getPercentage(UM.ActiveTool.properties.getValue("ScaleY")), 4)


### PR DESCRIPTION
This makes profile switiching, variant switching and machine switching react in <500ms, with one minor visual regression: Setting items will pop-in relatively randomly when switching, instead of directly appearing. In my opinion, it is a trade-off we can live with.

Fixes CURA-472