### PR TITLE
Fix readonly state of profiles on Windows

### DIFF
--- a/UM/Resources.py
+++ b/UM/Resources.py
@@ -264,7 +264,7 @@ class Resources:
     @classmethod
     def __initializeStoragePaths(cls):
         if platform.system() == "Windows":
-            cls.__config_storage_path = os.path.join(os.path.expanduser("~/AppData/Local/"), cls.ApplicationIdentifier)
+            cls.__config_storage_path = os.path.join(os.path.expanduser("~\\AppData\\Local\\"), cls.ApplicationIdentifier)
         elif platform.system() == "Darwin":
             cls.__config_storage_path = os.path.join(os.path.expanduser("~/Library/Application Support"), cls.ApplicationIdentifier)
             # For backward compatibility, support loading files from the old storage location


### PR DESCRIPTION
Change config storage path to use back-slashes on Windows

Python magically fixes mixed slashes and backslashes in paths on Windows. However the storage path gets compared to the full path of files when loading configs to determine readonly state, and this comparison fails if the config storage path uses forward-slashes. The result is that all config files are treated as readonly, including quality_changes and user profiles. This is only really visible in the Profiles preference pane; after restarting Cura all profiles are shown as protected profiles.

Note that this only seems to be necessary in master; I have not yet found out when the readonly state broke in master compared to 2.3.