### PR TITLE
Improve performance of switching variant/materials/quality

### DIFF
--- a/UM/Settings/ContainerQuery.py
+++ b/UM/Settings/ContainerQuery.py
@@ -68,7 +68,7 @@ class ContainerQuery:
         return hash(self.__key())
 
     def __eq__(self, other):
-        return self.__key() == other.__key()
+        return isinstance(other, ContainerQuery) and self.__key() == other.__key()
 
     # protected:
 

--- a/UM/Settings/ContainerQuery.py
+++ b/UM/Settings/ContainerQuery.py
@@ -3,6 +3,8 @@
 
 import re
 
+from . import InstanceContainer
+
 ##  Wrapper class to perform a search for a certain set of containers.
 #
 #   This class is primarily intended to be used internally by
@@ -86,10 +88,8 @@ class ContainerQuery:
         elif property_name == "name":
             return value_pattern.match(container.getName())
         elif property_name == "definition":
-            try:
-                return value_pattern.match(container.getDefinition().getId())
-            except AttributeError:  # Only instanceContainers have a get definition. We can ignore all others.
-                pass
+            if isinstance(container, InstanceContainer.InstanceContainer):
+                return container.getDefinition() and value_pattern.match(container.getDefinition().getId())
 
         return value_pattern.match(str(container.getMetaDataEntry(property_name)))
 
@@ -102,10 +102,8 @@ class ContainerQuery:
         elif property_name == "name":
             return value == self._maybeLowercase(container.getName())
         elif property_name == "definition":
-            try:
-                return value == container.getDefinition().getId()
-            except AttributeError:
-                return False
+            if isinstance(container, InstanceContainer.InstanceContainer):
+                return container.getDefinition() and value == container.getDefinition().getId()
 
         return value == self._maybeLowercase(str(container.getMetaDataEntry(property_name)))
 
@@ -114,9 +112,9 @@ class ContainerQuery:
         if property_name == "id" or property_name == "name" or property_name == "definition":
             return False
         elif property_name == "read_only":
-            try:
+            if isinstance(container, InstanceContainer.InstanceContainer):
                 return value == container.isReadOnly()
-            except AttributeError:
+            else:
                 return False
 
         return value == container.getMetaDataEntry(property_name)

--- a/UM/Settings/ContainerQuery.py
+++ b/UM/Settings/ContainerQuery.py
@@ -1,0 +1,133 @@
+# Copyright (c) 2017 Ultimaker B.V.
+# Uranium is released under the terms of the AGPLv3 or higher.
+
+import re
+
+##  Wrapper class to perform a search for a certain set of containers.
+#
+#   This class is primarily intended to be used internally by
+#   ContainerRegistry::findContainers. It is used to perform the actual
+#   searching for containers and cache the results.
+#
+#   \note Instances of this class will ignore the query results when
+#   comparing. This is done to simplify the caching code in ContainerRegistry.
+class ContainerQuery:
+    ##  Constructor
+    #
+    #   \param registry The ContainerRegistry instance this query operates on.
+    #   \param container_type A specific container class that should be filtered for.
+    #   \param ignore_case Whether or not the query should be case sensitive.
+    #   \param kwargs A dict of key, value pairs that should be searched for.
+    def __init__(self, registry, container_type = None, *, ignore_case = False, **kwargs):
+        self._registry = registry
+
+        self._container_type = container_type
+        self._ignore_case = ignore_case
+        self._kwargs = kwargs
+
+        self._result = None
+
+    ##  Retrieve the result of this query.
+    #
+    #   \return A list of containers matching this query, or None if the query was not executed.
+    def getResult(self):
+        return self._result
+
+    ##  Check to see if this is a very simple query that looks up a single container by ID.
+    #
+    #   \return True if this query is case sensitive, has only 1 thing to search for and that thing is "id".
+    def isIdOnly(self):
+        return not self._ignore_case and len(self._kwargs) == 1 and "id" in self._kwargs
+
+    ##  Execute the actual query.
+    #
+    #   This will search the containers of the ContainerRegistry based on the arguments provided to this
+    #   class' constructor. After it is done, the result can be retrieved with getResult().
+    def execute(self):
+        containers = []
+        for container in filter(lambda c: not self._container_type or isinstance(c, self._container_type), self._registry._containers):
+            matches_container = True
+            for key, value in self._kwargs.items():
+                if isinstance(value, str):
+                    if "*" in value:
+                        matches_container = self._matchRegExp(container, key, value)
+                    else:
+                        matches_container = self._matchString(container, key, value)
+                else:
+                    matches_container = self._matchType(container, key, value)
+
+                if not matches_container: # For the moment, a query needs to match all specified criteria
+                    break
+
+            if matches_container:
+                containers.append(container)
+
+        self._result = containers
+
+    def __hash__(self):
+        return hash(self.__key())
+
+    def __eq__(self, other):
+        return self.__key() == other.__key()
+
+    # protected:
+
+    # Check to see if a container matches with a regular expression
+    def _matchRegExp(self, container, property_name, value):
+        value = re.escape(value) #Escape for regex patterns.
+        value = "^" + value.replace("\\*", ".*") + "$" #Instead of (now escaped) asterisks, match on any string. Also add anchors for a complete match.
+        if self._ignore_case:
+            value_pattern = re.compile(value, re.IGNORECASE)
+        else:
+            value_pattern = re.compile(value)
+
+        if property_name == "id":
+            return value_pattern.match(container.getId())
+        elif property_name == "name":
+            return value_pattern.match(container.getName())
+        elif property_name == "definition":
+            try:
+                return value_pattern.match(container.getDefinition().getId())
+            except AttributeError:  # Only instanceContainers have a get definition. We can ignore all others.
+                pass
+
+        return value_pattern.match(str(container.getMetaDataEntry(property_name)))
+
+    # Check to see if a container matches with a string
+    def _matchString(self, container, property_name, value):
+        value = self._maybeLowercase(value)
+
+        if property_name == "id":
+            return value == self._maybeLowercase(container.getId())
+        elif property_name == "name":
+            return value == self._maybeLowercase(container.getName())
+        elif property_name == "definition":
+            try:
+                return value == container.getDefinition().getId()
+            except AttributeError:
+                return False
+
+        return value == self._maybeLowercase(str(container.getMetaDataEntry(property_name)))
+
+    # Check to see if a container matches with a specific typed property
+    def _matchType(self, container, property_name, value):
+        if property_name == "id" or property_name == "name" or property_name == "definition":
+            return False
+        elif property_name == "read_only":
+            try:
+                return value == container.isReadOnly()
+            except AttributeError:
+                return False
+
+        return value == container.getMetaDataEntry(property_name)
+
+    # Helper function to simplify ignore case handling
+    def _maybeLowercase(self, value):
+        if self._ignore_case:
+            return value.lower()
+
+        return value
+
+    # Private helper function for __hash__ and __eq__
+    def __key(self):
+        return (type(self), self._container_type, self._ignore_case, tuple(self._kwargs.items()))

--- a/UM/Signal.py
+++ b/UM/Signal.py
@@ -189,6 +189,10 @@ class Signal:
     #   \param connector The signal or slot (function) to connect.
     @call_if_enabled(_traceConnect, _isTraceEnabled())
     def connect(self, connector):
+        if self._postpone_emit:
+            Logger.log("w", "Tried to connect to signal %s that is currently being postponed, this is not possible", self.__name)
+            return
+
         with self.__lock:
             if isinstance(connector, Signal):
                 if connector == self:
@@ -209,6 +213,10 @@ class Signal:
     #   \param connector The signal or slot (function) to disconnect.
     @call_if_enabled(_traceDisconnect, _isTraceEnabled())
     def disconnect(self, connector):
+        if self._postpone_emit:
+            Logger.log("w", "Tried to disconnect from signal %s that is currently being postponed, this is not possible", self.__name)
+            return
+
         with self.__lock:
             if isinstance(connector, Signal):
                 self.__signals = self.__signals.remove(connector)
@@ -219,6 +227,10 @@ class Signal:
 
     ##  Disconnect all connected slots.
     def disconnectAll(self):
+        if self._postpone_emit:
+            Logger.log("w", "Tried to disconnect from signal %s that is currently being postponed, this is not possible", self.__name)
+            return
+
         with self.__lock:
             self.__functions = WeakImmutableList()
             self.__methods = WeakImmutablePairList()

--- a/UM/Signal.py
+++ b/UM/Signal.py
@@ -9,6 +9,7 @@ import threading
 import os
 import weakref
 import contextlib
+import traceback
 
 import functools
 
@@ -162,7 +163,10 @@ class Signal:
         # Check to see if we need to postpone emits
         if self._postpone_emit:
             if threading.current_thread() != self._postpone_thread:
-                Logger.log("w", "Tried to emit signal from thread %s while emits are being postponed by %s. This may cause errors!", threading.current_thread(), self._postpone_thread)
+                Logger.log("w", "Tried to emit signal from thread %s while emits are being postponed by %s. Traceback:", threading.current_thread(), self._postpone_thread)
+                tb = traceback.format_stack()
+                for line in tb:
+                    Logger.log("w", line)
 
             if self._compress_postpone:
                 # If emits should be compressed, we only emit the last emit that was called

--- a/UM/Signal.py
+++ b/UM/Signal.py
@@ -310,22 +310,18 @@ def postponeSignals(*signals, compress = False):
             signal._postponed = []
         signal._postponed.append((args, kwargs))
 
-    restore_emit = False
+    restore_emit = []
     for signal in signals:
-        if not hasattr(signal, "_old_emit"):
             signal._old_emit = signal.emit
             if compress:
                 signal.emit = postponedEmitCompressed.__get__(signal, Signal)
             else:
                 signal.emit = postponedEmit.__get__(signal, Signal)
-            restore_emit = True
+            restore_emit.append(signal)
 
     yield
 
-    if not restore_emit:
-        return
-
-    for signal in signals:
+    for signal in restore_emit:
         signal.emit = signal._old_emit
         delattr(signal, "_old_emit")
         if hasattr(signal, "_postponed"):

--- a/UM/Signal.py
+++ b/UM/Signal.py
@@ -119,6 +119,8 @@ class Signal:
 
         self.__type = kwargs.get("type", Signal.Auto)
 
+        self.__enabled = True
+
         if _recordSignalNames():
             try:
                 if Platform.isWindows():
@@ -132,6 +134,9 @@ class Signal:
 
     def getName(self):
         return self.__name
+
+    def setEnabled(self, enable):
+        self.__enabled = enable
 
     ##  \exception NotImplementedError
     def __call__(self):
@@ -153,6 +158,9 @@ class Signal:
     @call_if_enabled(_traceEmit, _isTraceEnabled())
     @profileEmit
     def emit(self, *args, **kwargs):
+        if not self.__enabled:
+            return
+
         try:
             if self.__type == Signal.Queued:
                 Signal._app.functionEvent(CallFunctionEvent(self.__performEmit, args, kwargs))

--- a/tests/benchmarks/Settings/BenchmarkContainerRegistry.py
+++ b/tests/benchmarks/Settings/BenchmarkContainerRegistry.py
@@ -1,0 +1,56 @@
+
+import os.path
+import pytest
+
+from UM.MimeTypeDatabase import MimeType, MimeTypeDatabase
+import UM
+import UM.Settings
+
+@pytest.fixture
+def container_registry(application):
+    MimeTypeDatabase.addMimeType(
+        MimeType(
+            name = "application/x-uranium-definitioncontainer",
+            comment = "Uranium Definition Container",
+            suffixes = ["def.json"]
+        )
+    )
+
+    MimeTypeDatabase.addMimeType(
+        MimeType(
+            name = "application/x-uranium-instancecontainer",
+            comment = "Uranium Instance Container",
+            suffixes = [ "inst.cfg" ]
+        )
+    )
+
+    MimeTypeDatabase.addMimeType(
+        MimeType(
+            name = "application/x-uranium-containerstack",
+            comment = "Uranium Container Stack",
+            suffixes = [ "stack.cfg" ]
+        )
+    )
+
+    UM.Resources.addSearchPath(os.path.realpath(os.path.join(os.path.dirname(__file__), "..", "..", "Settings")))
+    UM.Settings.ContainerRegistry._ContainerRegistry__instance = None # Reset the private instance variable every time
+    UM.PluginRegistry.getInstance().removeType("settings_container")
+
+    UM.Settings.ContainerRegistry.getInstance().load()
+
+    return UM.Settings.ContainerRegistry.getInstance()
+
+
+benchmark_findContainers_data = [
+    { "id": "basic" },
+    { "name": "Test"},
+    { "name": "T*" },
+    { "name": "Test", "category": "Test" },
+    { "name": "*", "category": "*" },
+    { "id": "*setting*" }
+]
+
+@pytest.mark.parametrize("query_args", benchmark_findContainers_data)
+def benchmark_findContainers(benchmark, container_registry, query_args):
+    result = benchmark(container_registry.findDefinitionContainers, **query_args)
+    assert len(result) >= 1


### PR DESCRIPTION
This reduces the time it takes to switch variant on an UM3 from ~14 seconds on my machine to ~1.6 seconds.

It introduces two changes: 

* A way to postpone signals so they are emitted later, with optional compression (making sure to only emit a signals once).
* A cache for queries in ContainerRegistry::findContainers.
  We make a lot of calls to findContainers, often without any of the underlying list of containers changing. By caching the result, we can improve those cases, since we do not need to execute the expensive search operation again.

This fixes CURA-3312