### PR TITLE
UpdateChecker: Don't tell user about an exception

### DIFF
--- a/plugins/UpdateChecker/UpdateChecker.py
+++ b/plugins/UpdateChecker/UpdateChecker.py
@@ -84,7 +84,7 @@ class UpdateCheckerJob(Job):
                 Logger.log("w", "Did not find any version information for %s." % application_name)
         except Exception:
             Logger.logException("e", "Exception in update checker while parsing the JSON file.")
-            Message(i18n_catalog.i18nc("@info", "An exception occured while parsing the JSON file.")).show()
+            Message(i18n_catalog.i18nc("@info", "An error occured while parsing the JSON file.")).show()
             no_new_version = False # Just to suppress the message below.
 
         if no_new_version and not self.silent:


### PR DESCRIPTION
.. but about an error. I think when we are talking about exceptions it is clear what we are talking about.
In my point of view it is more than enough to tell the user that there was an error. Don't think he is neither interested in more details nor able to fix the problem on her/his own.