### PR TITLE
CURA-1764: Appending environment variables with set_tests_properties

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,16 +12,21 @@ include(GNUInstallDirs)
 
 find_package(PythonInterp 3.4.0 REQUIRED)
 
-# Checks using pylint
+# # Checks using pylint
 # Note that we use exit 0 here to not mark the build as a failure on check failure
 # In addition, the specified pylint configuration uses the spellchecker plugin. This required python-enchant to be installed.
 add_custom_target(check)
 add_custom_command(TARGET check POST_BUILD COMMAND "PYTHONPATH=${CMAKE_SOURCE_DIR}" ${PYTHON_EXECUTABLE} -m pylint --rcfile=${CMAKE_SOURCE_DIR}/pylint.cfg UM --msg-template=\"{path}:{line}: [{msg_id}({symbol}), {obj}] {msg}\" > ${CMAKE_BINARY_DIR}/pylint.log || exit 0 WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})
 
-# Tests
-# Note that we use exit 0 here to not mark the build as a failure on test failure
-add_test(NAME pytest COMMAND "LANG=C" "PYTHONPATH=${CMAKE_SOURCE_DIR}" ${PYTHON_EXECUTABLE} -m pytest -r a --junitxml=${CMAKE_BINARY_DIR}/junit.xml ${CMAKE_SOURCE_DIR} || exit 0)
+# # Tests
 enable_testing()
+add_test(NAME pytest COMMAND ${PYTHON_EXECUTABLE} -m pytest -r a --junitxml=${CMAKE_BINARY_DIR}/junit.xml ${CMAKE_SOURCE_DIR})
+# Using untranslated strings on Linux
+if(UNIX AND NOT APPLE) 
+    set_tests_properties(pytest PROPERTIES ENVIRONMENT LANG=de_DE.UTF-8)
+endif()
+# Adding PYTHONPATH on every OS
+set_tests_properties(pytest PROPERTIES ENVIRONMENT PYTHONPATH=${CMAKE_SOURCE_DIR})
 
 # # Benchmarks
 # add_custom_target(benchmark)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 project(uranium NONE)
 
-cmake_minimum_required(VERSION 2.8.12)
+cmake_minimum_required(VERSION 3.2.0)
 
 message(STATUS ${CMAKE_MODULE_PATH})
 
@@ -20,8 +20,8 @@ add_custom_command(TARGET check POST_BUILD COMMAND "PYTHONPATH=${CMAKE_SOURCE_DI
 
 # Tests
 # Note that we use exit 0 here to not mark the build as a failure on test failure
-add_custom_target(tests)
-add_custom_command(TARGET tests POST_BUILD COMMAND "LANG=C" "PYTHONPATH=${CMAKE_SOURCE_DIR}" ${PYTHON_EXECUTABLE} -m pytest -r a --junitxml=${CMAKE_BINARY_DIR}/junit.xml ${CMAKE_SOURCE_DIR} || exit 0)
+add_test(NAME pytest COMMAND "LANG=C" "PYTHONPATH=${CMAKE_SOURCE_DIR}" ${PYTHON_EXECUTABLE} -m pytest -r a --junitxml=${CMAKE_BINARY_DIR}/junit.xml ${CMAKE_SOURCE_DIR} || exit 0)
+enable_testing()
 
 # # Benchmarks
 # add_custom_target(benchmark)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 project(uranium NONE)
 
-cmake_minimum_required(VERSION 3.2.0)
+cmake_minimum_required(VERSION 2.8.12)
 
 message(STATUS ${CMAKE_MODULE_PATH})
 
@@ -23,10 +23,14 @@ enable_testing()
 add_test(NAME pytest COMMAND ${PYTHON_EXECUTABLE} -m pytest -r a --junitxml=${CMAKE_BINARY_DIR}/junit.xml ${CMAKE_SOURCE_DIR})
 # Using untranslated strings on Linux
 if(UNIX AND NOT APPLE) 
-    set_tests_properties(pytest PROPERTIES ENVIRONMENT LANG=de_DE.UTF-8)
+    set_tests_properties(pytest PROPERTIES ENVIRONMENT LANG=C)
 endif()
 # Adding PYTHONPATH on every OS
 set_tests_properties(pytest PROPERTIES ENVIRONMENT PYTHONPATH=${CMAKE_SOURCE_DIR})
+# Adding compatibility with our old tests target
+add_custom_target(tests
+                  COMMAND ${CMAKE_COMMAND} --build ${CMAKE_BINARY_DIR} --target test
+                  COMMENT "Notice: tests target is deprecated, please use the test target")
 
 # # Benchmarks
 # add_custom_target(benchmark)


### PR DESCRIPTION
As discussed on JIRA the best way to add our environment variables is to pass them via "set_tests_properties". Of course, this depends on #171, which begins to use the set of commands provided by CMake to declare tests.

However, there seems to be a problem in the test suite, therefore it isn't working  completely now.

Fixes: #171 
(Includes: #171 )
Contributes to CURA-1697
Contributes to CURA-1764