### PR TITLE
Massively speedup ContainerRegistry.findContainers()

### DIFF
--- a/UM/Settings/ContainerRegistry.py
+++ b/UM/Settings/ContainerRegistry.py
@@ -114,7 +114,8 @@ class ContainerRegistry:
                                 continue
                             except AttributeError:  # Only instanceContainers have a get definition. We can ignore all others.
                                 pass
-                        elif not value_pattern.match(str(container.getMetaDataEntry(key))):
+
+                        if not value_pattern.match(str(container.getMetaDataEntry(key))):
                             matches_container = False
                     elif not ignore_case:
                         if key == "id":
@@ -132,7 +133,8 @@ class ContainerRegistry:
                                 continue
                             except AttributeError:  # Only instanceContainers have a get definition. We can ignore all others.
                                 pass
-                        elif value != str(container.getMetaDataEntry(key)):
+
+                        if value != str(container.getMetaDataEntry(key)):
                             matches_container = False
                     else:
                         if key == "id":
@@ -150,7 +152,8 @@ class ContainerRegistry:
                                 continue
                             except AttributeError:  # Only instanceContainers have a get definition. We can ignore all others.
                                 pass
-                        elif value.lower() != str(container.getMetaDataEntry(key)).lower():
+
+                        if value.lower() != str(container.getMetaDataEntry(key)).lower():
                             matches_container = False
                 except TypeError: #Value was not a string.
                     if key == "id" or key == "name" or key == "definition":
@@ -163,7 +166,8 @@ class ContainerRegistry:
                             continue
                         except AttributeError:
                             pass
-                    elif value != container.getMetaDataEntry(key):
+
+                    if value != container.getMetaDataEntry(key):
                         matches_container = False
                     continue
 

--- a/UM/Settings/ContainerRegistry.py
+++ b/UM/Settings/ContainerRegistry.py
@@ -91,53 +91,79 @@ class ContainerRegistry:
             matches_container = True
             for key, value in kwargs.items():
                 try:
-                    value = re.escape(value) #Escape for regex patterns.
-                    value = "^" + value.replace("\\*", ".*") + "$" #Instead of (now escaped) asterisks, match on any string. Also add anchors for a complete match.
-                    if ignore_case:
-                        value_pattern = re.compile(value, re.IGNORECASE)
+                    if "*" in value:
+                        value = re.escape(value) #Escape for regex patterns.
+                        value = "^" + value.replace("\\*", ".*") + "$" #Instead of (now escaped) asterisks, match on any string. Also add anchors for a complete match.
+                        if ignore_case:
+                            value_pattern = re.compile(value, re.IGNORECASE)
+                        else:
+                            value_pattern = re.compile(value)
+
+                        if key == "id":
+                            if not value_pattern.match(container.getId()):
+                                matches_container = False
+                            continue
+                        elif key == "name":
+                            if not value_pattern.match(container.getName()):
+                                matches_container = False
+                            continue
+                        elif key == "definition":
+                            try:
+                                if not value_pattern.match(container.getDefinition().getId()):
+                                    matches_container = False
+                                continue
+                            except AttributeError:  # Only instanceContainers have a get definition. We can ignore all others.
+                                pass
+                        elif not value_pattern.match(str(container.getMetaDataEntry(key))):
+                            matches_container = False
+                    elif not ignore_case:
+                        if key == "id":
+                            if value != container.getId():
+                                matches_container = False
+                            continue
+                        elif key == "name":
+                            if value != container.getName():
+                                matches_container = False
+                            continue
+                        elif key == "definition":
+                            try:
+                                if value != container.getDefinition().getId():
+                                    matches_container = False
+                                continue
+                            except AttributeError:  # Only instanceContainers have a get definition. We can ignore all others.
+                                pass
+                        elif value != str(container.getMetaDataEntry(key)):
+                            matches_container = False
                     else:
-                        value_pattern = re.compile(value)
-                    if key == "id":
-                        if not value_pattern.match(container.getId()):
-                            matches_container = False
-                        continue
-                    if key == "name":
-                        if not value_pattern.match(container.getName()):
-                            matches_container = False
-                        continue
-                    if key == "definition":
-                        try:
-                            if not value_pattern.match(container.getDefinition().getId()):
+                        if key == "id":
+                            if value.lower() != container.getId().lower():
                                 matches_container = False
                             continue
-                        except AttributeError:  # Only instanceContainers have a get definition. We can ignore all others.
-                            pass
-                    if not value_pattern.match(str(container.getMetaDataEntry(key))):
-                        matches_container = False
+                        elif key == "name":
+                            if value.lower() != container.getName().lower():
+                                matches_container = False
+                            continue
+                        elif key == "definition":
+                            try:
+                                if value.lower() != container.getDefinition().getId().lower():
+                                    matches_container = False
+                                continue
+                            except AttributeError:  # Only instanceContainers have a get definition. We can ignore all others.
+                                pass
+                        elif value.lower() != str(container.getMetaDataEntry(key)).lower():
+                            matches_container = False
                 except TypeError: #Value was not a string.
-                    if key == "id":
-                        if value != container.getId():
-                            matches_container = False
+                    if key == "id" or key == "name" or key == "definition":
+                        matches_container = False
                         continue
-                    if key == "name":
-                        if container.getName() != value:
-                            matches_container = False
-                        continue
-                    if key == "definition":
-                        try:
-                            if value != container.getDefinition().getId():
-                                matches_container = False
-                            continue
-                        except AttributeError:
-                            pass
-                    if key == "read_only":
+                    elif key == "read_only":
                         try:
                             if value != container.isReadOnly():
                                 matches_container = False
                             continue
                         except AttributeError:
                             pass
-                    if value != container.getMetaDataEntry(key):
+                    elif value != container.getMetaDataEntry(key):
                         matches_container = False
                     continue
 

--- a/UM/Util.py
+++ b/UM/Util.py
@@ -6,4 +6,4 @@
 #   \param \type{bool|str|int} any value.
 #   \return \type{bool}
 def parseBool(value):
-    return value in [True, "True", "true", 1]
+    return value in [True, "True", "true", "Yes", "yes", 1]


### PR DESCRIPTION
Only use regular expressions when we need to. Most of the time simple string comparison is all that is needed.

This cuts the loading time of Cura by ~35% for me (from 43 to 34 seconds on my machine). Specifically, and in combination with the optimisation in https://github.com/Ultimaker/Cura/commit/30a679ddf9019aad721e8b1deccd7e453a216683 this has cut deserialisation of the XMLMaterialProfiles from 24 seconds to 4 seconds.

I am putting this in a PR because I am not 100% sure it does not break things; it needs testing, and I am curious to know if it speeds things up on other systems as dramatically as it does on mine.

CURA-2187