### PR TITLE
Resources: Ignore dot directories inside resources

### DIFF
--- a/UM/Resources.py
+++ b/UM/Resources.py
@@ -83,7 +83,10 @@ class Resources:
             if not os.path.isdir(directory):
                 continue
 
-            for root, dirname, entries in os.walk(directory, followlinks = True):
+            for root, dirnames, entries in os.walk(directory, followlinks = True):
+                root = os.path.realpath(root)
+                if os.sep + "." in root:
+                    continue
                 for entry in entries:
                     if not entry.startswith('.') and os.path.isfile(os.path.join(root, entry)):
                         if not entry in files:


### PR DESCRIPTION
While embedding fdm_materials inside I had problems because UM.Resources
tried in another function to guess the MIME type of .git/index. So I
decided to make UM.Resources ignore all "dot directories", which are
hidden on Linux, but visible on Windows.

I added a print(root) between line 88 and 89 to be sure only the .git
directory is ignored here and this is the result:

```
C:\Users\thopi\Documents\GitHub\Cura\resources\materials\.git
C:\Users\thopi\Documents\GitHub\Cura\resources\materials\.git\hooks
C:\Users\thopi\Documents\GitHub\Cura\resources\materials\.git\info
C:\Users\thopi\Documents\GitHub\Cura\resources\materials\.git\logs
C:\Users\thopi\Documents\GitHub\Cura\resources\materials\.git\logs\refs
C:\Users\thopi\Documents\GitHub\Cura\resources\materials\.git\logs\refs\heads
C:\Users\thopi\Documents\GitHub\Cura\resources\materials\.git\logs\refs\remotes
C:\Users\thopi\Documents\GitHub\Cura\resources\materials\.git\logs\refs\remotes\origin
C:\Users\thopi\Documents\GitHub\Cura\resources\materials\.git\objects
C:\Users\thopi\Documents\GitHub\Cura\resources\materials\.git\objects\info
C:\Users\thopi\Documents\GitHub\Cura\resources\materials\.git\objects\pack
C:\Users\thopi\Documents\GitHub\Cura\resources\materials\.git\refs
C:\Users\thopi\Documents\GitHub\Cura\resources\materials\.git\refs\heads
C:\Users\thopi\Documents\GitHub\Cura\resources\materials\.git\refs\remotes
C:\Users\thopi\Documents\GitHub\Cura\resources\materials\.git\refs\remotes\origin
C:\Users\thopi\Documents\GitHub\Cura\resources\materials\.git\refs\tags
```
