### PR TITLE
UM.Application: Remove Unity workaround

### DIFF
--- a/UM/Application.py
+++ b/UM/Application.py
@@ -44,8 +44,6 @@ class Application():
         self._version = version
         self._buildtype = buildtype
 
-        os.putenv("UBUNTU_MENUPROXY", "0")  # For Ubuntu Unity this makes Qt use its own menu bar rather than pass it on to Unity.
-
         Signal._app = self
         Resources.ApplicationIdentifier = name
         i18nCatalog.setApplication(self)


### PR DESCRIPTION
Just found this workaround between regular code.
I would prefer to move the workaround to all the other workarounds at cura_app.py.