### PR TITLE
[master] Mesh: Converting floating point faces into int()

### DIFF
--- a/UM/Mesh/MeshData.py
+++ b/UM/Mesh/MeshData.py
@@ -217,7 +217,7 @@ class MeshData(SignalEmitter):
     #
     #   \param num_faces Number of faces for which memory must be reserved.
     def reserveFaceCount(self, num_faces):
-        if (type(num_faces) == float):
+        if type(num_faces) == float:
             Logger.log("w", "Had to convert 'num_faces' with int(): %s -> %s ", num_faces, int(num_faces))
             num_faces = int(num_faces)
 

--- a/UM/Mesh/MeshData.py
+++ b/UM/Mesh/MeshData.py
@@ -217,6 +217,10 @@ class MeshData(SignalEmitter):
     #
     #   \param num_faces Number of faces for which memory must be reserved.
     def reserveFaceCount(self, num_faces):
+        if (type(num_faces) == float):
+            Logger.log("w", "Had to convert 'num_faces' with int(): %s -> %s ", num_faces, int(num_faces))
+            num_faces = int(num_faces)
+
         self._vertices = numpy.zeros((num_faces * 3, 3), dtype=numpy.float32)
         self._normals = numpy.zeros((num_faces * 3, 3), dtype=numpy.float32)
         self._indices = numpy.zeros((num_faces, 3), dtype=numpy.int32)


### PR DESCRIPTION
It seems that some CAD applications export the number of faces as floating point numbers. Our STL loader seems not to care about this and passes num_faces as float().
This commit converts the floating point value into int() as needed. Of course, we should check about this much earlier.

This might be useful to backport to a bugfix version of 2.1.