### PR TITLE
[master] tracing for logger

### DIFF
--- a/UM/Logger.py
+++ b/UM/Logger.py
@@ -29,8 +29,8 @@ class Logger:
     #   \param *args \type{list} List of variables to be added to the message.
     @classmethod
     def log(cls, log_type, message, *args):
-        func = inspect.currentframe().f_back.f_code
-        address = "%s (%s [%s]): " %(func.co_filename, func.co_name, func.co_firstlineno)
+        function = inspect.currentframe().f_back.f_code
+        address = "%s (%s [%s]): " %(function.co_filename, function.co_name, function.co_firstlineno)
         for logger in cls.__loggers:
             filled_message = address + message % args # Replace all the %s with the variables. Python formating is magic.
             logger.log(log_type, filled_message)

--- a/UM/Logger.py
+++ b/UM/Logger.py
@@ -34,7 +34,7 @@ class Logger:
         filename = function.co_filename
         for path in sys.path:
             if filename.startswith(path):
-                filename = filename.replace(path, "<PATH>")
+                filename = filename.replace(path, "...")
                 continue
         address = "%s (%s [%s]): " %(filename, function.co_name, function.co_firstlineno)
         for logger in cls.__loggers:

--- a/UM/Logger.py
+++ b/UM/Logger.py
@@ -2,6 +2,7 @@
 # Uranium is released under the terms of the AGPLv3 or higher.
 
 import traceback
+import inspect
 
 from UM.PluginObject import PluginObject
 

--- a/UM/Logger.py
+++ b/UM/Logger.py
@@ -1,6 +1,7 @@
 # Copyright (c) 2015 Ultimaker B.V.
 # Uranium is released under the terms of the AGPLv3 or higher.
 
+import sys
 import traceback
 import inspect
 

--- a/UM/Logger.py
+++ b/UM/Logger.py
@@ -30,7 +30,12 @@ class Logger:
     @classmethod
     def log(cls, log_type, message, *args):
         function = inspect.currentframe().f_back.f_code
-        address = "%s (%s [%s]): " %(function.co_filename, function.co_name, function.co_firstlineno)
+        filename = function.co_filename
+        for path in sys.path:
+            if filename.startswith(path):
+                filename = filename.replace(path, "<PATH>")
+                continue
+        address = "%s (%s [%s]): " %(filename, function.co_name, function.co_firstlineno)
         for logger in cls.__loggers:
             filled_message = address + message % args # Replace all the %s with the variables. Python formating is magic.
             logger.log(log_type, filled_message)

--- a/UM/Logger.py
+++ b/UM/Logger.py
@@ -28,8 +28,10 @@ class Logger:
     #   \param *args \type{list} List of variables to be added to the message.
     @classmethod
     def log(cls, log_type, message, *args):
+        func = inspect.currentframe().f_back.f_code
+        address = "%s (%s [%s]): " %(func.co_filename, func.co_name, func.co_firstlineno)
         for logger in cls.__loggers:
-            filled_message = message % args # Replace all the %s with the variables. Python formating is magic.
+            filled_message = address + message % args # Replace all the %s with the variables. Python formating is magic.
             logger.log(log_type, filled_message)
 
     ##


### PR DESCRIPTION
This will add logger outputs like:

```
2016-03-18 15:51:06,332 - INFO - <PATH>/UM/PluginRegistry.py (loadPlugin [61]): Loaded plugin ChangeLogPlugin
2016-03-18 15:51:06,334 - INFO - <PATH>/UM/Qt/QtApplication.py (__init__ [36]): Command line arguments: {'file': [], 'disable-textures': False, 'external-backend': False, 'debug-mode': False}
2016-03-18 15:51:06,481 - WARNING - <PATH>/UM/Settings/MachineManager.py (saveVisibility [707]): No active machine found when trying to save setting visibility
2016-03-18 15:51:06,588 - WARNING - <PATH>/UM/Settings/Profile.py (setSettingValue [148]): Tried to set value of non-user setting platform_adhesion
2016-03-18 15:51:06,590 - WARNING - <PATH>/UM/Settings/Profile.py (setSettingValue [148]): Tried to set value of non-user setting platform_adhesion
2016-03-18 15:51:06,613 - INFO - <PATH>/UM/Backend/Backend.py (startEngine [45]): Started engine process: /usr/bin/CuraEngine
2016-03-18 15:51:06,653 - DEBUG - <PATH>/UM/Backend/Backend.py (_onSocketStateChanged [122]): Backend connected on port 49674
2016-03-18 15:51:06,654 - DEBUG - <PATH>/UM/Controller.py (setActiveView [83]): Setting active view to SolidView
```