### PR TITLE
CMake: Using add_test for registering tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 project(uranium NONE)
 
-cmake_minimum_required(VERSION 2.8.12)
+cmake_minimum_required(VERSION 3.2.0)
 
 message(STATUS ${CMAKE_MODULE_PATH})
 
@@ -20,8 +20,8 @@ add_custom_command(TARGET check POST_BUILD COMMAND "PYTHONPATH=${CMAKE_SOURCE_DI
 
 # Tests
 # Note that we use exit 0 here to not mark the build as a failure on test failure
-add_custom_target(tests)
-add_custom_command(TARGET tests POST_BUILD COMMAND "LANG=C" "PYTHONPATH=${CMAKE_SOURCE_DIR}" ${PYTHON_EXECUTABLE} -m pytest -r a --junitxml=${CMAKE_BINARY_DIR}/junit.xml ${CMAKE_SOURCE_DIR} || exit 0)
+add_test(NAME pytest COMMAND "LANG=C" "PYTHONPATH=${CMAKE_SOURCE_DIR}" ${PYTHON_EXECUTABLE} -m pytest -r a --junitxml=${CMAKE_BINARY_DIR}/junit.xml ${CMAKE_SOURCE_DIR} || exit 0)
+enable_testing()
 
 # # Benchmarks
 # add_custom_target(benchmark)


### PR DESCRIPTION
On JIRA it was discussed to use an alias instead of renaming our target called "tests" to "test".
When trying to define a target called "test", CMake warns about calling a custom target like this. I read in CMake docs how they expect to have test registered and found add_test for that.
CMake then provides a target called "test", but adding a custom target called "tests" and make it depend on "test" doesn't work for a reason. The error message says that "test" is not defined (even if I have the statement called after "enable_testing()"!).
Finally I kept it like that as we are already using "test" in CuraEngine.

Contributes to CURA-1697
Replaces PR #170
