### PR TITLE
CURA-1445: Adding getDurationInISOFormat

### DIFF
--- a/UM/Qt/Duration.py
+++ b/UM/Qt/Duration.py
@@ -100,4 +100,8 @@ class Duration(QObject):
                 return i18n_catalog.i18nc("@label Minutes only duration format, {0} is minutes", "{0} minutes", self._minutes)
 
         return ""
+    
+    def getDurationInISOFormat(self):
+        total_hours = self.hours() + self.days() * 24
+        return "%02d:%02d:%02d" % (total_hours, self.minutes(), self.seconds())
 


### PR DESCRIPTION
Currently we are not passing the print duration in ISO format.

This will make it possible to get it directly from our print_information variable in SliceInfo plugin.