### PR TITLE
Allow adding a container at a specified index in the stack

### DIFF
--- a/UM/Settings/ContainerStack.py
+++ b/UM/Settings/ContainerStack.py
@@ -401,7 +401,6 @@ class ContainerStack(ContainerInterface.ContainerInterface, PluginObject):
     def insertContainer(self, index, container):
         if container is self:
             raise Exception("Unable to add stack to itself.")
-            return
 
         container.propertyChanged.connect(self._collectPropertyChanges)
         self._containers.insert(index, container)

--- a/UM/Settings/ContainerStack.py
+++ b/UM/Settings/ContainerStack.py
@@ -390,14 +390,22 @@ class ContainerStack(ContainerInterface.ContainerInterface, PluginObject):
     ##  Add a container to the top of the stack.
     #
     #   \param container The container to add to the stack.
-    #   \param index \type{int} The index of to insert the container at; defaults to the top
-    def addContainer(self, container, index = 0):
-        if container is not self:
-            container.propertyChanged.connect(self._collectPropertyChanges)
-            self._containers.insert(index, container)
-            self.containersChanged.emit(container)
-        else:
+    def addContainer(self, container):
+        self.insertContainer(0, container)
+
+    ##  Insert a container into the stack.
+    #
+    #   \param index \type{int} The index of to insert the container at.
+    #          A negative index counts from the bottom
+    #   \param container The container to add to the stack.
+    def insertContainer(self, index, container):
+        if container is self:
             raise Exception("Unable to add stack to itself.")
+            return
+
+        container.propertyChanged.connect(self._collectPropertyChanges)
+        self._containers.insert(index, container)
+        self.containersChanged.emit(container)
 
     ##  Replace a container in the stack.
     #

--- a/UM/Settings/ContainerStack.py
+++ b/UM/Settings/ContainerStack.py
@@ -390,10 +390,11 @@ class ContainerStack(ContainerInterface.ContainerInterface, PluginObject):
     ##  Add a container to the top of the stack.
     #
     #   \param container The container to add to the stack.
-    def addContainer(self, container):
+    #   \param index \type{int} The index of to insert the container at; defaults to the top
+    def addContainer(self, container, index = 0):
         if container is not self:
             container.propertyChanged.connect(self._collectPropertyChanges)
-            self._containers.insert(0, container)
+            self._containers.insert(index, container)
             self.containersChanged.emit(container)
         else:
             raise Exception("Unable to add stack to itself.")


### PR DESCRIPTION
This PR adds an optional parameter to ContainerStack.addContainer that makes it possible to add a container at the specified index in an existing stack, instead of always at the top. If the parameter is not specified, the container is added to the top of the stack as before the PR.