### PR TITLE
New SettingDefinitionsModel

### DIFF
--- a/UM/Settings/Models/SettingPreferenceVisibilityHandler.py
+++ b/UM/Settings/Models/SettingPreferenceVisibilityHandler.py
@@ -1,34 +1,28 @@
 from PyQt5.QtCore import QObject, pyqtProperty, pyqtSignal
 from UM.Preferences import Preferences
 
+from . import SettingVisibilityHandler
 
-class SettingPreferenceVisibilityHandler(QObject):
+class SettingPreferenceVisibilityHandler(SettingVisibilityHandler.SettingVisibilityHandler):
     def __init__(self, parent = None, *args, **kwargs):
         super().__init__(parent = parent, *args, **kwargs)
-        self._visible = set()
-        self._visibility_string = ""
 
         Preferences.getInstance().preferenceChanged.connect(self._onPreferencesChanged)
         self._onPreferencesChanged("general/visible_settings")
 
-    visibilityChanged = pyqtSignal()
+        self.visibilityChanged.connect(self._onVisibilityChanged)
 
     def _onPreferencesChanged(self, name):
         if name != "general/visible_settings":
             return
+
         new_visible = set()
-        self._visibility_string = Preferences.getInstance().getValue("general/visible_settings")
-        for key in self._visibility_string.split(";"):
+        visibility_string = Preferences.getInstance().getValue("general/visible_settings")
+        for key in visibility_string.split(";"):
             new_visible.add(key.strip())
 
-        self._visible = new_visible
-        self.visibilityChanged.emit()
+        self.setVisible(new_visible)
 
-    def setVisible(self, visible):
-        self._visible = visible
-        preference = ";".join(self._visible)
+    def _onVisibilityChanged(self):
+        preference = ";".join(self.getVisible())
         Preferences.getInstance().setValue("general/visible_settings", preference)
-
-    def getVisible(self):
-        return self._visible
-

--- a/UM/Settings/Models/SettingVisibilityHandler.py
+++ b/UM/Settings/Models/SettingVisibilityHandler.py
@@ -1,0 +1,21 @@
+# Copyright (c) 2016 Ultimaker B.V.
+# Uranium is released under the terms of the AGPLv3 or higher.
+
+from PyQt5.QtCore import QObject, pyqtSignal
+
+class SettingVisibilityHandler(QObject):
+    def __init__(self, parent = None, *args, **kwargs):
+        super().__init__(parent = parent, *args, **kwargs)
+
+        self._visible = set()
+
+    visibilityChanged = pyqtSignal()
+
+    def setVisible(self, visible):
+        if visible != self._visible:
+            self._visible = visible
+            self.visibilityChanged.emit()
+
+    def getVisible(self):
+        return self._visible.copy()
+


### PR DESCRIPTION
This is a reimplementation of SettingDefinitionsModel that is both simpler and faster. It is designed to never trigger a complete model reset apart from containerId or root property changes. In addition, it fixes a number of bugs currently present in the model:

* Children-of-children are visible even if their parents are not
* Empty categories are hidden
* Filtering removes rows instead of hiding the data
* Allow setting the expanded settings so we can re-enable saving and loading of expanded categories.
* Row changes are done through insertRows/removeRows which prevents a complete model reset and only changes things that actually changed.

Additionally this paves the way for creating an "EnabledVisibilityHandler" that modifies visibility based on the enabled property.