### PR TITLE
Add a system-defined monospaced font to the theme

### DIFF
--- a/UM/Qt/Bindings/Theme.py
+++ b/UM/Qt/Bindings/Theme.py
@@ -188,7 +188,8 @@ class Theme(QObject):
 
     def _initializeDefaults(self):
         self._fonts = {
-            "system": QCoreApplication.instance().font()
+            "system": QCoreApplication.instance().font(),
+            "fixed": QFontDatabase.systemFont(QFontDatabase.FixedFont)
         }
 
         palette = QCoreApplication.instance().palette()


### PR DESCRIPTION
A fixed width font is useful for displaying code, eg start/end-gcode in Cura.