### PR TITLE
[master] Adding a field of the build type to the spashscreen.

### DIFF
--- a/UM/Application.py
+++ b/UM/Application.py
@@ -29,7 +29,7 @@ class Application(SignalEmitter):
     #
     #   \param name \type{string} The name of the application.
     #   \param version \type{string} Version, formatted as major.minor.rev
-    def __init__(self, name, version, **kwargs):
+    def __init__(self, name, version, buildtype = "", **kwargs):
         if Application._instance != None:
             raise ValueError("Duplicate singleton creation")
 
@@ -39,6 +39,7 @@ class Application(SignalEmitter):
 
         self._application_name = name
         self._version = version
+        self._buildtype = buildtype
 
         os.putenv("UBUNTU_MENUPROXY", "0")  # For Ubuntu Unity this makes Qt use its own menu bar rather than pass it on to Unity.
 
@@ -119,6 +120,11 @@ class Application(SignalEmitter):
     #   \returns version \type{string}
     def getVersion(self):
         return self._version
+
+    ##  Get the buildtype of the application
+    #   \returns version \type{string}
+    def getBuildType(self):
+        return self._buildtype
 
     ##  Add a message to the visible message list so it will be displayed.
     #   This should only be called by message object itself.


### PR DESCRIPTION
For example, if the community distributes Cura in a different way, they
can set CURA_BUILDTYPE via 'cmake -DCURA_BUILDTYPE=' and whenever Cura
is launched " (PPA)" will be appended. Of course, this could be done by
appending " (PPA)" to CURA_VERSION, but in case of my Ubuntu/Debian
packaging it will only need one modification in debian/changelog to
change the version. During build (debian/rules) this version will be
read from debian/changelog.
Changing the version number across different files, is a waste of time.

Finally, we can use that field in the future to indicate debug or other
other special builds.

* Needed by: https://github.com/Ultimaker/Cura/pull/764