### PR TITLE
Camera control bugs

### DIFF
--- a/plugins/Tools/CameraTool/CameraTool.py
+++ b/plugins/Tools/CameraTool/CameraTool.py
@@ -107,7 +107,7 @@ class CameraTool(Tool):
     def initiateZoom(self, event):
         if event.type is event.MousePressEvent:
             return False
-        elif event.type is Event.MouseMoveEvent and self._ctrl_is_active is False: #space -> mousemove
+        elif event.type is Event.MouseMoveEvent and self._space_is_active is False: #space -> mousemove
             self._start_y = None
         elif event.type is Event.MouseMoveEvent and self._space_is_active is True:  # space -> mousemove
                 if self._start_y is None:

--- a/plugins/Tools/CameraTool/CameraTool.py
+++ b/plugins/Tools/CameraTool/CameraTool.py
@@ -23,7 +23,7 @@ class CameraTool(Tool):
         self._yaw = 0
         self._pitch = 0
         self._origin = Vector(0, 0, 0)
-        self._min_zoom = 0
+        self._min_zoom = 1
         self._max_zoom = 2000.0
         self._manual_zoom = 200
 
@@ -107,6 +107,8 @@ class CameraTool(Tool):
     def initiateZoom(self, event):
         if event.type is event.MousePressEvent:
             return False
+        elif event.type is Event.MouseMoveEvent and self._ctrl_is_active is False: #space -> mousemove
+            self._start_y = None
         elif event.type is Event.MouseMoveEvent and self._space_is_active is True:  # space -> mousemove
                 if self._start_y is None:
                     self._start_y = event.y


### PR DESCRIPTION
1. Zoom in bug.

When you continue zoom in after you don't see visual difference, then you must zoom out same amount after you will see visual zoom out.
In CameraTool.py "self._min_zoom = 0" but mathematically it will move endlessly closer to 0.
"self._min_zoom = 1" is fixing that bug


2. space + mouse zoom jump
Space + mouse zoom "jump"(zoom in or out) sometimes when start new zoom. ( only with "space + mouse" zoom)
Script don't reset sometimes "self._start_y" value before next zoom.
added reset when "space" is not active.
Maybe not best option but it will fix that bug