### PR TITLE
MeshFileHandler: Care about type of "mesh_handler"

### DIFF
--- a/UM/Mesh/MeshFileHandler.py
+++ b/UM/Mesh/MeshFileHandler.py
@@ -119,11 +119,15 @@ class MeshFileHandler(object):
         meta_data = PluginRegistry.getInstance().getAllMetaData(filter = {"mesh_reader": {}}, active_only = True)
         for entry in meta_data:
             if "mesh_reader" in entry:
-                for input_type in entry["mesh_reader"]:
-                    ext = input_type.get("extension", None)
-                    if ext:
-                        description = input_type.get("description", ext)
-                        supported_types[ext] = description
+                if type(entry["mesh_reader"]) is list:
+                    for input_type in entry["mesh_reader"]:
+                        ext = input_type.get("extension", None)
+                        if ext:
+                            description = input_type.get("description", ext)
+                            supported_types[ext] = description
+                else:
+                    Logger.log("w", "Unexpected info has been provided with the keyname 'mesh_reader'. Ignoring..")
+                    continue
 
         return supported_types
 

--- a/UM/Mesh/MeshFileHandler.py
+++ b/UM/Mesh/MeshFileHandler.py
@@ -119,7 +119,7 @@ class MeshFileHandler(object):
         meta_data = PluginRegistry.getInstance().getAllMetaData(filter = {"mesh_reader": {}}, active_only = True)
         for entry in meta_data:
             if "mesh_reader" in entry:
-                if type(entry["mesh_reader"]) is list:
+                if "__iter__" in dir(entry["mesh_reader"]): # Check whether we have an object here which is an iterable
                     for input_type in entry["mesh_reader"]:
                         ext = input_type.get("extension", None)
                         if ext:


### PR DESCRIPTION
Misunderstood the syntax how to declare multiple data formats in my
plugin's `__init__.py`.
However this is what I've left at the end, which could be helpful if
someone mixes up a list with a dictionary, for example.
