### PR TITLE
CURA-3648 Don't save (auth keys) certain metadata key-values during serialization

### DIFF
--- a/UM/Settings/ContainerStack.py
+++ b/UM/Settings/ContainerStack.py
@@ -51,6 +51,7 @@ class ContainerStack(ContainerInterface, PluginObject):
         self._id = str(stack_id)
         self._name = stack_id
         self._metadata = {}
+        self._metadata_serialization_excluded_keys = set()
         self._containers = []
         self._next_stack = None
         self._read_only = False
@@ -100,6 +101,9 @@ class ContainerStack(ContainerInterface, PluginObject):
     #   Reimplemented from ContainerInterface
     def getMetaData(self):
         return self._metadata
+
+    def addMetaDataSerializationExcludedKey(self, key):
+        self._metadata_serialization_excluded_keys.add(key)
 
     ##  \copydoc ContainerInterface::getMetaDataEntry
     #
@@ -232,6 +236,10 @@ class ContainerStack(ContainerInterface, PluginObject):
 
         parser["metadata"] = {}
         for key, value in self._metadata.items():
+            # skip the key-values that we don't want to save
+            if key in self._metadata_serialization_excluded_keys:
+                continue
+
             parser["metadata"][key] = str(value)
 
         parser.add_section("containers")


### PR DESCRIPTION
Add some code making it possible to exclude certain keys during serialization, so we can ignore the auth keys.
I believe this one should go to `2.5`.