### PR TITLE
Add "All Supported Types" option to profile import dialog

### DIFF
--- a/UM/Settings/Models/InstanceContainersModel.py
+++ b/UM/Settings/Models/InstanceContainersModel.py
@@ -4,7 +4,7 @@ from UM.Qt.ListModel import ListModel
 
 from PyQt5.QtCore import pyqtProperty, Qt, pyqtSignal, pyqtSlot, QUrl
 
-from UM.PluginRegistry import PluginRegistry #For getting the possible profile readers/writers.
+from UM.PluginRegistry import PluginRegistry #For getting the possible profile readers and writers.
 from UM.Settings.ContainerRegistry import ContainerRegistry
 from UM.Settings.InstanceContainer import InstanceContainer
 
@@ -135,7 +135,9 @@ class InstanceContainersModel(ListModel):
                 self._update()
 
     ##  Gets a list of the possible file filters that the plugins have
-    #   registered they can write.
+    #   registered they can read or write. The convenience meta-filters
+    #   "All Supported Types" and "All Files" are added when listing
+    #   readers, but not when listing writers.
     #
     #   \param io_type \type{str} name of the needed IO type
     #   \return A list of strings indicating file name filters for a file
@@ -162,7 +164,7 @@ class InstanceContainersModel(ListModel):
     def getDefaultPath(self):
         return QUrl.fromLocalFile(os.path.expanduser("~/"))
 
-    ##  Gets a list of profile reader/writer plugins
+    ##  Gets a list of profile reader or writer plugins
     #   \return List of tuples of (plugin_id, meta_data).
     def _getIOPlugins(self, io_type):
         pr = PluginRegistry.getInstance()

--- a/UM/Settings/Models/InstanceContainersModel.py
+++ b/UM/Settings/Models/InstanceContainersModel.py
@@ -4,7 +4,7 @@ from UM.Qt.ListModel import ListModel
 
 from PyQt5.QtCore import pyqtProperty, Qt, pyqtSignal, pyqtSlot, QUrl
 
-from UM.PluginRegistry import PluginRegistry #For getting the possible profile writers to write with.
+from UM.PluginRegistry import PluginRegistry #For getting the possible profile readers/writers.
 from UM.Settings.ContainerRegistry import ContainerRegistry
 from UM.Settings.InstanceContainer import InstanceContainer
 
@@ -145,21 +145,24 @@ class InstanceContainersModel(ListModel):
         filters = []
         all_types = []
         for plugin_id, meta_data in self._getIOPlugins(io_type):
-            for writer in meta_data[io_type]:
-                filters.append(writer["description"] + " (*." + writer["extension"] + ")")
-                all_types.append("*.{0}".format(writer["extension"]))
+            for io_plugin in meta_data[io_type]:
+                filters.append(io_plugin["description"] + " (*." + io_plugin["extension"] + ")")
+                all_types.append("*.{0}".format(io_plugin["extension"]))
 
-        filters.insert(0, catalog.i18nc("@item:inlistbox", "All Supported Types ({0})", " ".join(all_types)))
+        if "_reader" in io_type:
+            # if we're listing readers, add the option to show all supported files as the default option
+            filters.insert(0,
+                catalog.i18nc("@item:inlistbox", "All Supported Types ({0})", " ".join(all_types)))
 
-        filters.append(
-            catalog.i18nc("@item:inlistbox", "All Files (*)"))  # Also allow arbitrary files, if the user so prefers.
+            filters.append(
+                catalog.i18nc("@item:inlistbox", "All Files (*)"))  # Also allow arbitrary files, if the user so prefers.
         return filters
 
     @pyqtSlot(result=QUrl)
     def getDefaultPath(self):
         return QUrl.fromLocalFile(os.path.expanduser("~/"))
 
-    ##  Gets a list of profile writer plugins
+    ##  Gets a list of profile reader/writer plugins
     #   \return List of tuples of (plugin_id, meta_data).
     def _getIOPlugins(self, io_type):
         pr = PluginRegistry.getInstance()

--- a/UM/Settings/Models/InstanceContainersModel.py
+++ b/UM/Settings/Models/InstanceContainersModel.py
@@ -143,9 +143,13 @@ class InstanceContainersModel(ListModel):
     @pyqtSlot(str, result="QVariantList")
     def getFileNameFilters(self, io_type):
         filters = []
+        all_types = []
         for plugin_id, meta_data in self._getIOPlugins(io_type):
             for writer in meta_data[io_type]:
                 filters.append(writer["description"] + " (*." + writer["extension"] + ")")
+                all_types.append("*.{0}".format(writer["extension"]))
+
+        filters.insert(0, catalog.i18nc("@item:inlistbox", "All Supported Types ({0})", " ".join(all_types)))
 
         filters.append(
             catalog.i18nc("@item:inlistbox", "All Files (*)"))  # Also allow arbitrary files, if the user so prefers.


### PR DESCRIPTION
This PR adds a "All Supported Types" filter to the import profile dialog as the default option. This way the functionality to import gcode and legacy profiles are no longer hidden from the user; as it is now the user must manually switch filetypes to even see gcode or legacy profiles. Especially on OSX this is quite hidden.