### PR TITLE
CURA-3495 Allow preRead() to take flexible arguments

### DIFF
--- a/UM/FileHandler/FileReader.py
+++ b/UM/FileHandler/FileReader.py
@@ -35,7 +35,7 @@ class FileReader(PluginObject):
     #   this function should block until it has been closed.
     #
     #   \return \type{PreReadResult} indicating if the user accepted or canceled the dialog.
-    def preRead(self, file_name):
+    def preRead(self, file_name, *args, **kwargs):
         return FileReader.PreReadResult.accepted
 
     ##  Read mesh data from file and returns a node that contains the data


### PR DESCRIPTION
`preRead()` in `ThreeMFWorkspaceReader` shows a summary dialog. We want to use `preRead()` for checking whether a file is a valid project file, so in this case, the dialog is not desired.

We change the base `preRead()` to take a flexible number of arguments, so we can pass something like a `show_dialog=True/False` argument to `ThreeMFWorkspaceReader.preRead()`.