### PR TITLE
Use Roaming instead of Local AppData on Windows

### DIFF
--- a/UM/Resources.py
+++ b/UM/Resources.py
@@ -269,7 +269,7 @@ class Resources:
         storage_dir_name = os.path.join(cls.ApplicationIdentifier, cls.ApplicationVersion)
 
         if platform.system() == "Windows":
-            cls.__config_storage_path = os.path.join(os.getenv("LOCALAPPDATA"), storage_dir_name)
+            cls.__config_storage_path = os.path.join(os.getenv("APPDATA"), storage_dir_name)
         elif platform.system() == "Darwin":
             cls.__config_storage_path = os.path.join(os.path.expanduser("~/Library/Application Support"), storage_dir_name)
             # For backward compatibility, support loading files from the old storage location


### PR DESCRIPTION
Applications should use the Roaming AppData folder for data that is supposed to follow the user around on different computers.

Followup to https://github.com/Ultimaker/Uranium/pull/216
See https://github.com/Ultimaker/Cura/issues/1369 for discussion

This changes the path for configurations, so an upgrade step needs to be implemeted. Now is a good time to make this change, since the configuration folder structure is changing anyway: https://github.com/Ultimaker/Uranium/pull/234