### PR TITLE
[master] ConsoleLogger: Optional colored output

### DIFF
--- a/plugins/ConsoleLogger/ConsoleLogger.py
+++ b/plugins/ConsoleLogger/ConsoleLogger.py
@@ -5,13 +5,27 @@ from UM.Logger import LogOutput
 
 import logging
 
+try:
+    from colorlog import ColoredFormatter
+    logging_formatter = ColoredFormatter("%(purple)s%(asctime)s%(reset)s - %(log_color)s%(levelname)s%(reset)s - %(white)s%(message)s%(reset)s",
+                                         log_colors = {'DEBUG': 'cyan',
+                                                       'INFO': 'green',
+                                                       'WARNING': 'yellow',
+                                                       'ERROR': 'red',
+                                                       'CRITICAL': 'red,bg_white',
+                                                       },
+                                         )
+except:
+    from logging import Formatter
+    logging_formatter = Formatter("%(asctime)s - %(levelname)s - %(message)s")
+
 class ConsoleLogger(LogOutput):
     def __init__(self):
         super().__init__()
         self._logger = logging.getLogger(self._name) #Create python logger 
         self._logger.setLevel(logging.DEBUG)
         stream_handler = logging.StreamHandler() # Log to stream
-        stream_handler.setFormatter(logging.Formatter("%(asctime)s - %(levelname)s - %(message)s"))
+        stream_handler.setFormatter(logging_formatter)
         self._logger.addHandler(stream_handler)
     
     ##  Log the message to console


### PR DESCRIPTION
In case the colorlog module is installed, it's Formatter will be used to colorize the output.
It improves the possibility to find ERRORs and WARNINGs.
It should be no problem to make that available on Windows and OSX, too, as colorlog is crossplatform and handles the different ways to pass the colors to the terminals.

![cura12](https://cloud.githubusercontent.com/assets/1847437/14984837/05c23d26-1145-11e6-8f11-24774e10ffe6.png)
