### PR TITLE
Fix the location of the configuration folder on Windows

### DIFF
--- a/UM/Resources.py
+++ b/UM/Resources.py
@@ -264,7 +264,7 @@ class Resources:
     @classmethod
     def __initializeStoragePaths(cls):
         if platform.system() == "Windows":
-            cls.__config_storage_path = os.path.join(os.path.expanduser("~\\AppData\\Local\\"), cls.ApplicationIdentifier)
+            cls.__config_storage_path = os.path.join(os.getenv("LOCALAPPDATA"), cls.ApplicationIdentifier)
         elif platform.system() == "Darwin":
             cls.__config_storage_path = os.path.join(os.path.expanduser("~/Library/Application Support"), cls.ApplicationIdentifier)
             # For backward compatibility, support loading files from the old storage location


### PR DESCRIPTION
~/AppData/Local may not be correctly expanded to the AppData folder on systems with itinerant profiles (eg corporate/educational networks where the user profile is stored on the network)

See https://github.com/Ultimaker/Cura/issues/1369 for discussion
Also see the Cura PR: https://github.com/Ultimaker/Cura/pull/1375