### PR TITLE
Logger: fixes for logException

### DIFF
--- a/UM/Logger.py
+++ b/UM/Logger.py
@@ -38,22 +38,25 @@ class Logger:
                 filename = filename.replace(path, "...")
                 continue
         address = "%s (%s [%s]): " %(filename, function.co_name, function.co_firstlineno)
+        
+        if args: # Only format the message if there are args
+            message = message % args # Replace all the %s with the variables. Python formatting is magic.
+        
         for logger in cls.__loggers:
-            filled_message = address + message % args # Replace all the %s with the variables. Python formatting is magic.
+            filled_message = address + message
             logger.log(log_type, filled_message)
 
         if not cls.__loggers:
-            print(message % args)
+            print(message)
 
     ##
     @classmethod
     def logException(cls, log_type, message, *args):
-        filled_message = message % args
-        cls.log(log_type, "Exception: %s" % filled_message)
+        cls.log(log_type, message, *args)
         # The function traceback.format_exception gives a list of strings, but those are not properly split on newlines.
         # traceback.format_exc only gives back a single string, but we can properly split that. It does add an extra newline at the end, so strip that.
         for line in traceback.format_exc().rstrip().split("\n"):
-            cls.log(log_type, "%s", line)
+            cls.log(log_type, line)
 
     __loggers = []
 

--- a/UM/Logger.py
+++ b/UM/Logger.py
@@ -52,7 +52,7 @@ class Logger:
     ##
     @classmethod
     def logException(cls, log_type, message, *args):
-        cls.log(log_type, message, *args)
+        cls.log(log_type, "Exception: " + message, *args)
         # The function traceback.format_exception gives a list of strings, but those are not properly split on newlines.
         # traceback.format_exc only gives back a single string, but we can properly split that. It does add an extra newline at the end, so strip that.
         for line in traceback.format_exc().rstrip().split("\n"):


### PR DESCRIPTION
* Don't format lines from traceback
* Directly pass args to self.log()
* Format message only once
* Only format messages when args are passed

Contributes to CURA-1445 and CURA-1771