### PR TITLE
Themeable viewport

### DIFF
--- a/UM/Qt/Bindings/Theme.py
+++ b/UM/Qt/Bindings/Theme.py
@@ -202,6 +202,16 @@ class Theme(QObject):
             "line": QSizeF(self._em_width, self._em_height)
         }
 
-def createTheme(engine, script_engine):
-    return Theme(engine)
+    ##  Get the singleton instance for this class.
+    @classmethod
+    def getInstance(cls, engine = None):
+        # Note: Explicit use of class name to prevent issues with inheritance.
+        if Theme.__instance is None:
+            Theme.__instance = cls(engine)
+        return Theme.__instance
+
+    __instance = None
+
+def createTheme(engine, script_engine = None):
+    return Theme.getInstance(engine)
 

--- a/UM/Qt/QtApplication.py
+++ b/UM/Qt/QtApplication.py
@@ -24,6 +24,8 @@ import UM.Settings.InstanceContainer #For version upgrade to know the version nu
 import UM.Settings.ContainerStack #For version upgrade to know the version number.
 import UM.Preferences #For version upgrade to know the version number.
 
+import UM.Qt.Bindings.Theme
+
 # Raised when we try to use an unsupported version of a dependency.
 class UnsupportedVersionError(Exception):
     pass
@@ -62,6 +64,7 @@ class QtApplication(QApplication, Application):
         self._engine = None
         self._renderer = None
         self._main_window = None
+        self._theme = None
 
         self._shutting_down = False
         self._qml_import_paths = []
@@ -180,6 +183,15 @@ class QtApplication(QApplication, Application):
         if window != self._main_window:
             self._main_window = window
             self.mainWindowChanged.emit()
+
+    def getTheme(self, *args):
+        if self._theme is None:
+            if self._engine is None:
+                Logger.log("e", "The theme cannot be accessed before the engine is initialised")
+                return None
+
+            self._theme = UM.Qt.Bindings.Theme.Theme.getInstance(self._engine)
+        return self._theme
 
     #   Handle a function that should be called later.
     def functionEvent(self, event):

--- a/UM/Scene/ToolHandle.py
+++ b/UM/Scene/ToolHandle.py
@@ -25,14 +25,16 @@ class ToolHandle(SceneNode.SceneNode):
     ZAxis = 4
     AllAxis = 5
 
-    DisabledColor = Color(0.5, 0.5, 0.5, 1.0)
-    XAxisColor = Color(1.0, 0.0, 0.0, 1.0)
-    YAxisColor = Color(0.0, 0.0, 1.0, 1.0)
-    ZAxisColor = Color(0.0, 1.0, 0.0, 1.0)
-    AllAxisColor = Color(1.0, 1.0, 1.0, 1.0)
-
     def __init__(self, parent = None):
         super().__init__(parent)
+
+        self._disabled_axis_color = None
+        self._x_axis_color = None
+        self._y_axis_color = None
+        self._z_axis_color = None
+        self._all_axis_color = None
+
+        self._axis_color_map = {}
 
         self._scene = Application.getInstance().getController().getScene()
 
@@ -48,6 +50,7 @@ class ToolHandle(SceneNode.SceneNode):
         self.setCalculateBoundingBox(False)
 
         Selection.selectionCenterChanged.connect(self._onSelectionCenterChanged)
+        Application.getInstance().engineCreatedSignal.connect(self._onEngineCreated)
 
     def getLineMesh(self):
         return self._line_mesh
@@ -90,36 +93,41 @@ class ToolHandle(SceneNode.SceneNode):
 
         return True
 
-    def getSelectionMap(self):
-        return {
-            self.XAxisColor: self.XAxis,
-            self.YAxisColor: self.YAxis,
-            self.ZAxisColor: self.ZAxis,
-            self.AllAxisColor: self.AllAxis
-        }
-
     def setActiveAxis(self, axis):
         if axis == self._active_axis or not self._shader:
             return
 
         if axis:
-            self._shader.setUniformValue("u_activeColor", self._axisColorMap[axis])
+            self._shader.setUniformValue("u_activeColor", self._axis_color_map[axis])
         else:
-            self._shader.setUniformValue("u_activeColor", self.DisabledColor)
+            self._shader.setUniformValue("u_activeColor", self._disabled_axis_color)
         self._active_axis = axis
         self._scene.sceneChanged.emit(self)
 
-    @classmethod
-    def isAxis(cls, value):
-        return value in cls._axisColorMap
+    def isAxis(self, value):
+        return value in self._axis_color_map
 
-    _axisColorMap = {
-        NoAxis: DisabledColor,
-        XAxis: XAxisColor,
-        YAxis: YAxisColor,
-        ZAxis: ZAxisColor,
-        AllAxis: AllAxisColor
-    }
+    def buildMesh(self):
+        # This method should be overridden by toolhandle implementations
+        pass
 
     def _onSelectionCenterChanged(self):
         self.setPosition(Selection.getSelectionCenter())
+
+    def _onEngineCreated(self):
+        theme = Application.getInstance().getTheme()
+        self._disabled_axis_color = Color(*theme.getColor("disabled_axis").getRgb())
+        self._x_axis_color = Color(*theme.getColor("x_axis").getRgb())
+        self._y_axis_color = Color(*theme.getColor("y_axis").getRgb())
+        self._z_axis_color = Color(*theme.getColor("z_axis").getRgb())
+        self._all_axis_color = Color(*theme.getColor("all_axis").getRgb())
+
+        self._axis_color_map = {
+            self.NoAxis: self._disabled_axis_color,
+            self.XAxis: self._x_axis_color,
+            self.YAxis: self._y_axis_color,
+            self.ZAxis: self._z_axis_color,
+            self.AllAxis: self._all_axis_color
+        }
+
+        self.buildMesh()

--- a/UM/View/CompositePass.py
+++ b/UM/View/CompositePass.py
@@ -3,6 +3,7 @@
 
 from UM.Application import Application
 from UM.Resources import Resources
+from UM.Math.Color import Color
 
 from UM.View.RenderPass import RenderPass
 from UM.View.GL.OpenGL import OpenGL
@@ -26,6 +27,10 @@ class CompositePass(RenderPass):
         super().__init__("composite", width, height, RenderPass.MaximumPriority)
 
         self._shader = OpenGL.getInstance().createShaderProgram(Resources.getPath(Resources.Shaders, "composite.shader"))
+        theme = Application.getInstance().getTheme()
+        self._shader.setUniformValue("u_background_color", Color(*theme.getColor("viewport_background").getRgb()))
+        self._shader.setUniformValue("u_outline_color", Color(*theme.getColor("model_selection_outline").getRgb()))
+
         self._gl = OpenGL.getInstance().getBindingsObject()
         self._renderer = Application.getInstance().getRenderer()
 

--- a/UM/View/SelectionPass.py
+++ b/UM/View/SelectionPass.py
@@ -39,18 +39,26 @@ class SelectionPass(RenderPass):
 
     ##  Perform the actual rendering.
     def render(self):
-        self._selection_map = {
-            self._dropAlpha(ToolHandle.DisabledColor): ToolHandle.NoAxis,
-            self._dropAlpha(ToolHandle.XAxisColor): ToolHandle.XAxis,
-            self._dropAlpha(ToolHandle.YAxisColor): ToolHandle.YAxis,
-            self._dropAlpha(ToolHandle.ZAxisColor): ToolHandle.ZAxis,
-            self._dropAlpha(ToolHandle.AllAxisColor): ToolHandle.AllAxis,
-            ToolHandle.DisabledColor: ToolHandle.NoAxis,
-            ToolHandle.XAxisColor: ToolHandle.XAxis,
-            ToolHandle.YAxisColor: ToolHandle.YAxis,
-            ToolHandle.ZAxisColor: ToolHandle.ZAxis,
-            ToolHandle.AllAxisColor: ToolHandle.AllAxis
-        }
+        if not self._selection_map:
+            theme = Application.getInstance().getTheme()
+            disabled_axis_color = Color(*theme.getColor("disabled_axis").getRgb())
+            x_axis_color = Color(*theme.getColor("x_axis").getRgb())
+            y_axis_color = Color(*theme.getColor("y_axis").getRgb())
+            z_axis_color = Color(*theme.getColor("z_axis").getRgb())
+            all_axis_color = Color(*theme.getColor("all_axis").getRgb())
+
+            self._selection_map = {
+                self._dropAlpha(disabled_axis_color): ToolHandle.NoAxis,
+                self._dropAlpha(x_axis_color): ToolHandle.XAxis,
+                self._dropAlpha(y_axis_color): ToolHandle.YAxis,
+                self._dropAlpha(z_axis_color): ToolHandle.ZAxis,
+                self._dropAlpha(all_axis_color): ToolHandle.AllAxis,
+                disabled_axis_color: ToolHandle.NoAxis,
+                x_axis_color: ToolHandle.XAxis,
+                y_axis_color: ToolHandle.YAxis,
+                z_axis_color: ToolHandle.ZAxis,
+                all_axis_color: ToolHandle.AllAxis
+            }
 
         batch = RenderBatch(self._shader)
         tool_handle = RenderBatch(self._tool_handle_shader, type = RenderBatch.RenderType.Overlay)

--- a/plugins/Tools/MirrorTool/MirrorTool.py
+++ b/plugins/Tools/MirrorTool/MirrorTool.py
@@ -39,7 +39,7 @@ class MirrorTool(Tool):
             if not id:
                 return False
 
-            if ToolHandle.isAxis(id):
+            if self._handle.isAxis(id):
                 self.setLockedAxis(id)
                 self._operation_started = True
                 self.operationStarted.emit(self)

--- a/plugins/Tools/MirrorTool/MirrorToolHandle.py
+++ b/plugins/Tools/MirrorTool/MirrorToolHandle.py
@@ -16,6 +16,7 @@ class MirrorToolHandle(ToolHandle):
         self._handle_height = 14
         self._handle_position = 20
 
+    def buildMesh(self):
         mb = MeshBuilder()
 
         mb.addPyramid(
@@ -23,7 +24,7 @@ class MirrorToolHandle(ToolHandle):
             height = self._handle_height,
             depth = self._handle_width,
             center = Vector(0, self._handle_position, 0),
-            color = ToolHandle.YAxisColor
+            color = self._y_axis_color
         )
 
         mb.addPyramid(
@@ -31,7 +32,7 @@ class MirrorToolHandle(ToolHandle):
             height = self._handle_height,
             depth = self._handle_width,
             center = Vector(0, -self._handle_position, 0),
-            color = ToolHandle.YAxisColor,
+            color = self._y_axis_color,
             axis = Vector.Unit_X,
             angle = 180
         )
@@ -41,7 +42,7 @@ class MirrorToolHandle(ToolHandle):
             height = self._handle_height,
             depth = self._handle_width,
             center = Vector(self._handle_position, 0, 0),
-            color = ToolHandle.XAxisColor,
+            color = self._x_axis_color,
             axis = Vector.Unit_Z,
             angle = 90
         )
@@ -51,7 +52,7 @@ class MirrorToolHandle(ToolHandle):
             height = self._handle_height,
             depth = self._handle_width,
             center = Vector(-self._handle_position, 0, 0),
-            color = ToolHandle.XAxisColor,
+            color = self._x_axis_color,
             axis = Vector.Unit_Z,
             angle = -90
         )
@@ -61,7 +62,7 @@ class MirrorToolHandle(ToolHandle):
             height = self._handle_height,
             depth = self._handle_width,
             center = Vector(0, 0, -self._handle_position),
-            color = ToolHandle.ZAxisColor,
+            color = self._z_axis_color,
             axis = Vector.Unit_X,
             angle = 90
         )
@@ -71,7 +72,7 @@ class MirrorToolHandle(ToolHandle):
             height = self._handle_height,
             depth = self._handle_width,
             center = Vector(0, 0, self._handle_position),
-            color = ToolHandle.ZAxisColor,
+            color = self._z_axis_color,
             axis = Vector.Unit_X,
             angle = -90
         )

--- a/plugins/Tools/RotateTool/RotateTool.py
+++ b/plugins/Tools/RotateTool/RotateTool.py
@@ -72,7 +72,7 @@ class RotateTool(Tool):
             if not id:
                 return False
 
-            if ToolHandle.isAxis(id):
+            if self._handle.isAxis(id):
                 self.setLockedAxis(id)
             else:
                 # Not clicked on an axis: do nothing.

--- a/plugins/Tools/RotateTool/RotateToolHandle.py
+++ b/plugins/Tools/RotateTool/RotateToolHandle.py
@@ -19,6 +19,7 @@ class RotateToolHandle(ToolHandle):
         self._active_outer_radius = 44
         self._active_line_width = 3
 
+    def buildMesh(self):
         #SOLIDMESH
         mb = MeshBuilder()
 
@@ -26,7 +27,7 @@ class RotateToolHandle(ToolHandle):
             inner_radius = self._inner_radius,
             outer_radius = self._outer_radius,
             width = self._line_width,
-            color = ToolHandle.ZAxisColor
+            color = self._z_axis_color
         )
 
         mb.addDonut(
@@ -35,7 +36,7 @@ class RotateToolHandle(ToolHandle):
             width = self._line_width,
             axis = Vector.Unit_X,
             angle = math.pi / 2,
-            color = ToolHandle.YAxisColor
+            color = self._y_axis_color
         )
 
         mb.addDonut(
@@ -44,7 +45,7 @@ class RotateToolHandle(ToolHandle):
             width = self._line_width,
             axis = Vector.Unit_Y,
             angle = math.pi / 2,
-            color = ToolHandle.XAxisColor
+            color = self._x_axis_color
         )
         self.setSolidMesh(mb.build())
 
@@ -55,7 +56,7 @@ class RotateToolHandle(ToolHandle):
             inner_radius = self._active_inner_radius,
             outer_radius = self._active_outer_radius,
             width = self._active_line_width,
-            color = ToolHandle.ZAxisColor
+            color = self._z_axis_color
         )
 
         mb.addDonut(
@@ -64,7 +65,7 @@ class RotateToolHandle(ToolHandle):
             width = self._active_line_width,
             axis = Vector.Unit_X,
             angle = math.pi / 2,
-            color = ToolHandle.YAxisColor
+            color = self._y_axis_color
         )
 
         mb.addDonut(
@@ -73,7 +74,7 @@ class RotateToolHandle(ToolHandle):
             width = self._active_line_width,
             axis = Vector.Unit_Y,
             angle = math.pi / 2,
-            color = ToolHandle.XAxisColor
+            color = self._x_axis_color
         )
 
         self.setSelectionMesh(mb.build())

--- a/plugins/Tools/ScaleTool/ScaleTool.py
+++ b/plugins/Tools/ScaleTool/ScaleTool.py
@@ -94,7 +94,7 @@ class ScaleTool(Tool):
             if not id:
                 return False
 
-            if ToolHandle.isAxis(id):
+            if self._handle.isAxis(id):
                 self.setLockedAxis(id)
             self._saved_handle_position = self._handle.getWorldPosition()
 

--- a/plugins/Tools/ScaleTool/ScaleTool.qml
+++ b/plugins/Tools/ScaleTool/ScaleTool.qml
@@ -115,7 +115,7 @@ Item
             height: UM.Theme.getSize("setting_control").height;
             text: "X";
             font: UM.Theme.getFont("default");
-            color: "red"
+            color: UM.Theme.getColor("x_axis");
             verticalAlignment: Text.AlignVCenter;
         }
 
@@ -124,7 +124,7 @@ Item
             height: UM.Theme.getSize("setting_control").height;
             text: "Y";
             font: UM.Theme.getFont("default");
-            color: "green"
+            color: UM.Theme.getColor("y_axis");
             verticalAlignment: Text.AlignVCenter;
         }
 
@@ -133,7 +133,7 @@ Item
             height: UM.Theme.getSize("setting_control").height;
             text: "Z";
             font: UM.Theme.getFont("default");
-            color: "blue"
+            color: UM.Theme.getColor("z_axis");
             verticalAlignment: Text.AlignVCenter;
         }
 

--- a/plugins/Tools/ScaleTool/ScaleToolHandle.py
+++ b/plugins/Tools/ScaleTool/ScaleToolHandle.py
@@ -21,6 +21,7 @@ class ScaleToolHandle(ToolHandle):
         self._active_handle_position = 40
         self._active_handle_width = 15
 
+    def buildMesh(self):
         #SOLIDMESH -> LINES
         mb = MeshBuilder()
 
@@ -29,14 +30,14 @@ class ScaleToolHandle(ToolHandle):
             height = self._line_length,
             depth = self._line_width,
             center = Vector(0, self._handle_position/2, 0),
-            color = ToolHandle.YAxisColor
+            color = self._y_axis_color
         )
         mb.addCube(
             width = self._line_length,
             height = self._line_width,
             depth = self._line_width,
             center = Vector(self._handle_position/2, 0, 0),
-            color = ToolHandle.XAxisColor
+            color = self._x_axis_color
         )
 
         mb.addCube(
@@ -44,7 +45,7 @@ class ScaleToolHandle(ToolHandle):
             height = self._line_width,
             depth = self._line_length,
             center = Vector(0, 0, self._handle_position/2),
-            color = ToolHandle.ZAxisColor
+            color = self._z_axis_color
         )
 
         #SOLIDMESH -> HANDLES
@@ -53,7 +54,7 @@ class ScaleToolHandle(ToolHandle):
             height = self._handle_width,
             depth = self._handle_width,
             center = Vector(0, 0, 0),
-            color = ToolHandle.AllAxisColor
+            color = self._all_axis_color
         )
 
         mb.addCube(
@@ -61,7 +62,7 @@ class ScaleToolHandle(ToolHandle):
             height = self._handle_width,
             depth = self._handle_width,
             center = Vector(0, self._handle_position, 0),
-            color = ToolHandle.YAxisColor
+            color = self._y_axis_color
         )
 
         mb.addCube(
@@ -69,7 +70,7 @@ class ScaleToolHandle(ToolHandle):
             height = self._handle_width,
             depth = self._handle_width,
             center = Vector(self._handle_position, 0, 0),
-            color = ToolHandle.XAxisColor
+            color = self._x_axis_color
         )
 
         mb.addCube(
@@ -77,7 +78,7 @@ class ScaleToolHandle(ToolHandle):
             height = self._handle_width,
             depth = self._handle_width,
             center = Vector(0, 0, self._handle_position),
-            color = ToolHandle.ZAxisColor
+            color = self._z_axis_color
         )
         self.setSolidMesh(mb.build())
 
@@ -88,7 +89,7 @@ class ScaleToolHandle(ToolHandle):
             height = self._active_line_length,
             depth = self._active_line_width,
             center = Vector(0, self._active_handle_position/2, 0),
-            color = ToolHandle.YAxisColor
+            color = self._y_axis_color
         )
 
         mb.addCube(
@@ -96,7 +97,7 @@ class ScaleToolHandle(ToolHandle):
             height = self._active_line_width,
             depth = self._active_line_width,
             center = Vector(self._active_handle_position/2, 0, 0),
-            color = ToolHandle.XAxisColor
+            color = self._x_axis_color
         )
 
         mb.addCube(
@@ -104,7 +105,7 @@ class ScaleToolHandle(ToolHandle):
             height = self._active_line_width,
             depth = self._active_line_length,
             center = Vector(0, 0, self._active_handle_position/2),
-            color = ToolHandle.ZAxisColor
+            color = self._z_axis_color
         )
 
         #SELECTIONMESH -> HANDLES
@@ -113,7 +114,7 @@ class ScaleToolHandle(ToolHandle):
             height = self._active_handle_width,
             depth = self._active_handle_width,
             center = Vector(0, 0, 0),
-            color = ToolHandle.AllAxisColor
+            color = self._all_axis_color
         )
 
         mb.addCube(
@@ -121,7 +122,7 @@ class ScaleToolHandle(ToolHandle):
             height = self._active_handle_width,
             depth = self._active_handle_width,
             center = Vector(0, self._active_handle_position, 0),
-            color = ToolHandle.YAxisColor
+            color = self._y_axis_color
         )
 
         mb.addCube(
@@ -129,7 +130,7 @@ class ScaleToolHandle(ToolHandle):
             height = self._active_handle_width,
             depth = self._active_handle_width,
             center = Vector(self._active_handle_position, 0, 0),
-            color = ToolHandle.XAxisColor
+            color = self._x_axis_color
         )
 
         mb.addCube(
@@ -137,7 +138,7 @@ class ScaleToolHandle(ToolHandle):
             height = self._active_handle_width,
             depth = self._active_handle_width,
             center = Vector(0, 0, self._active_handle_position),
-            color = ToolHandle.ZAxisColor
+            color = self._z_axis_color
         )
 
         self.setSelectionMesh(mb.build())

--- a/plugins/Tools/TranslateTool/TranslateTool.qml
+++ b/plugins/Tools/TranslateTool/TranslateTool.qml
@@ -52,7 +52,7 @@ Item
             height: UM.Theme.getSize("setting_control").height;
             text: "X";
             font: UM.Theme.getFont("default");
-            color: "red"
+            color: UM.Theme.getColor("x_axis");
             verticalAlignment: Text.AlignVCenter;
         }
 
@@ -61,7 +61,7 @@ Item
             height: UM.Theme.getSize("setting_control").height;
             text: "Y";
             font: UM.Theme.getFont("default");
-            color: "green"
+            color: UM.Theme.getColor("y_axis");
             verticalAlignment: Text.AlignVCenter;
         }
 
@@ -70,7 +70,7 @@ Item
             height: UM.Theme.getSize("setting_control").height;
             text: "Z";
             font: UM.Theme.getFont("default");
-            color: "blue"
+            color: UM.Theme.getColor("z_axis");
             verticalAlignment: Text.AlignVCenter;
         }
         TextField

--- a/plugins/Tools/TranslateTool/TranslateToolHandle.py
+++ b/plugins/Tools/TranslateTool/TranslateToolHandle.py
@@ -26,9 +26,9 @@ class TranslateToolHandle(ToolHandle):
 
     def setEnabledAxis(self, axis):
         self._enabled_axis = axis
-        self._rebuild()
+        self.buildMesh()
 
-    def _rebuild(self):
+    def buildMesh(self):
         mb = MeshBuilder()
 
         #SOLIDMESH -> LINES
@@ -38,7 +38,7 @@ class TranslateToolHandle(ToolHandle):
                 height = self._line_length,
                 depth = self._line_width,
                 center = Vector(0, self._handle_position/2, 0),
-                color = ToolHandle.YAxisColor
+                color = self._y_axis_color
             )
         if self.XAxis in self._enabled_axis:
             mb.addCube(
@@ -46,7 +46,7 @@ class TranslateToolHandle(ToolHandle):
                 height = self._line_width,
                 depth = self._line_width,
                 center = Vector(self._handle_position/2, 0, 0),
-                color = ToolHandle.XAxisColor
+                color = self._x_axis_color
             )
 
         if self.ZAxis in self._enabled_axis:
@@ -55,7 +55,7 @@ class TranslateToolHandle(ToolHandle):
                 height = self._line_width,
                 depth = self._line_length,
                 center = Vector(0, 0, self._handle_position/2),
-                color = ToolHandle.ZAxisColor
+                color = self._z_axis_color
             )
 
         #SOLIDMESH -> HANDLES
@@ -65,7 +65,7 @@ class TranslateToolHandle(ToolHandle):
                 height = self._handle_height,
                 depth = self._handle_width,
                 center = Vector(0, self._handle_position, 0),
-                color = ToolHandle.YAxisColor
+                color = self._y_axis_color
             )
 
         if self.XAxis in self._enabled_axis:
@@ -74,7 +74,7 @@ class TranslateToolHandle(ToolHandle):
                 height = self._handle_height,
                 depth = self._handle_width,
                 center = Vector(self._handle_position, 0, 0),
-                color = ToolHandle.XAxisColor,
+                color = self._x_axis_color,
                 axis = Vector.Unit_Z,
                 angle = 90
             )
@@ -85,7 +85,7 @@ class TranslateToolHandle(ToolHandle):
                 height = self._handle_height,
                 depth = self._handle_width,
                 center = Vector(0, 0, self._handle_position),
-                color = ToolHandle.ZAxisColor,
+                color = self._z_axis_color,
                 axis = Vector.Unit_X,
                 angle = -90
             )
@@ -100,7 +100,7 @@ class TranslateToolHandle(ToolHandle):
                 height = self._active_line_length,
                 depth = self._active_line_width,
                 center = Vector(0, self._active_handle_position/2, 0),
-                color = ToolHandle.YAxisColor
+                color = self._y_axis_color
             )
         if self.XAxis in self._enabled_axis:
             mb.addCube(
@@ -108,7 +108,7 @@ class TranslateToolHandle(ToolHandle):
                 height = self._active_line_width,
                 depth = self._active_line_width,
                 center = Vector(self._active_handle_position/2, 0, 0),
-                color = ToolHandle.XAxisColor
+                color = self._x_axis_color
             )
 
         if self.ZAxis in self._enabled_axis:
@@ -117,7 +117,7 @@ class TranslateToolHandle(ToolHandle):
                 height = self._active_line_width,
                 depth = self._active_line_length,
                 center = Vector(0, 0, self._active_handle_position/2),
-                color = ToolHandle.ZAxisColor
+                color = self._z_axis_color
             )
 
         #SELECTIONMESH -> HANDLES
@@ -126,7 +126,7 @@ class TranslateToolHandle(ToolHandle):
             height = self._active_handle_width,
             depth = self._active_handle_width,
             center = Vector(0, 0, 0),
-            color = ToolHandle.AllAxisColor
+            color = self._all_axis_color
         )
 
         mb.addCube(
@@ -134,7 +134,7 @@ class TranslateToolHandle(ToolHandle):
             height = self._active_handle_width,
             depth = self._active_handle_width,
             center = Vector(0, self._active_handle_position, 0),
-            color = ToolHandle.YAxisColor
+            color = self._y_axis_color
         )
 
         mb.addCube(
@@ -142,7 +142,7 @@ class TranslateToolHandle(ToolHandle):
             height = self._active_handle_width,
             depth = self._active_handle_width,
             center = Vector(self._active_handle_position, 0, 0),
-            color = ToolHandle.XAxisColor
+            color = self._x_axis_color
         )
 
         mb.addCube(
@@ -150,6 +150,6 @@ class TranslateToolHandle(ToolHandle):
             height = self._active_handle_width,
             depth = self._active_handle_width,
             center = Vector(0, 0, self._active_handle_position),
-            color = ToolHandle.ZAxisColor
+            color = self._z_axis_color
         )
         self.setSelectionMesh(mb.build())


### PR DESCRIPTION
This PR makes the Theme layer available to python, so it can be used to theme the parts of the UI that is governed by python as opposed to QML, most notably the viewport. This paves the road for a dark theme, among other things.

Note that the theme relies on the qml engine to exist; the theme should not be accessed before Application.engineCreatedSignal is fired.

This PR relies on its Cura counterpart: https://github.com/Ultimaker/Cura/pull/1370