### PR TITLE
Optionally scale meshes that are so tiny they could not otherwise be selected

### DIFF
--- a/UM/Mesh/ReadMeshJob.py
+++ b/UM/Mesh/ReadMeshJob.py
@@ -13,6 +13,7 @@ from UM.Mesh.MeshReader import MeshReader
 
 import time
 import os.path
+import math
 
 from UM.i18n import i18nCatalog
 i18n_catalog = i18nCatalog("uranium")
@@ -80,16 +81,25 @@ class ReadMeshJob(Job):
                 timeout_counter += 1
                 if timeout_counter > 10:
                     break
-            if max_bounds.width < bounding_box.width or max_bounds.height < bounding_box.height or max_bounds.depth < bounding_box.depth:
+
+            if Preferences.getInstance().getValue("mesh/scale_to_fit") == True or Preferences.getInstance().getValue("mesh/scale_tiny_meshes") == True:
                 scale_factor_width = max_bounds.width / bounding_box.width
                 scale_factor_height = max_bounds.height / bounding_box.height
                 scale_factor_depth = max_bounds.depth / bounding_box.depth
                 scale_factor = min(scale_factor_width,scale_factor_height,scale_factor_depth)
+                if Preferences.getInstance().getValue("mesh/scale_to_fit") == True and (scale_factor_width < 1 or scale_factor_height < 1 or scale_factor_depth < 1):
+                    # Use scale factor to scale large object down
+                    pass
+                elif Preferences.getInstance().getValue("mesh/scale_tiny_meshes") == True and (scale_factor_width > 100 and scale_factor_height > 100 and scale_factor_depth > 100):
+                    # Round scale factor to lower factor of 10 to scale tiny object up (eg convert m to mm units)
+                    scale_factor = math.pow(10, math.floor(math.log(scale_factor)/math.log(10)))
+                else:
+                    scale_factor = 1
 
-                scale_vector = Vector(scale_factor, scale_factor, scale_factor)
-                display_scale_factor = scale_factor * 100
+                if scale_factor != 1:
+                    scale_vector = Vector(scale_factor, scale_factor, scale_factor)
+                    display_scale_factor = scale_factor * 100
 
-                if Preferences.getInstance().getValue("mesh/scale_to_fit") == True:
                     scale_message = Message(i18n_catalog.i18nc("@info:status", "Auto scaled object to {0}% of original size", ("%i" % display_scale_factor)))
 
                     try:
@@ -97,7 +107,6 @@ class ReadMeshJob(Job):
                         scale_message.show()
                     except Exception as e:
                         print(e)
-
         self.setResult(node)
 
         loading_message.hide()


### PR DESCRIPTION
When objects have been modeled with meters as units, they become so tiny that the cannot be selected in Cura to be scaled up.

See https://github.com/Ultimaker/Cura/issues/697#issuecomment-209518061

Also see https://github.com/Ultimaker/Cura/pull/733