### PR TITLE
Improvements to ContainerRegistry::load

### DIFF
--- a/UM/Resources.py
+++ b/UM/Resources.py
@@ -36,6 +36,8 @@ class Resources:
     InstanceContainers = 9
     ## Location of container stack files. Equal to $resources/stacks
     ContainerStacks = 10
+    ## Location of cached data
+    Cache = 11
 
     ## Any custom resource types should be greater than this to prevent collisions with standard types.
     UserType = 128
@@ -147,6 +149,8 @@ class Resources:
         # Special casing for Linux, since configuration should be stored in ~/.config but data should be stored in ~/.local/share
         if resource_type == cls.Preferences:
             path = cls.__config_storage_path
+        elif resource_type == cls.Cache:
+            path = cls.__cache_storage_path
         else:
             path = os.path.join(cls.__data_storage_path, cls.__types_storage[resource_type])
 
@@ -249,20 +253,32 @@ class Resources:
                 xdg_data_home = os.environ["XDG_DATA_HOME"]
             except KeyError:
                 xdg_data_home = os.path.expanduser("~/.local/share")
-
             cls.__data_storage_path = os.path.join(xdg_data_home, cls.ApplicationIdentifier)
+
+            xdg_cache_home = ""
+            try:
+                xdg_cache_home = os.environ["XDG_CACHE_HOME"]
+            except KeyError:
+                xdg_cache_home = os.path.expanduser("~/.cache")
+            cls.__cache_storage_path = os.path.join(xdg_cache_home, cls.ApplicationIdentifier)
         else:
             cls.__config_storage_path = "."
 
         if not cls.__data_storage_path:
             cls.__data_storage_path = cls.__config_storage_path
 
+        if not cls.__cache_storage_path:
+            cls.__cache_storage_path = os.path.join(cls.__config_storage_path, "cache")
+
     __config_storage_path = None
     __data_storage_path = None
+    __cache_storage_path = None
+
     __paths = []
     __types = {
         Resources: "",
         Preferences: "",
+        Cache: "",
         Meshes: "meshes",
         Shaders: "shaders",
         i18n: "i18n",
@@ -275,6 +291,7 @@ class Resources:
     __types_storage = {
         Resources: "",
         Preferences: "",
+        Cache: "",
         InstanceContainers: "instances",
         ContainerStacks: "stacks",
     }

--- a/UM/Settings/ContainerRegistry.py
+++ b/UM/Settings/ContainerRegistry.py
@@ -48,6 +48,8 @@ class ContainerRegistry:
 
         self._containers = [ self._emptyInstanceContainer ]
 
+        self._id_container_cache = {}
+
         self._resource_types = [Resources.DefinitionContainers]
 
     containerAdded = Signal()
@@ -94,6 +96,13 @@ class ContainerRegistry:
     #   list if nothing was found.
     def findContainers(self, container_type = None, **kwargs):
         containers = []
+
+        if len(kwargs) == 1 and "id" in kwargs:
+            # If we are just searching for a single container by ID, look it up from the container cache
+            container = self._id_container_cache.get(kwargs.get("id"))
+            if container:
+                return [ container ]
+
         for container in self._containers:
             if container_type and not isinstance(container, container_type):
                 continue
@@ -164,7 +173,8 @@ class ContainerRegistry:
     ##  Load all available definition containers, instance containers and
     #   container stacks.
     #
-    #   If this function is called again, it will clear the old data and reload.
+    #   \note This method does not clear the internal list of containers. This means that any containers
+    #   that were already added when the first call to this method happened will not be re-added.
     def load(self):
         files = []
         for resource_type in self._resource_types:
@@ -203,23 +213,25 @@ class ContainerRegistry:
         files = sorted(files, key = lambda i: i[0])
 
         for _, container_id, file_path, read_only, container_type in files:
+            if container_id in self._id_container_cache:
+                continue
+
             try:
                 if issubclass(container_type, DefinitionContainer.DefinitionContainer):
                     definition = self._loadCachedDefinition(container_id, file_path)
                     if definition:
-                        self._containers.append(definition)
+                        self.addContainer(definition)
                         continue
 
                 new_container = container_type(container_id)
                 with open(file_path, encoding = "utf-8") as f:
                     new_container.deserialize(f.read())
                 new_container.setReadOnly(read_only)
-                self._containers.append(new_container)
-                self.containerAdded.emit(new_container)
 
                 if issubclass(container_type, DefinitionContainer.DefinitionContainer):
                     self._saveCachedDefinition(new_container)
 
+                self.addContainer(new_container)
             except Exception as e:
                 Logger.logException("e", "Could not deserialize container %s", container_id)
 
@@ -230,6 +242,7 @@ class ContainerRegistry:
             return
 
         self._containers.append(container)
+        self._id_container_cache[container.getId()] = container
         self.containerAdded.emit(container)
 
     def removeContainer(self, container_id):
@@ -238,6 +251,7 @@ class ContainerRegistry:
             container = containers[0]
 
             self._containers.remove(container)
+            del self._id_container_cache[container.id]
             self._deleteFiles(container)
             self.containerRemoved.emit(container)
 

--- a/UM/Settings/ContainerRegistry.py
+++ b/UM/Settings/ContainerRegistry.py
@@ -370,6 +370,8 @@ class ContainerRegistry:
                     return None
 
             return definition
+        except FileNotFoundError:
+            return None
         except Exception as e:
             # We could not load a cached version for some reason. Ignore it.
             Logger.logException("d", "Could not load cached definition for %s", path)

--- a/UM/Settings/ContainerRegistry.py
+++ b/UM/Settings/ContainerRegistry.py
@@ -3,8 +3,8 @@
 
 import os
 import re #For finding containers with asterisks in the constraints.
-import urllib
-import pickle
+import urllib #For ensuring container file names are proper file names
+import pickle #For serializing/deserializing Python classes to binary files
 
 from UM.PluginRegistry import PluginRegistry
 from UM.Resources import Resources, UnsupportedStorageTypeError

--- a/UM/Settings/DefinitionContainer.py
+++ b/UM/Settings/DefinitionContainer.py
@@ -40,6 +40,7 @@ class DefinitionContainer(ContainerInterface.ContainerInterface, PluginObject):
         self._name = container_id
         self._metadata = {}
         self._definitions = []
+        self._inherited_files = []
         self._i18n_catalog = i18n_catalog
 
         self._definition_cache = {}
@@ -85,6 +86,9 @@ class DefinitionContainer(ContainerInterface.ContainerInterface, PluginObject):
     @property
     def definitions(self):
         return self._definitions
+
+    def getInheritedFiles(self):
+        return self._inherited_files
 
     ##  Gets all keys of settings in this container.
     #
@@ -211,6 +215,8 @@ class DefinitionContainer(ContainerInterface.ContainerInterface, PluginObject):
         contents = {}
         with open(path, encoding = "utf-8") as f:
             contents = json.load(f, object_pairs_hook=collections.OrderedDict)
+
+        self._inherited_files.append(path)
         return contents
 
     # Recursively resolve loading inherited files


### PR DESCRIPTION
This contains two major changes:

* Sort the list of files to load by the container type. This ensures we load DefinitionContainers before InstanceContainers and InstanceContainers before ContainerStacks.

* Use pickle to cache a binary version of the DefinitionContainer that is much faster to load. This reduces startup time on my machine from ~5 seconds to ~3 seconds.