### PR TITLE
Add ListModel.setItems

### DIFF
--- a/UM/Qt/Bindings/DirectoryListModel.py
+++ b/UM/Qt/Bindings/DirectoryListModel.py
@@ -36,12 +36,13 @@ class DirectoryListModel(ListModel):
                     path = path[7:]
             self._directory = os.path.dirname(path)
 
-            self.clear()
+            items = []
             extensions = Application.getInstance().getMeshFileHandler().getSupportedFileTypesRead()
             for entry in os.listdir(self._directory):
                 if os.path.splitext(entry)[1] in extensions:
-                    self.appendItem({ "name": os.path.basename(entry), "url": QUrl.fromLocalFile(os.path.join(self._directory, entry)) })
+                    items.append({ "name": os.path.basename(entry), "url": QUrl.fromLocalFile(os.path.join(self._directory, entry)) })
 
-        self.sort(lambda e: e["name"])
+        items.sort(key = lambda e: e["name"])
+        self.setItems(items)
 
     directory = pyqtProperty(str, fget = getDirectory, fset = setDirectory, notify = directoryChanged)

--- a/UM/Qt/Bindings/MeshListModel.py
+++ b/UM/Qt/Bindings/MeshListModel.py
@@ -105,7 +105,7 @@ class MeshListModel(ListModel):
                 #self.insertItem(new_index,data)
 
     def updateList(self, trigger_node):
-        self.clear()
+        items = []
         for root_child in self._scene.getRoot().getChildren():
             if root_child.callDecoration("isGroup"): # Check if its a group node
                 parent_key = id(root_child)
@@ -122,7 +122,7 @@ class MeshListModel(ListModel):
                             "is_group":bool(node.callDecoration("isGroup")),
                             "is_dummy" : False
                             }
-                    self.appendItem(data)
+                    items.append(data)
                 data = { "name":"Dummy",
                          "visibility": True,
                          "key": 0,
@@ -132,7 +132,7 @@ class MeshListModel(ListModel):
                          "is_group":False,
                          "is_dummy" : True
                         }
-                self.appendItem(data)
+                items.append(data)
 
             elif type(root_child) is SceneNode or type(root_child) is PointCloudNode: # Item is not a group node.
                 data = {"name":root_child.getName(),
@@ -151,7 +151,9 @@ class MeshListModel(ListModel):
                     self.removeItem(index)
                     self.insertItem(index,data)
                 else:
-                    self.appendItem(data)
+                    items.append(data)
+
+        self.setItems(items)
 
     # set the visibility of a node (by key)
     @pyqtSlot("long",bool)

--- a/UM/Qt/Bindings/PluginsModel.py
+++ b/UM/Qt/Bindings/PluginsModel.py
@@ -32,7 +32,7 @@ class PluginsModel(ListModel):
         self._update()
 
     def _update(self):
-        self.clear() 
+        items = [] 
         active_plugins = self._plugin_registery.getActivePlugins()
         for plugin in self._plugin_registery.getAllMetaData():
             if "plugin" not in plugin:
@@ -40,7 +40,7 @@ class PluginsModel(ListModel):
                 continue
 
             aboutData = plugin["plugin"]
-            self.appendItem({
+            items.append({
                 "id": plugin["id"],
                 "required": plugin["id"] in self._required_plugins,
                 "enabled": plugin["id"] in active_plugins,
@@ -50,7 +50,8 @@ class PluginsModel(ListModel):
                 "author": aboutData.get("author", "John Doe"),
                 "version": aboutData.get("version", "Unknown")
             })
-        self.sort(lambda k: k["name"])
+        items.sort(key = lambda k: k["name"])
+        self.setItems(items)
 
     @pyqtSlot(str,bool)
     def setEnabled(self, name, enabled):

--- a/UM/Qt/Bindings/ToolModel.py
+++ b/UM/Qt/Bindings/ToolModel.py
@@ -33,7 +33,7 @@ class ToolModel(ListModel):
         self.addRoleName(self.DescriptionRole, "description")
 
     def _onToolsChanged(self):
-        self.clear()
+        items = []
 
         tools = self._controller.getAllTools()
         for name in tools:
@@ -50,7 +50,7 @@ class ToolModel(ListModel):
 
             enabled = self._controller.getTool(name).getEnabled()
 
-            self.appendItem({
+            items.append({
                 "id": name,
                 "name": toolMetaData.get("name", name),
                 "icon": iconName,
@@ -60,7 +60,8 @@ class ToolModel(ListModel):
                 "weight": weight
             })
 
-        self.sort(lambda t: t["weight"])
+        items.sort(key = lambda t: t["weight"])
+        self.setItems(items)
 
     def _onActiveToolChanged(self):
         activeTool = self._controller.getActiveTool()

--- a/UM/Qt/Bindings/ViewModel.py
+++ b/UM/Qt/Bindings/ViewModel.py
@@ -28,7 +28,7 @@ class ViewModel(ListModel):
         self.addRoleName(self.IconRole, "icon")
 
     def _onViewsChanged(self):
-        self.clear()
+        items = []
         views = self._controller.getAllViews()
 
         for id in views:
@@ -45,6 +45,7 @@ class ViewModel(ListModel):
             weight = viewMetaData.get("weight", 0)
 
             currentView = self._controller.getActiveView()
-            self.appendItem({ "id": id, "name": name, "active": id == currentView.getPluginId(), "description": description, "icon": iconName, "weight": weight })
+            items.append({ "id": id, "name": name, "active": id == currentView.getPluginId(), "description": description, "icon": iconName, "weight": weight })
 
-        self.sort(lambda t: t["weight"])
+        items.sort(key = lambda t: t["weight"])
+        self.setItems(items)

--- a/UM/Qt/ListModel.py
+++ b/UM/Qt/ListModel.py
@@ -52,6 +52,12 @@ class ListModel(QAbstractListModel):
     def items(self):
         return self._items
 
+    ##  Clear the list.
+    def setItems(self, items):
+        self.beginResetModel()
+        self._items = items
+        self.endResetModel()
+
     ##  Add an item to the list.
     @pyqtSlot(dict)
     def appendItem(self, item):

--- a/UM/Qt/ListModel.py
+++ b/UM/Qt/ListModel.py
@@ -52,13 +52,15 @@ class ListModel(QAbstractListModel):
     def items(self):
         return self._items
 
-    ##  Clear the list.
+    ##  Replace all items at once.
+    #   \param items The new list of items.
     def setItems(self, items):
         self.beginResetModel()
         self._items = items
         self.endResetModel()
 
     ##  Add an item to the list.
+    #   \param item The item to add.
     @pyqtSlot(dict)
     def appendItem(self, item):
         self.insertItem(len(self._items), item)

--- a/UM/Settings/Models/ContainerStacksModel.py
+++ b/UM/Settings/Models/ContainerStacksModel.py
@@ -37,7 +37,7 @@ class ContainerStacksModel(ListModel):
 
     ##  Private convenience function to reset & repopulate the model.
     def _update(self):
-        self.clear()
+        items = []
 
         # Remove all connections
         for container in self._container_stacks:
@@ -52,9 +52,10 @@ class ContainerStacksModel(ListModel):
                 metadata["definition_name"] = container.getBottom().getName()
 
             container.nameChanged.connect(self._onContainerNameChanged)
-            self.appendItem({"name": container.getName(),
+            items.append({"name": container.getName(),
                              "id": container.getId(),
                              "metadata": metadata})
+        self.setItems(items)
 
     ##  Set the filter of this model based on a string.
     #   \param filter_dict Dictionary to do the filtering by.

--- a/UM/Settings/Models/DefinitionContainersModel.py
+++ b/UM/Settings/Models/DefinitionContainersModel.py
@@ -39,19 +39,20 @@ class DefinitionContainersModel(ListModel):
 
     ##  Private convenience function to reset & repopulate the model.
     def _update(self):
-        self.clear()
+        items = []
         self._definition_containers = ContainerRegistry.getInstance().findDefinitionContainers(**self._filter_dict)
         self._definition_containers.sort(key = self._sortKey)
 
         for container in self._definition_containers:
             metadata = container.getMetaData().copy()
 
-            self.appendItem({
+            items.append({
                 "name": container.getName(),
                 "id": container.getId(),
                 "metadata": metadata,
                 "section": container.getMetaDataEntry(self._section_property, ""),
             })
+        self.setItems(items)
 
     def setSectionProperty(self, property_name):
         if self._section_property != property_name:

--- a/UM/Settings/Models/InstanceContainersModel.py
+++ b/UM/Settings/Models/InstanceContainersModel.py
@@ -53,7 +53,7 @@ class InstanceContainersModel(ListModel):
             container.nameChanged.disconnect(self._update)
             container.metaDataChanged.disconnect(self._updateMetaData)
 
-        self.clear()
+        items = []
         self._instance_containers = ContainerRegistry.getInstance().findInstanceContainers(**self._filter_dict)
         self._instance_containers.sort(key = self._sortKey)
 
@@ -64,14 +64,15 @@ class InstanceContainersModel(ListModel):
             metadata = container.getMetaData().copy()
             metadata["has_settings"] = len(container.getAllKeys()) > 0
 
-            self.appendItem({
+            items.append({
                 "name": container.getName(),
                 "id": container.getId(),
                 "metadata": metadata,
                 "readOnly": container.isReadOnly(),
                 "section": container.getMetaDataEntry(self._section_property, ""),
             })
-        self.sort(lambda k: (k["section"], k["id"]))
+        items.sort(key = lambda k: (k["section"], k["id"]))
+        self.setItems(items)
 
 
     def setSectionProperty(self, property_name):


### PR DESCRIPTION
setItems sets the items to a (presorted) list of items instead of adding items one by one and then sorting the list. This way if an update to the model causes a signal storm at least it happens only once for an update.

Fixes CURA-1838, contributes to CURA-2193