### PR TITLE
Revert "Revert "i18n: Remove creation of en translations""

### DIFF
--- a/scripts/extract-messages
+++ b/scripts/extract-messages
@@ -20,11 +20,6 @@ msgconv --to-code=UTF-8 $basedir/resources/i18n/$catalogname.pot -o $basedir/res
 for pot in $basedir/resources/i18n/*.pot; do
     filename=$(basename $pot)
 
-    dir=$basedir/resources/i18n/en
-    mkdir -p $dir
-    po=$dir/${filename/.pot/.po}
-    msginit --no-translator -l en -i $pot -o $po
-
     dir=$basedir/resources/i18n/x-test
     mkdir -p $dir
     po=$dir/${filename/.pot/.po}


### PR DESCRIPTION
Since we have already i18n-*-po-* targets, we can remove it from the script.
I'm just don't know much about about the x-test. So I left it in the script.

Reverted this commit, because we've not discussed about it, but when writing the commit message of the first commit I hit the enter key instead if the tabulator and tada!.. commited.
Sorry for this.

This reverts commit a9f30ee12a2be9fcdf1ae42bff62bad66d3cda30.