### PR TITLE
Improve Performance of SettingPropertyProvider and property changes

### DIFF
--- a/UM/Settings/ContainerStack.py
+++ b/UM/Settings/ContainerStack.py
@@ -503,7 +503,7 @@ class ContainerStack(ContainerInterface.ContainerInterface, PluginObject):
         self._property_changes[key].add(property_name)
 
         if not self._emit_property_changed_queued:
-            Signal._app.callLater(self._emitCollectedPropertyChanges)
+            UM.Settings.ContainerRegistry.getApplication().callLater(self._emitCollectedPropertyChanges)
             self._emit_property_changed_queued = True
 
     # Perform the emission of the change signals that were collected in a previous step.

--- a/UM/Settings/Models/SettingPropertyProvider.py
+++ b/UM/Settings/Models/SettingPropertyProvider.py
@@ -136,25 +136,6 @@ class SettingPropertyProvider(QObject):
             return -1
         return self._stack_levels
 
-    def _updateStackLevels(self):
-        levels = []
-        # Start looking at the stack this provider is attached to.
-        current_stack = self._stack
-        index = 0
-        while current_stack:
-            for container in current_stack.getContainers():
-                try:
-                    if container.getProperty(self._key, "value") is not None:
-                        levels.append(index)
-                except AttributeError:
-                    pass
-                index += 1
-            # If there is a next stack, check that one as well.
-            current_stack = current_stack.getNextStack()
-        if levels != self._stack_levels:
-            self._stack_levels = levels
-            self.stackLevelChanged.emit()
-
     ##  Set the value of a property.
     #
     #   \param stack_index At which level in the stack should this property be set?
@@ -313,6 +294,25 @@ class SettingPropertyProvider(QObject):
         # Force update of value_used
         self._value_used = None
         self.isValueUsedChanged.emit()
+
+    def _updateStackLevels(self):
+        levels = []
+        # Start looking at the stack this provider is attached to.
+        current_stack = self._stack
+        index = 0
+        while current_stack:
+            for container in current_stack.getContainers():
+                try:
+                    if container.getProperty(self._key, "value") is not None:
+                        levels.append(index)
+                except AttributeError:
+                    pass
+                index += 1
+            # If there is a next stack, check that one as well.
+            current_stack = current_stack.getNextStack()
+        if levels != self._stack_levels:
+            self._stack_levels = levels
+            self.stackLevelChanged.emit()
 
     def _getPropertyValue(self, property_name):
         property_value = self._stack.getProperty(self._key, property_name)

--- a/UM/Settings/Models/SettingPropertyProvider.py
+++ b/UM/Settings/Models/SettingPropertyProvider.py
@@ -177,7 +177,7 @@ class SettingPropertyProvider(QObject):
         if self._property_map.value(property_name) == property_value and self._remove_unused_value:
             return
 
-        container.setProperty(self._key, property_name, property_value, self._stack)
+        container.setProperty(self._key, property_name, property_value)
 
     ##  Manually request the value of a property.
     #   The most notable difference with the properties is that you have more control over at what point in the stack

--- a/UM/Settings/Models/SettingPropertyProvider.py
+++ b/UM/Settings/Models/SettingPropertyProvider.py
@@ -41,7 +41,7 @@ class SettingPropertyProvider(QObject):
         self._stack_id = stack_id
 
         if self._stack:
-            self._stack.propertyChanged.disconnect(self._onPropertyChanged)
+            self._stack.propertiesChanged.disconnect(self._onPropertiesChanged)
             self._stack.containersChanged.disconnect(self._update)
 
         if self._stack_id:
@@ -53,7 +53,7 @@ class SettingPropertyProvider(QObject):
                     self._stack = stacks[0]
 
             if self._stack:
-                self._stack.propertyChanged.connect(self._onPropertyChanged)
+                self._stack.propertiesChanged.connect(self._onPropertiesChanged)
                 self._stack.containersChanged.connect(self._update)
         else:
             self._stack = None
@@ -261,23 +261,23 @@ class SettingPropertyProvider(QObject):
 
     # protected:
 
-    def _onPropertyChanged(self, key, property_name):
+    def _onPropertiesChanged(self, key, property_names):
         if key != self._key:
             if key in self._relations:
                 self._value_used = None
                 self.isValueUsedChanged.emit()
-
             return
 
-        if property_name not in self._watched_properties:
-            return
+        for property_name in property_names:
+            if property_name not in self._watched_properties:
+                continue
 
-        self._property_map.insert(property_name, self._getPropertyValue(property_name))
-        self._updateStackLevels()
+            self._property_map.insert(property_name, self._getPropertyValue(property_name))
 
     def _update(self, container = None):
         if not self._stack or not self._watched_properties or not self._key:
             return
+
         self._updateStackLevels()
         relations = self._stack.getProperty(self._key, "relations")
         if relations:  # If the setting doesn't have the property relations, None is returned

--- a/UM/Settings/Models/SettingPropertyProvider.py
+++ b/UM/Settings/Models/SettingPropertyProvider.py
@@ -274,6 +274,8 @@ class SettingPropertyProvider(QObject):
 
             self._property_map.insert(property_name, self._getPropertyValue(property_name))
 
+        self._updateStackLevels()
+
     def _update(self, container = None):
         if not self._stack or not self._watched_properties or not self._key:
             return


### PR DESCRIPTION
This contains two changes: Replacing the dict in SettingPropertyProvider with QQmlPropertyMap, which is a dict-like object that allows QML bindings on individual keys in the dictionary so we do not constantly need to update the entire dict when a single property changes.

The other change is to collect all property change signals that should be handled by ContainerStack and emit them together. This reduces the amount of duplicate signals emitted by ContainerStack and allows us to emit a single signal that references all properties that have changed.

These changes combined reduce the time needed to handle toggling "Enable Support" from 140ms down to 40ms, according to the QML profiler.
