### PR TITLE
Fix size of dialogs on high-ish DPI screens

### DIFF
--- a/UM/Qt/qml/UM/Dialog.qml
+++ b/UM/Qt/qml/UM/Dialog.qml
@@ -13,8 +13,8 @@ Window {
     modality: Qt.ApplicationModal;
     flags: Qt.Dialog | Qt.CustomizeWindowHint | Qt.WindowTitleHint | Qt.WindowCloseButtonHint;
 
-    width: screenScaleFactor * 640;
-    height: screenScaleFactor * 480;
+    width: Screen.devicePixelRatio * 640;
+    height: Screen.devicePixelRatio * 480;
 
     property int margin: Screen.devicePixelRatio * 8;
     property bool closeOnAccept: true;  // Automatically close the window when the window is "accepted" (eg using the return key)


### PR DESCRIPTION
The calculation of screenScaleFactor (QtApplication.py) is fairly naive and has an arbitrary cutoff. It fails on my new 1080p 13" laptop (which has a ~160 DPI resolution): dialog windows (which don't set their own sizes) become a factor 2 too large.

It also does not take into account future screens that might have a higher screen scale factor (new iPads already have a scale factor of 3, so it is not unlikely that we will get 3x screens in computers).

Screen.devicePixelRatio works everywhere else in Cura and Uranium, so I don't know why this screenScaleFactor was introduced in the first place. Perhaps the analysis of CURA-422 has an answer, but I don't have access to that anymore.