### PR TITLE
CURA-3482 Handle the case where a property doesn't exist

### DIFF
--- a/UM/Settings/Models/ContainerPropertyProvider.py
+++ b/UM/Settings/Models/ContainerPropertyProvider.py
@@ -122,7 +122,7 @@ class ContainerPropertyProvider(QObject):
 
         value = self._getPropertyValue(property_name)
 
-        if self._property_values[property_name] != value:
+        if self._property_values.get(property_name, None) != value:
             self._property_values[property_name] = value
             self.propertiesChanged.emit()
 


### PR DESCRIPTION
Fixes this issue:
```
Version: 2.4.99-master.20170309034509
Platform: Windows-10-10.0.14393
Qt: 5.7.1
PyQt: 5.7.1

Exception:
Traceback (most recent call last):
  File "D:/master/build/inst/lib/python3.5/site-packages/UM\Settings\Models\ContainerPropertyProvider.py", line 75, in setKey
  File "D:/master/build/inst/lib/python3.5/site-packages/UM\Settings\Models\ContainerPropertyProvider.py", line 135, in _update
  File "D:/master/build/inst/lib/python3.5/site-packages/UM\Settings\Models\ContainerPropertyProvider.py", line 142, in _getPropertyValue
  File "D:/master/build/inst/lib/python3.5/site-packages/UM\Settings\InstanceContainer.py", line 214, in getProperty
  File "D:/master/build/inst/lib/python3.5/site-packages/UM\Settings\InstanceContainer.py", line 398, in _instantiateCachedValues
  File "D:/master/build/inst/lib/python3.5/site-packages/UM\Settings\InstanceContainer.py", line 264, in setProperty
  File "D:/master/build/inst/lib/python3.5/site-packages/UM\Settings\SettingInstance.py", line 132, in setProperty
  File "D:/master/build/inst/lib/python3.5/site-packages/UM\Signal.py", line 201, in emit
  File "D:/master/build/inst/lib/python3.5/site-packages/UM\Signal.py", line 309, in __performEmit
  File "D:/master/build/inst/lib/python3.5/site-packages/UM\Signal.py", line 201, in emit
  File "D:/master/build/inst/lib/python3.5/site-packages/UM\Signal.py", line 305, in __performEmit
  File "D:/master/build/inst/lib/python3.5/site-packages/UM\Settings\Models\ContainerPropertyProvider.py", line 125, in _onPropertyChanged
KeyError: 'value'
```