### PR TITLE
CURA-1921: Adding command-line option to remove user data

### DIFF
--- a/UM/Qt/QtApplication.py
+++ b/UM/Qt/QtApplication.py
@@ -162,6 +162,7 @@ class QtApplication(QApplication, Application):
         return self._renderer
 
     def addCommandLineOptions(self, parser):
+        super().addCommandLineOptions(parser)
         parser.add_argument("--disable-textures",
                             dest="disable-textures",
                             action="store_true", default=False,


### PR DESCRIPTION
Adds command-line options: "--mrproper" and "--all-users".
"--all-users" can be optionally used for other tasks in the future.
E.g. shutting down all running Cura/Uranium instances.

The prints inside the code are needed since the _mrproper function is
called very early, when UM.Logger is not set up.
I'm personally not very happy about the solution in _mrproper to use
hardcoded pattern, but I guess this is the only way to remove
everything.
Alternatively those patterns can be moved into UM.Resources, but that
needs to be discussed.

Contributes to CURA-1921