### PR TITLE
[WIP] GLESv2: Defining precision for float

### DIFF
--- a/resources/shaders/composite.shader
+++ b/resources/shaders/composite.shader
@@ -13,6 +13,14 @@ vertex =
     }
 
 fragment =
+    #ifdef GL_ES
+        #ifdef GL_FRAGMENT_PRECISION_HIGH
+            precision highp float;
+        #else
+            precision mediump float;
+        #endif // GL_FRAGMENT_PRECISION_HIGH
+    #endif // GL_ES
+
     uniform sampler2D u_layer0;
     uniform sampler2D u_layer1;
     uniform sampler2D u_layer2;


### PR DESCRIPTION
When running Cura with closed-source Mali drivers it is needed to define the precision for float. I'm not sure (as I wrote this some time ago), but this was not needed if you are using software rendering via LLVM pipe.
The same effect can happen, when using other GLESv2 closed-source drivers.
- Related to https://github.com/Ultimaker/Uranium/pull/116
