### PR TITLE
Disable camera control with cursor keys when >1 modifiers are pressed

### DIFF
--- a/plugins/Tools/CameraTool/CameraTool.py
+++ b/plugins/Tools/CameraTool/CameraTool.py
@@ -68,8 +68,8 @@ class CameraTool(Tool):
     #   \param event type(Event) event passed from event handler
     def checkModifierKeys(self, event):
         modifiers = QtWidgets.QApplication.keyboardModifiers()
-        self._shift_is_active = modifiers == QtCore.Qt.ShiftModifier
-        self._ctrl_is_active = modifiers == QtCore.Qt.ControlModifier
+        self._shift_is_active = (modifiers & QtCore.Qt.ShiftModifier) != QtCore.Qt.NoModifier
+        self._ctrl_is_active = (modifiers & QtCore.Qt.ControlModifier) != QtCore.Qt.NoModifier
         # Checks for the press and release event of the space key
         if event.type is Event.KeyPressEvent:
             if event.key == KeyEvent.SpaceKey:


### PR DESCRIPTION
CameraTool disables cursorkey control of the camera when the Ctrl modifier is pressed, but not when both the Ctrl and (eg) Shift modifier is pressed.

This enables eg stepping through layers in Cura faster (Ctrl + Shift + Up/Down) without affecting the camera.