### PR TITLE
Fix exception when file cannot be upgraded

### DIFF
--- a/UM/VersionUpgradeManager.py
+++ b/UM/VersionUpgradeManager.py
@@ -307,12 +307,14 @@ class VersionUpgradeManager:
             new_files_data = []
             for file_idx, file_data in enumerate(files_data):
                 try:
-                    this_filenames_without_extension, this_files_data = upgrade_step(file_data, filenames_without_extension[file_idx])
+                    upgrade_step_result = upgrade_step(file_data, filenames_without_extension[file_idx])
                 except Exception as e: #Upgrade failed due to a coding error in the plug-in.
                     Logger.logException("w", "Exception in %s upgrade with %s: %s", old_configuration_type,
                                         upgrade_step.__module__, traceback.format_exc() )
                     return False
-                if not this_files_data: #Upgrade failed.
+                if upgrade_step_result:
+                    this_filenames_without_extension, this_files_data = upgrade_step_result
+                else: #Upgrade failed.
                     Logger.log("w", "Unable to upgrade the file %s. Skipping it.", filenames_without_extension[file_idx])
                     return False
                 new_filenames_without_extension += this_filenames_without_extension

--- a/UM/VersionUpgradeManager.py
+++ b/UM/VersionUpgradeManager.py
@@ -315,7 +315,7 @@ class VersionUpgradeManager:
                 if upgrade_step_result:
                     this_filenames_without_extension, this_files_data = upgrade_step_result
                 else: #Upgrade failed.
-                    Logger.log("w", "Unable to upgrade the file %s. Skipping it.", filenames_without_extension[file_idx])
+                    Logger.log("w", "Unable to upgrade the file %s with %s.%s. Skipping it.", filenames_without_extension[file_idx], upgrade_step.__module__, upgrade_step.__name__)
                     return False
                 new_filenames_without_extension += this_filenames_without_extension
                 new_files_data += this_files_data


### PR DESCRIPTION
This PR checks we got a valid result from upgrade_step() before trying to split the result so we get the intended warning instead of a (double printed?) exception.