### PR TITLE
Convenience functions to convert a UM.Math.Color to/from a hex-string

### DIFF
--- a/UM/Math/Color.py
+++ b/UM/Math/Color.py
@@ -67,3 +67,25 @@ class Color:
             (value & 0x000000ff) >> 0,
             (value & 0xff000000) >> 24
         )
+
+    ##  Returns a new Color constructed from a 7-character string "#RRGGBB" format.
+    #
+    #   \param value A 7-character string representing a color in "#RRGGBB" format.
+    #   \return A Color constructed from the components of value.
+    @staticmethod
+    def fromRGBString(value):
+        return Color(
+            int(value[1:3], 16) / 255,
+            int(value[3:5], 16) / 255,
+            int(value[5:7], 16) / 255,
+            1.0
+        )
+
+    ##  Returns a 7-character string in "#RRGGBB" format representing the color.
+    #
+    #   \return A 7-character string representing a color in "#RRGGBB" format.
+    def toRGBString(self):
+        value = ((int(self._r * 255) & 255) << 16) + \
+                ((int(self._g * 255) & 255) << 8) + \
+                (int(self._b * 255) & 255)
+        return "#%s" % hex(value)[2:]

--- a/UM/Math/Color.py
+++ b/UM/Math/Color.py
@@ -68,24 +68,35 @@ class Color:
             (value & 0xff000000) >> 24
         )
 
-    ##  Returns a new Color constructed from a 7-character string "#RRGGBB" format.
+    ##  Returns a new Color constructed from a 7- or 9-character string "#RRGGBB" or "#AARRGGBB" format.
     #
-    #   \param value A 7-character string representing a color in "#RRGGBB" format.
+    #   \param value A 7- or 9-character string representing a color in "#RRGGBB" or "#AARRGGBB" format.
     #   \return A Color constructed from the components of value.
     @staticmethod
-    def fromRGBString(value):
-        return Color(
-            int(value[1:3], 16) / 255,
-            int(value[3:5], 16) / 255,
-            int(value[5:7], 16) / 255,
-            1.0
-        )
+    def fromHexString(value):
+        if len(value) == 9:
+            return Color(
+                int(value[3:5], 16) / 255,
+                int(value[5:7], 16) / 255,
+                int(value[7:9], 16) / 255,
+                int(value[1:3], 16) / 255
+            )
+        else:
+            return Color(
+                int(value[1:3], 16) / 255,
+                int(value[3:5], 16) / 255,
+                int(value[5:7], 16) / 255,
+                1.0
+            )
 
     ##  Returns a 7-character string in "#RRGGBB" format representing the color.
     #
-    #   \return A 7-character string representing a color in "#RRGGBB" format.
-    def toRGBString(self):
+    #   \param include_alpha Whether to return a 7-character "#RRGGBB" or a 9 character "#AARRGGBB" format.
+    #   \return A 7- or 9-character string representing a color in "#AARRGGBB" format.
+    def toHexString(self, include_alpha = False):
         value = ((int(self._r * 255) & 255) << 16) + \
                 ((int(self._g * 255) & 255) << 8) + \
                 (int(self._b * 255) & 255)
+        if include_alpha:
+            value += (int(self._a * 255) & 255) << 24
         return "#%s" % hex(value)[2:]


### PR DESCRIPTION
RGB-colors are commonly represented as "web-friendly" #RRGGBB strings (eg #ffffff for white). This PR adds convenience functions to the UM.Math.Color class to convert to/from this format. Usefull in cases where colors are specified in configurations.