### PR TITLE
Fix build plate color for printers without a build plate texture

### DIFF
--- a/UM/Qt/GL/QtTexture.py
+++ b/UM/Qt/GL/QtTexture.py
@@ -25,6 +25,7 @@ class QtTexture(Texture):
                 self._image = QImage(self._file_name).mirrored()
             elif self._image is None: # No filename or image set.
                 self._image = QImage(1, 1, QImage.Format_ARGB32)
+                self._image.fill(0)
             self._qt_texture.setData(self._image)
             self._qt_texture.setMinMagFilters(QOpenGLTexture.Linear, QOpenGLTexture.Linear)
 


### PR DESCRIPTION
QImage() returns an image with uninitialised data. This could cause the buildplate of machines that don't have a texture (EG UMO) to become a random color.