### PR TITLE
Fix toolhandle selection colors

### DIFF
--- a/UM/Scene/ToolHandle.py
+++ b/UM/Scene/ToolHandle.py
@@ -25,6 +25,14 @@ class ToolHandle(SceneNode.SceneNode):
     ZAxis = 4
     AllAxis = 5
 
+    # These colors are used to draw the selection pass only. They must be unique, which is
+    # why we cannot rely on themed colors
+    DisabledSelectionColor = Color(0.5, 0.5, 0.5, 1.0)
+    XAxisSelectionColor = Color(1.0, 0.0, 0.0, 1.0)
+    YAxisSelectionColor = Color(0.0, 0.0, 1.0, 1.0)
+    ZAxisSelectionColor = Color(0.0, 1.0, 0.0, 1.0)
+    AllAxisSelectionColor = Color(1.0, 1.0, 1.0, 1.0)
+
     def __init__(self, parent = None):
         super().__init__(parent)
 

--- a/UM/View/SelectionPass.py
+++ b/UM/View/SelectionPass.py
@@ -35,30 +35,24 @@ class SelectionPass(RenderPass):
         self._renderer = Application.getInstance().getRenderer()
 
         self._selection_map = {}
+        self._toolhandle_selection_map = {
+            self._dropAlpha(ToolHandle.DisabledSelectionColor): ToolHandle.NoAxis,
+            self._dropAlpha(ToolHandle.XAxisSelectionColor): ToolHandle.XAxis,
+            self._dropAlpha(ToolHandle.YAxisSelectionColor): ToolHandle.YAxis,
+            self._dropAlpha(ToolHandle.ZAxisSelectionColor): ToolHandle.ZAxis,
+            self._dropAlpha(ToolHandle.AllAxisSelectionColor): ToolHandle.AllAxis,
+            ToolHandle.DisabledSelectionColor: ToolHandle.NoAxis,
+            ToolHandle.XAxisSelectionColor: ToolHandle.XAxis,
+            ToolHandle.YAxisSelectionColor: ToolHandle.YAxis,
+            ToolHandle.ZAxisSelectionColor: ToolHandle.ZAxis,
+            ToolHandle.AllAxisSelectionColor: ToolHandle.AllAxis
+        }
+
         self._output = None
 
     ##  Perform the actual rendering.
     def render(self):
-        if not self._selection_map:
-            theme = Application.getInstance().getTheme()
-            disabled_axis_color = Color(*theme.getColor("disabled_axis").getRgb())
-            x_axis_color = Color(*theme.getColor("x_axis").getRgb())
-            y_axis_color = Color(*theme.getColor("y_axis").getRgb())
-            z_axis_color = Color(*theme.getColor("z_axis").getRgb())
-            all_axis_color = Color(*theme.getColor("all_axis").getRgb())
-
-            self._selection_map = {
-                self._dropAlpha(disabled_axis_color): ToolHandle.NoAxis,
-                self._dropAlpha(x_axis_color): ToolHandle.XAxis,
-                self._dropAlpha(y_axis_color): ToolHandle.YAxis,
-                self._dropAlpha(z_axis_color): ToolHandle.ZAxis,
-                self._dropAlpha(all_axis_color): ToolHandle.AllAxis,
-                disabled_axis_color: ToolHandle.NoAxis,
-                x_axis_color: ToolHandle.XAxis,
-                y_axis_color: ToolHandle.YAxis,
-                z_axis_color: ToolHandle.ZAxis,
-                all_axis_color: ToolHandle.AllAxis
-            }
+        self._selection_map = self._toolhandle_selection_map.copy()
 
         batch = RenderBatch(self._shader)
         tool_handle = RenderBatch(self._tool_handle_shader, type = RenderBatch.RenderType.Overlay)

--- a/plugins/Tools/MirrorTool/MirrorToolHandle.py
+++ b/plugins/Tools/MirrorTool/MirrorToolHandle.py
@@ -19,6 +19,7 @@ class MirrorToolHandle(ToolHandle):
     def buildMesh(self):
         mb = MeshBuilder()
 
+        #SOLIDMESH
         mb.addPyramid(
             width = self._handle_width,
             height = self._handle_height,
@@ -76,6 +77,66 @@ class MirrorToolHandle(ToolHandle):
             axis = Vector.Unit_X,
             angle = -90
         )
-        mesh = mb.build()
-        self.setSolidMesh(mesh)
-        self.setSelectionMesh(mesh)
+
+        self.setSolidMesh(mb.build())
+
+        #SELECTIONMESH
+        mb.addPyramid(
+            width = self._handle_width,
+            height = self._handle_height,
+            depth = self._handle_width,
+            center = Vector(0, self._handle_position, 0),
+            color = self._y_axis_color
+        )
+
+        mb.addPyramid(
+            width = self._handle_width,
+            height = self._handle_height,
+            depth = self._handle_width,
+            center = Vector(0, -self._handle_position, 0),
+            color = self._y_axis_color,
+            axis = Vector.Unit_X,
+            angle = 180
+        )
+
+        mb.addPyramid(
+            width = self._handle_width,
+            height = self._handle_height,
+            depth = self._handle_width,
+            center = Vector(self._handle_position, 0, 0),
+            color = self._x_axis_color,
+            axis = Vector.Unit_Z,
+            angle = 90
+        )
+
+        mb.addPyramid(
+            width = self._handle_width,
+            height = self._handle_height,
+            depth = self._handle_width,
+            center = Vector(-self._handle_position, 0, 0),
+            color = self._x_axis_color,
+            axis = Vector.Unit_Z,
+            angle = -90
+        )
+
+        mb.addPyramid(
+            width = self._handle_width,
+            height = self._handle_height,
+            depth = self._handle_width,
+            center = Vector(0, 0, -self._handle_position),
+            color = self._z_axis_color,
+            axis = Vector.Unit_X,
+            angle = 90
+        )
+
+        mb.addPyramid(
+            width = self._handle_width,
+            height = self._handle_height,
+            depth = self._handle_width,
+            center = Vector(0, 0, self._handle_position),
+            color = self._z_axis_color,
+            axis = Vector.Unit_X,
+            angle = -90
+        )
+
+        self.setSelectionMesh(mb.build())

--- a/plugins/Tools/MirrorTool/MirrorToolHandle.py
+++ b/plugins/Tools/MirrorTool/MirrorToolHandle.py
@@ -86,7 +86,7 @@ class MirrorToolHandle(ToolHandle):
             height = self._handle_height,
             depth = self._handle_width,
             center = Vector(0, self._handle_position, 0),
-            color = self._y_axis_color
+            color = ToolHandle.YAxisSelectionColor
         )
 
         mb.addPyramid(
@@ -94,7 +94,7 @@ class MirrorToolHandle(ToolHandle):
             height = self._handle_height,
             depth = self._handle_width,
             center = Vector(0, -self._handle_position, 0),
-            color = self._y_axis_color,
+            color = ToolHandle.YAxisSelectionColor,
             axis = Vector.Unit_X,
             angle = 180
         )
@@ -104,7 +104,7 @@ class MirrorToolHandle(ToolHandle):
             height = self._handle_height,
             depth = self._handle_width,
             center = Vector(self._handle_position, 0, 0),
-            color = self._x_axis_color,
+            color = ToolHandle.XAxisSelectionColor,
             axis = Vector.Unit_Z,
             angle = 90
         )
@@ -114,7 +114,7 @@ class MirrorToolHandle(ToolHandle):
             height = self._handle_height,
             depth = self._handle_width,
             center = Vector(-self._handle_position, 0, 0),
-            color = self._x_axis_color,
+            color = ToolHandle.XAxisSelectionColor,
             axis = Vector.Unit_Z,
             angle = -90
         )
@@ -124,7 +124,7 @@ class MirrorToolHandle(ToolHandle):
             height = self._handle_height,
             depth = self._handle_width,
             center = Vector(0, 0, -self._handle_position),
-            color = self._z_axis_color,
+            color = ToolHandle.ZAxisSelectionColor,
             axis = Vector.Unit_X,
             angle = 90
         )
@@ -134,7 +134,7 @@ class MirrorToolHandle(ToolHandle):
             height = self._handle_height,
             depth = self._handle_width,
             center = Vector(0, 0, self._handle_position),
-            color = self._z_axis_color,
+            color = ToolHandle.ZAxisSelectionColor,
             axis = Vector.Unit_X,
             angle = -90
         )

--- a/plugins/Tools/RotateTool/RotateToolHandle.py
+++ b/plugins/Tools/RotateTool/RotateToolHandle.py
@@ -56,7 +56,7 @@ class RotateToolHandle(ToolHandle):
             inner_radius = self._active_inner_radius,
             outer_radius = self._active_outer_radius,
             width = self._active_line_width,
-            color = self._z_axis_color
+            color = ToolHandle.ZAxisSelectionColor
         )
 
         mb.addDonut(
@@ -65,7 +65,7 @@ class RotateToolHandle(ToolHandle):
             width = self._active_line_width,
             axis = Vector.Unit_X,
             angle = math.pi / 2,
-            color = self._y_axis_color
+            color = ToolHandle.YAxisSelectionColor
         )
 
         mb.addDonut(
@@ -74,7 +74,7 @@ class RotateToolHandle(ToolHandle):
             width = self._active_line_width,
             axis = Vector.Unit_Y,
             angle = math.pi / 2,
-            color = self._x_axis_color
+            color = ToolHandle.XAxisSelectionColor
         )
 
         self.setSelectionMesh(mb.build())

--- a/plugins/Tools/ScaleTool/ScaleToolHandle.py
+++ b/plugins/Tools/ScaleTool/ScaleToolHandle.py
@@ -89,7 +89,7 @@ class ScaleToolHandle(ToolHandle):
             height = self._active_line_length,
             depth = self._active_line_width,
             center = Vector(0, self._active_handle_position/2, 0),
-            color = self._y_axis_color
+            color = ToolHandle.YAxisSelectionColor
         )
 
         mb.addCube(
@@ -97,7 +97,7 @@ class ScaleToolHandle(ToolHandle):
             height = self._active_line_width,
             depth = self._active_line_width,
             center = Vector(self._active_handle_position/2, 0, 0),
-            color = self._x_axis_color
+            color = ToolHandle.XAxisSelectionColor
         )
 
         mb.addCube(
@@ -105,7 +105,7 @@ class ScaleToolHandle(ToolHandle):
             height = self._active_line_width,
             depth = self._active_line_length,
             center = Vector(0, 0, self._active_handle_position/2),
-            color = self._z_axis_color
+            color = ToolHandle.ZAxisSelectionColor
         )
 
         #SELECTIONMESH -> HANDLES
@@ -114,7 +114,7 @@ class ScaleToolHandle(ToolHandle):
             height = self._active_handle_width,
             depth = self._active_handle_width,
             center = Vector(0, 0, 0),
-            color = self._all_axis_color
+            color = ToolHandle.AllAxisSelectionColor
         )
 
         mb.addCube(
@@ -122,7 +122,7 @@ class ScaleToolHandle(ToolHandle):
             height = self._active_handle_width,
             depth = self._active_handle_width,
             center = Vector(0, self._active_handle_position, 0),
-            color = self._y_axis_color
+            color = ToolHandle.YAxisSelectionColor
         )
 
         mb.addCube(
@@ -130,7 +130,7 @@ class ScaleToolHandle(ToolHandle):
             height = self._active_handle_width,
             depth = self._active_handle_width,
             center = Vector(self._active_handle_position, 0, 0),
-            color = self._x_axis_color
+            color = ToolHandle.XAxisSelectionColor
         )
 
         mb.addCube(
@@ -138,7 +138,7 @@ class ScaleToolHandle(ToolHandle):
             height = self._active_handle_width,
             depth = self._active_handle_width,
             center = Vector(0, 0, self._active_handle_position),
-            color = self._z_axis_color
+            color = ToolHandle.ZAxisSelectionColor
         )
 
         self.setSelectionMesh(mb.build())

--- a/plugins/Tools/TranslateTool/TranslateToolHandle.py
+++ b/plugins/Tools/TranslateTool/TranslateToolHandle.py
@@ -126,7 +126,7 @@ class TranslateToolHandle(ToolHandle):
             height = self._active_handle_width,
             depth = self._active_handle_width,
             center = Vector(0, 0, 0),
-            color = self._all_axis_color
+            color = ToolHandle.AllAxisSelectionColor
         )
 
         mb.addCube(
@@ -134,7 +134,7 @@ class TranslateToolHandle(ToolHandle):
             height = self._active_handle_width,
             depth = self._active_handle_width,
             center = Vector(0, self._active_handle_position, 0),
-            color = self._y_axis_color
+            color = ToolHandle.YAxisSelectionColor
         )
 
         mb.addCube(
@@ -142,7 +142,7 @@ class TranslateToolHandle(ToolHandle):
             height = self._active_handle_width,
             depth = self._active_handle_width,
             center = Vector(self._active_handle_position, 0, 0),
-            color = self._x_axis_color
+            color = ToolHandle.XAxisSelectionColor
         )
 
         mb.addCube(
@@ -150,6 +150,6 @@ class TranslateToolHandle(ToolHandle):
             height = self._active_handle_width,
             depth = self._active_handle_width,
             center = Vector(0, 0, self._active_handle_position),
-            color = self._z_axis_color
+            color = ToolHandle.ZAxisSelectionColor
         )
         self.setSelectionMesh(mb.build())

--- a/plugins/Tools/TranslateTool/TranslateToolHandle.py
+++ b/plugins/Tools/TranslateTool/TranslateToolHandle.py
@@ -93,7 +93,7 @@ class TranslateToolHandle(ToolHandle):
         self.setSolidMesh(mb.build())
 
         mb = MeshBuilder()
-        #ACTIVEMESH -> LINES
+        #SELECTIONMESH -> LINES
         if self.YAxis in self._enabled_axis:
             mb.addCube(
                 width = self._active_line_width,


### PR DESCRIPTION
When the colors for toolhandles are themed, we cannot rely on these colors being unique between axes, or between potential other "special" colors in the selection pass. This PR restores fixed constant colors per axis, for the selection meshes only. These fixed colors are never visible to the user because they are only used in the selection pass.

This PR is a followup for https://github.com/Ultimaker/Uranium/pull/215