### PR TITLE
Change ContainerStack serialization format to handle special characters properly

### DIFF
--- a/UM/Settings/ContainerStack.py
+++ b/UM/Settings/ContainerStack.py
@@ -276,7 +276,7 @@ class ContainerStack(ContainerInterface.ContainerInterface, PluginObject):
                     raise Exception("When trying to deserialize %s, we received an unknown ID (%s) for container" % (self._id, container_id))
 
         elif parser.has_option("general", "containers"):
-            # Backward compatibility: The containers used to be saved in a single comma-separated list.
+            # Backward compatibility with 2.3.1: The containers used to be saved in a single comma-separated list.
             container_string = parser["general"].get("containers", "")
             Logger.log("d", "While deserializing, we got the following container string: %s", container_string)
             container_id_list = container_string.split(",")

--- a/UM/Settings/ContainerStack.py
+++ b/UM/Settings/ContainerStack.py
@@ -222,11 +222,9 @@ class ContainerStack(ContainerInterface.ContainerInterface, PluginObject):
         for key, value in self._metadata.items():
             parser["metadata"][key] = str(value)
 
-        container_id_string = ""
-        for container in self._containers:
-            container_id_string += str(container.getId()) + ","
-
-        parser["general"]["containers"] = container_id_string
+        parser.add_section("containers")
+        for index in range(len(self._containers)):
+            parser["containers"][str(index)] = self._containers[index].getId()
 
         stream = io.StringIO()
         parser.write(stream)
@@ -260,18 +258,28 @@ class ContainerStack(ContainerInterface.ContainerInterface, PluginObject):
         if "metadata" in parser:
             self._metadata = dict(parser["metadata"])
 
-        # The containers are saved in a single comma-separated list.
-        container_string = parser["general"].get("containers", "")
-        Logger.log("d", "While deserializing, we got the following container string: %s", container_string)
-        container_id_list = container_string.split(",")
-        for container_id in container_id_list:
-            if container_id != "":
+        if "containers" in parser:
+            for index, container_id in parser.items("containers"):
                 containers = UM.Settings.ContainerRegistry.getInstance().findContainers(id = container_id)
                 if containers:
                     containers[0].propertyChanged.connect(self._collectPropertyChanges)
                     self._containers.append(containers[0])
                 else:
                     raise Exception("When trying to deserialize %s, we received an unknown ID (%s) for container" % (self._id, container_id))
+
+        elif parser.has_option("general", "containers"):
+            # Backward compatibility: The containers used to be saved in a single comma-separated list.
+            container_string = parser["general"].get("containers", "")
+            Logger.log("d", "While deserializing, we got the following container string: %s", container_string)
+            container_id_list = container_string.split(",")
+            for container_id in container_id_list:
+                if container_id != "":
+                    containers = UM.Settings.ContainerRegistry.getInstance().findContainers(id = container_id)
+                    if containers:
+                        containers[0].propertyChanged.connect(self._collectPropertyChanges)
+                        self._containers.append(containers[0])
+                    else:
+                        raise Exception("When trying to deserialize %s, we received an unknown ID (%s) for container" % (self._id, container_id))
 
         ## TODO; Deserialize the containers.
 

--- a/tests/Settings/TestContainerStack.py
+++ b/tests/Settings/TestContainerStack.py
@@ -161,11 +161,16 @@ def test_deserialize_syntax_error(container_stack):
 def test_deserialize_wrong_version(container_stack, container_registry):
     container_registry.addContainer(UM.Settings.InstanceContainer("a")) # Make sure this container isn't the one it complains about.
 
-    serialised = """[general]
-name = Test
-id = testid
-containers = a
-version = -1""" # -1 should always be wrong.
+    serialised = """
+    [general]
+    name = Test
+    id = testid
+    version = -1
+
+    [containers]
+    0 = a
+    """ # -1 should always be wrong.
+
     with pytest.raises(IncorrectVersionError):
         container_stack.deserialize(serialised)
 
@@ -178,35 +183,57 @@ version = -1""" # -1 should always be wrong.
 def test_deserialize_missing_items(container_stack, container_registry):
     container_registry.addContainer(UM.Settings.InstanceContainer("a")) # Make sure this container isn't the one it complains about.
 
-    serialised_no_name = """[general]
-id = testid
-containers = a
-version = """ + str(UM.Settings.ContainerStack.Version)
+    serialised_no_name = """
+    [general]
+    id = testid
+    version = {version}
+
+    [containers]
+    0 = a
+    """.format(version = UM.Settings.ContainerStack.Version)
+
     with pytest.raises(InvalidContainerStackError):
         container_stack.deserialize(serialised_no_name)
 
-    serialised_no_id = """[general]
-name = Test
-containers = a
-version = """ + str(UM.Settings.ContainerStack.Version)
+    serialised_no_id = """
+    [general]
+    name = Test
+    version = {version}
+
+    [containers]
+    0 = a
+    """.format(version = UM.Settings.ContainerStack.Version)
+
     with pytest.raises(InvalidContainerStackError):
         container_stack.deserialize(serialised_no_id)
 
-    serialised_no_version = """[general]
-name = Test
-id = testid
-containers = a"""
+    serialised_no_version = """
+    [general]
+    name = Test
+    id = testid
+
+    [containers]
+    0 = a
+    """
+
     with pytest.raises(InvalidContainerStackError):
         container_stack.deserialize(serialised_no_version)
 
-    serialised_no_containers = """[general]
-name = Test
-id = testid
-version = """ + str(UM.Settings.ContainerStack.Version)
-    container_stack.deserialize(serialised_no_containers) # Missing containers is allowed.
+    serialised_no_containers = """
+    [general]
+    name = Test
+    id = testid
+    version = {version}
+    """.format(version = UM.Settings.ContainerStack.Version)
 
-    serialised_no_general = """[metadata]
-foo = bar"""
+    container_stack.deserialize(serialised_no_containers) # Missing containers is allowed.
+    assert container_stack.getContainers() == [] # Deserialize of an empty stack should result in an empty stack
+
+    serialised_no_general = """
+    [metadata]
+    foo = bar
+    """
+
     with pytest.raises(InvalidContainerStackError):
         container_stack.deserialize(serialised_no_general)
 
@@ -220,38 +247,59 @@ def test_deserialize_containers(container_stack, container_registry):
     container = UM.Settings.InstanceContainer("a")
     container_registry.addContainer(container)
 
-    serialised = """[general]
-name = Test
-id = testid
-containers = a
-version = """ + str(UM.Settings.ContainerStack.Version) # Test case where there is a container.
+    serialised = """
+    [general]
+    name = Test
+    id = testid
+    version = {version}
+
+    [containers]
+    0 = a
+    """.format(version = UM.Settings.ContainerStack.Version) # Test case where there is a container.
+
     container_stack.deserialize(serialised)
     assert container_stack.getContainers() == [container]
 
     container_stack = UM.Settings.ContainerStack(uuid.uuid4().int)
-    serialised = """[general]
-name = Test
-id = testid
-containers =
-version = """ + str(UM.Settings.ContainerStack.Version) # Test case where there is no container.
+    serialised = """
+    [general]
+    name = Test
+    id = testid
+    version = {version}
+
+    [containers]
+    """.format(version = UM.Settings.ContainerStack.Version) # Test case where there is no container.
+
     container_stack.deserialize(serialised)
     assert container_stack.getContainers() == []
 
     container_stack = UM.Settings.ContainerStack(uuid.uuid4().int)
-    serialised = """[general]
-name = Test
-id = testid
-containers = a,a
-version = """ + str(UM.Settings.ContainerStack.Version) # Test case where there are two of the same containers.
+    serialised = """
+    [general]
+    name = Test
+    id = testid
+    version = {version}
+
+    [containers]
+    0 = a
+    1 = a
+    """.format(version = UM.Settings.ContainerStack.Version) # Test case where there are two of the same containers.
+
     container_stack.deserialize(serialised)
     assert container_stack.getContainers() == [container, container]
 
     container_stack = UM.Settings.ContainerStack(uuid.uuid4().int)
-    serialised = """[general]
-name = Test
-id = testid
-containers = a,b
-version = """ + str(UM.Settings.ContainerStack.Version) # Test case where a container doesn't exist.
+    serialised = """
+    [general]
+    name = Test
+    id = testid
+    version = {version}
+
+    [containers]
+    0 = a
+    1 = b
+    """.format(version = UM.Settings.ContainerStack.Version) # Test case where a container doesn't exist.
+
     with pytest.raises(Exception):
         container_stack.deserialize(serialised)
 

--- a/tests/Settings/TestContainerStack.py
+++ b/tests/Settings/TestContainerStack.py
@@ -23,8 +23,8 @@ from UM.Settings.ContainerStack import InvalidContainerStackError
 #   actual implementations, the tests in this suite are unaffected.
 class MockContainer(UM.Settings.ContainerInterface.ContainerInterface):
     ##  Creates a mock container with a new unique ID.
-    def __init__(self):
-        self._id = uuid.uuid4().int
+    def __init__(self, container_id = None):
+        self._id = uuid.uuid4().int if container_id == None else container_id
         self._metadata = {}
         self.items = {}
 

--- a/tests/Settings/TestContainerStack.py
+++ b/tests/Settings/TestContainerStack.py
@@ -645,6 +645,25 @@ def test_setNextStack(container_stack):
     with pytest.raises(Exception):
         container_stack.setNextStack(container_stack) # Can't set itself as next stack.
 
+##  Test backward compatibility of container config file format change
+#
+#   This tests whether ContainerStack can still deserialize containers using the old
+#   format where we would have a single comma separated entry with the containers.
+def test_backwardCompatibility(container_stack, container_registry):
+    container_a = MockContainer("a")
+    container_registry.addContainer(container_a) # Make sure this container isn't the one it complains about.
+
+    serialised = """
+    [general]
+    name = Test
+    id = testid
+    version = {version}
+    containers = a,a,a
+    """.format(version = UM.Settings.ContainerStack.Version) # Old-style serialized stack
+
+    container_stack.deserialize(serialised)
+    assert container_stack.getContainers() == [container_a, container_a, container_a]
+
 ##  Tests a single cycle of serialising and deserialising a container stack.
 #
 #   This will serialise and then deserialise the container stack, and sees if


### PR DESCRIPTION
This changes how the containers stored in a ContainerStack are serialized, from a single entry with a comma-separated list to a single section with index, container_id entries. This simplifies the code and allows ConfigParser to deal with special characters and parsing. A bonus is that the resulting config file is easier to read.

The old format is still supported when deserializing to make sure this is properly backward compatible. In addition, I updated the unit tests and created two additional tests, on for backward compatibility and one for special characters.

Contributes to issue CURA-3098.