### PR TITLE
[master] Tests: Switch to default language

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,7 +15,7 @@ add_custom_command(TARGET check POST_BUILD COMMAND "PYTHONPATH=${CMAKE_SOURCE_DI
 # Tests
 # Note that we use exit 0 here to not mark the build as a failure on test failure
 add_custom_target(tests)
-add_custom_command(TARGET tests POST_BUILD COMMAND "LANG=C PYTHONPATH=${CMAKE_SOURCE_DIR}" ${PYTHON_EXECUTABLE} -m pytest -r a --junitxml=${CMAKE_BINARY_DIR}/junit.xml ${CMAKE_SOURCE_DIR} || exit 0)
+add_custom_command(TARGET tests POST_BUILD COMMAND "LANG=C" "PYTHONPATH=${CMAKE_SOURCE_DIR}" ${PYTHON_EXECUTABLE} -m pytest -r a --junitxml=${CMAKE_BINARY_DIR}/junit.xml ${CMAKE_SOURCE_DIR} || exit 0)
 
 # # Benchmarks
 # add_custom_target(benchmark)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,7 +15,7 @@ add_custom_command(TARGET check POST_BUILD COMMAND "PYTHONPATH=${CMAKE_SOURCE_DI
 # Tests
 # Note that we use exit 0 here to not mark the build as a failure on test failure
 add_custom_target(tests)
-add_custom_command(TARGET tests POST_BUILD COMMAND "PYTHONPATH=${CMAKE_SOURCE_DIR}" ${PYTHON_EXECUTABLE} -m pytest -r a --junitxml=${CMAKE_BINARY_DIR}/junit.xml ${CMAKE_SOURCE_DIR} || exit 0)
+add_custom_command(TARGET tests POST_BUILD COMMAND "LANG=C PYTHONPATH=${CMAKE_SOURCE_DIR}" ${PYTHON_EXECUTABLE} -m pytest -r a --junitxml=${CMAKE_BINARY_DIR}/junit.xml ${CMAKE_SOURCE_DIR} || exit 0)
 
 # # Benchmarks
 # add_custom_target(benchmark)


### PR DESCRIPTION
This is needed here to pass the test suite. When it compares strings it compares untranslated with translated and therefore fails.

```
thopiekar@home:~/Projekte/eclipse-Ultimaker/Uranium/build$ make tests
========================================================= test session starts =========================================================
platform linux -- Python 3.5.1+, pytest-2.8.7, py-1.4.31, pluggy-0.3.1
rootdir: /home/thopiekar/Projekte/eclipse-Ultimaker/Uranium, inifile: pytest.ini
collected 247 items 

../tests/TestDecorators.py .
../tests/TestSignals.py ..
../tests/Jobs/TestJobQueue.py .......
../tests/Math/TestAxisAlignedBox.py .....
../tests/Math/TestMatrix.py ..........
../tests/Math/TestPlane.py ..
../tests/Math/TestPolygon.py ................
../tests/Math/TestQuaternion.py .........
../tests/Math/TestVector.py .....
../tests/MimeTypes/TestMimeTypes.py F....F..
../tests/PluginRegistry/TestPluginRegistry.py ......
../tests/SaveFile/TestSaveFile.py ..
../tests/Scene/TestSceneNode.py .........
../tests/Settings/TestContainerRegistry.py .......................
../tests/Settings/TestContainerStack.py .......................
../tests/Settings/TestDefinitionContainer.py ........................
../tests/Settings/TestInstanceContainer.py ........
../tests/Settings/TestRoundtripping.py ............
../tests/Settings/TestSettingDefinition.py ......
../tests/Settings/TestSettingFunction.py .............................
../tests/Settings/TestSettingInstance.py .......
../tests/Settings/TestSettingRelation.py .
../tests/Settings/TestValidator.py ................................

----------------------- generated xml file: /home/thopiekar/Projekte/eclipse-Ultimaker/Uranium/build/junit.xml ------------------------
======================================================= short test summary info =======================================================
FAIL ../tests/MimeTypes/TestMimeTypes.py::test_system_mimetypes
FAIL ../tests/MimeTypes/TestMimeTypes.py::test_getMimeType
============================================================== FAILURES ===============================================================
________________________________________________________ test_system_mimetypes ________________________________________________________

mime_database = <class 'UM.MimeTypeDatabase.MimeTypeDatabase'>

    def test_system_mimetypes(mime_database):
        mime = mime_database.getMimeTypeForFile(os.path.abspath(__file__))
        assert mime.name == "text/x-python"
>       assert mime.comment == "Python script"
E       assert 'Python-Skript' == 'Python script'
E         - Python-Skript
E         ?       ^^^
E         + Python script
E         ?       ^^^

../tests/MimeTypes/TestMimeTypes.py:45: AssertionError
__________________________________________________________ test_getMimeType ___________________________________________________________

mime_database = <class 'UM.MimeTypeDatabase.MimeTypeDatabase'>

    def test_getMimeType(mime_database):
        mime = mime_database.getMimeType("application/x-test") # Easy case.
        assert mime.comment == "Test Mimetype"
    
        mime = mime_database.getMimeType("image/jpeg")
        assert mime.comment == "Custom JPEG MIME Type" # We must get the custom one, not Qt's MIME type.
    
        mime = mime_database.getMimeType("image/png")
>       assert mime.comment == "PNG image" # Qt's MIME type (at least on my system).
E       assert 'PNG-Bild' == 'PNG image'
E         - PNG-Bild
E         + PNG image

../tests/MimeTypes/TestMimeTypes.py:142: AssertionError
================================================ 2 failed, 245 passed in 7.72 seconds =================================================
Built target tests
thopiekar@home:~/Projekte/eclipse-Ultimaker/Uranium/build$ LANG=C make tests
========================================================= test session starts =========================================================
platform linux -- Python 3.5.1+, pytest-2.8.7, py-1.4.31, pluggy-0.3.1
rootdir: /home/thopiekar/Projekte/eclipse-Ultimaker/Uranium, inifile: pytest.ini
collected 247 items 

../tests/TestDecorators.py .
../tests/TestSignals.py ..
../tests/Jobs/TestJobQueue.py .......
../tests/Math/TestAxisAlignedBox.py .....
../tests/Math/TestMatrix.py ..........
../tests/Math/TestPlane.py ..
../tests/Math/TestPolygon.py ................
../tests/Math/TestQuaternion.py .........
../tests/Math/TestVector.py .....
../tests/MimeTypes/TestMimeTypes.py ........
../tests/PluginRegistry/TestPluginRegistry.py ......
../tests/SaveFile/TestSaveFile.py ..
../tests/Scene/TestSceneNode.py .........
../tests/Settings/TestContainerRegistry.py .......................
../tests/Settings/TestContainerStack.py .......................
../tests/Settings/TestDefinitionContainer.py ........................
../tests/Settings/TestInstanceContainer.py ........
../tests/Settings/TestRoundtripping.py ............
../tests/Settings/TestSettingDefinition.py ......
../tests/Settings/TestSettingFunction.py .............................
../tests/Settings/TestSettingInstance.py .......
../tests/Settings/TestSettingRelation.py .
../tests/Settings/TestValidator.py ................................

----------------------- generated xml file: /home/thopiekar/Projekte/eclipse-Ultimaker/Uranium/build/junit.xml ------------------------
===================================================== 247 passed in 7.18 seconds ======================================================
Built target tests
```