### PR TITLE
GLESv2: Make GL_VENDOR check more failsave

### DIFF
--- a/UM/Qt/GL/QtOpenGL.py
+++ b/UM/Qt/GL/QtOpenGL.py
@@ -40,7 +40,7 @@ class QtOpenGL(OpenGL):
         self._gpu_vendor = OpenGL.Vendor.Other
         vendor_string = self._gl.glGetString(self._gl.GL_VENDOR)
         if vendor_string is None:
-            vendor_string = ""
+            vendor_string = "Unknown"
         vendor_string = vendor_string.lower()
         if "nvidia" in vendor_string:
             self._gpu_vendor = OpenGL.Vendor.NVidia

--- a/UM/Qt/GL/QtOpenGL.py
+++ b/UM/Qt/GL/QtOpenGL.py
@@ -38,7 +38,10 @@ class QtOpenGL(OpenGL):
         self._gl.initializeOpenGLFunctions()
 
         self._gpu_vendor = OpenGL.Vendor.Other
-        vendor_string = self._gl.glGetString(self._gl.GL_VENDOR).lower()
+        vendor_string = self._gl.glGetString(self._gl.GL_VENDOR)
+        if vendor_string is None:
+            vendor_string = ""
+        vendor_string = vendor_string.lower()
         if "nvidia" in vendor_string:
             self._gpu_vendor = OpenGL.Vendor.NVidia
         elif "amd" in vendor_string or "ati" in vendor_string:


### PR DESCRIPTION
When executing glGetString(self._gl.GL_VENDOR) it returns here on Ubuntu Xenial (armhf) using closed-source mali drivers "None".
Therefore .lower() fails. I think for now replacing the None-Type with "" is ok for now.

* Related to https://github.com/Ultimaker/Uranium/pull/116