### PR TITLE
Replace "Root" storage path code with QStandardPaths

### DIFF
--- a/UM/Qt/QtApplication.py
+++ b/UM/Qt/QtApplication.py
@@ -67,6 +67,9 @@ class QtApplication(QApplication, Application):
 
         super().__init__(sys.argv, **kwargs)
 
+        # Set the QCoreApplication applicationName property
+        self.setApplicationName(self.getApplicationName())
+
         self.setAttribute(Qt.AA_UseDesktopOpenGL)
         major_version, minor_version, profile = OpenGLContext.detectBestOpenGLVersion()
 

--- a/UM/Resources.py
+++ b/UM/Resources.py
@@ -278,6 +278,9 @@ class Resources:
             config_root_list.append(os.path.join(os.path.expanduser("~"), cls.ApplicationIdentifier))
             # Config storage path on OSX used to be ~/Library/Application Support/cura but changed to ~/Library/Preferences/cura for 2.6.
             config_root_list.append(os.path.normpath(QStandardPaths.writableLocation(QStandardPaths.AppDataLocation)))
+        elif Platform.isWindows():
+            # Config used to be in AppData/Local, so make sure to include that.
+            config_root_list.append(os.path.normpath(QStandardPaths.writableLocation(QStandardPaths.AppLocalDataLocation)))
 
         return config_root_list
 
@@ -298,7 +301,11 @@ class Resources:
     # Returns the path where we store different versions of app configurations
     @classmethod
     def _getConfigStorageRootPath(cls):
-        # Equals ~/.config/<appname> on Linux, ~/Library/Preferences/<appname> on OSX, ~/AppData/Local/<appname> on Windows.
+        if Platform.isWindows():
+            # Special case for Windows, since Qt treats Config as local data but we want config in Roaming.
+            return os.path.normpath(QStandardPaths.writableLocation(QStandardPaths.AppDataLocation))
+
+        # Equals ~/.config/<appname> on Linux, ~/Library/Preferences/<appname> on OSX
         return os.path.normpath(QStandardPaths.writableLocation(QStandardPaths.AppConfigLocation))
 
     # Returns the path where we store different versions of app data

--- a/UM/Resources.py
+++ b/UM/Resources.py
@@ -327,11 +327,10 @@ class Resources:
         cls.__config_storage_path = os.path.join(Resources._getConfigStorageRootPath(), storage_dir_name)
         Logger.log("d", "Config storage path is %s", cls.__config_storage_path)
 
-        data_root_path = Resources._getDataStorageRootPath()
-        cls.__data_storage_path = os.path.join(data_root_path, storage_dir_name)
+        cls.__data_storage_path = os.path.join(Resources._getDataStorageRootPath(), storage_dir_name)
         Logger.log("d", "Data storage path is %s", cls.__data_storage_path)
 
-        cache_root_path = Resources._getCacheStorageRootPath()
+        cls.__cache_storage_path = os.path.join(Resources._getCacheStorageRootPath(), storage_dir_name)
         Logger.log("d", "Cache storage path is %s", cls.__cache_storage_path)
 
         if not os.path.exists(cls.__config_storage_path):

--- a/UM/Resources.py
+++ b/UM/Resources.py
@@ -277,7 +277,7 @@ class Resources:
             # Config storage path on OSX used to be ~/.cura but changed to ~/Library/Application Support/Cura for 2.3 and later.
             config_root_list.append(os.path.join(os.path.expanduser("~"), cls.ApplicationIdentifier))
             # Config storage path on OSX used to be ~/Library/Application Support/cura but changed to ~/Library/Preferences/cura for 2.6.
-            config_root_list.append(QStandardPaths.writableLocation(QStandardPaths.AppDataLocation))
+            config_root_list.append(os.path.normpath(QStandardPaths.writableLocation(QStandardPaths.AppDataLocation)))
 
         return config_root_list
 
@@ -288,7 +288,7 @@ class Resources:
 
         if Platform.isWindows():
             # Data storage path on Windows is now ~/AppData/Roaming/cura but used to be ~/AppData/Local/cura (changed since 2.6)
-            data_root_list.append(QStandardPaths.writableLocation(QStandardPaths.AppLocalDataLocation))
+            data_root_list.append(os.path.normpath(QStandardPaths.writableLocation(QStandardPaths.AppLocalDataLocation)))
         elif Platform.isOSX():
             # Data storage path on OSX used to be ~/.cura but is now ~/Library/Application Support/Cura (changed since 2.3)
             data_root_list.append(os.path.join(os.path.expanduser("~"), cls.ApplicationIdentifier))
@@ -299,19 +299,19 @@ class Resources:
     @classmethod
     def _getConfigStorageRootPath(cls):
         # Equals ~/.config/<appname> on Linux, ~/Library/Preferences/<appname> on OSX, ~/AppData/Local/<appname> on Windows.
-        return QStandardPaths.writableLocation(QStandardPaths.AppConfigLocation)
+        return os.path.normpath(QStandardPaths.writableLocation(QStandardPaths.AppConfigLocation))
 
     # Returns the path where we store different versions of app data
     @classmethod
     def _getDataStorageRootPath(cls):
         # Equals ~/.local/share/<appname> on Linux, ~/Library/Application Support/<appname> on OSX, ~/AppData/Roaming/<appname> on Windows.
-        return QStandardPaths.writableLocation(QStandardPaths.AppDataLocation)
+        return os.path.normpath(QStandardPaths.writableLocation(QStandardPaths.AppDataLocation))
 
     # Returns the path where we store different versions of app configurations
     @classmethod
     def _getCacheStorageRootPath(cls):
         # Equals ~/.cache/<appname> on Linux, ~/Library/Caches/<appname> on OSX, ~/AppData/Local/<appname>/cache on Windows.
-        return QStandardPaths.writableLocation(QStandardPaths.CacheLocation)
+        return os.path.normpath(QStandardPaths.writableLocation(QStandardPaths.CacheLocation))
 
     @classmethod
     def __initializeStoragePaths(cls):

--- a/tests/TestResources.py
+++ b/tests/TestResources.py
@@ -24,7 +24,7 @@ class TestResources(TestCase):
             self.skipTest("not on Windows")
 
         config_root_path = Resources._getConfigStorageRootPath()
-        expected_config_root_path = os.path.join(os.getenv("LOCALAPPDATA"), "test")
+        expected_config_root_path = os.path.join(os.getenv("APPDATA"), "test")
         self.assertEqual(expected_config_root_path, config_root_path)
 
     def test_getConfigStorageRootPath_Linux(self):

--- a/tests/TestResources.py
+++ b/tests/TestResources.py
@@ -1,14 +1,20 @@
 # Copyright (c) 2017 Ultimaker B.V.
 # Uranium is released under the terms of the AGPLv3 or higher.
 
+import sys
 import os
 import platform
 from unittest import TestCase
+
+from PyQt5.QtCore import QCoreApplication
 
 from UM.Resources import Resources
 
 
 class TestResources(TestCase):
+    def setUp(self):
+        self.application = QCoreApplication(sys.argv)
+        self.application.setApplicationName("test")
 
     #
     # getConfigStorageRootPath() tests
@@ -18,37 +24,24 @@ class TestResources(TestCase):
             self.skipTest("not on Windows")
 
         config_root_path = Resources._getConfigStorageRootPath()
-        expected_config_root_path = os.getenv("APPDATA")
-        self.assertEqual(expected_config_root_path, config_root_path,
-                         "expected %s, got %s" % (expected_config_root_path, config_root_path))
+        expected_config_root_path = os.path.join(os.getenv("LOCALAPPDATA"), "test")
+        self.assertEqual(expected_config_root_path, config_root_path)
 
     def test_getConfigStorageRootPath_Linux(self):
         if platform.system() != "Linux":
             self.skipTest("not on Linux")
 
-        # no XDG_CONFIG_HOME defined
-        if "XDG_CONFIG_HOME" in os.environ:
-            del os.environ["XDG_CONFIG_HOME"]
         config_root_path = Resources._getConfigStorageRootPath()
-        expected_config_root_path = os.path.expanduser("~/.config")
-        self.assertEqual(expected_config_root_path, config_root_path,
-                         "expected %s, got %s" % (expected_config_root_path, config_root_path))
-
-        # XDG_CONFIG_HOME defined
-        os.environ["XDG_CONFIG_HOME"] = "/tmp"
-        config_root_path = Resources._getConfigStorageRootPath()
-        expected_config_root_path = "/tmp"
-        self.assertEqual(expected_config_root_path, config_root_path,
-                         "expected %s, got %s" % (expected_config_root_path, config_root_path))
+        expected_config_root_path = os.path.expanduser("~/.config/test")
+        self.assertEqual(expected_config_root_path, config_root_path)
 
     def test_getConfigStorageRootPath_Mac(self):
         if platform.system() != "Darwin":
             self.skipTest("not on mac")
 
         config_root_path = Resources._getConfigStorageRootPath()
-        expected_config_root_path = os.path.expanduser("~/Library/Application Support")
-        self.assertEqual(expected_config_root_path, config_root_path,
-                         "expected %s, got %s" % (expected_config_root_path, config_root_path))
+        expected_config_root_path = os.path.expanduser("~/Library/Preferences/test")
+        self.assertEqual(expected_config_root_path, config_root_path)
 
     #
     # getDataStorageRootPath() tests
@@ -58,33 +51,24 @@ class TestResources(TestCase):
             self.skipTest("not on Windows")
 
         data_root_path = Resources._getDataStorageRootPath()
-        self.assertIsNone(data_root_path, "expected None, got %s" % data_root_path)
+        expected_data_root_path = os.path.join(os.getenv("APPDATA"), "test")
+        self.assertEqual(expected_data_root_path, data_root_path)
 
     def test_getDataStorageRootPath_Linux(self):
         if platform.system() != "Linux":
             self.skipTest("not on Linux")
 
-        # no XDG_CONFIG_HOME defined
-        if "XDG_DATA_HOME" in os.environ:
-            del os.environ["XDG_DATA_HOME"]
-        data_root_path = Resources._getConfigStorageRootPath()
-        expected_data_root_path = os.path.expanduser("~/.local/share")
-        self.assertEqual(expected_data_root_path, data_root_path,
-                         "expected %s, got %s" % (expected_data_root_path, data_root_path))
-
-        # XDG_CONFIG_HOME defined
-        os.environ["XDG_DATA_HOME"] = "/tmp"
         data_root_path = Resources._getDataStorageRootPath()
-        expected_data_root_path = "/tmp"
-        self.assertEqual(expected_data_root_path, data_root_path,
-                         "expected %s, got %s" % (expected_data_root_path, data_root_path))
+        expected_data_root_path = os.path.expanduser("~/.local/share/test")
+        self.assertEqual(expected_data_root_path, data_root_path)
 
     def test_getDataStorageRootPath_Mac(self):
         if platform.system() != "Darwin":
             self.skipTest("not on mac")
 
         data_root_path = Resources._getDataStorageRootPath()
-        self.assertIsNone(data_root_path, "expected None, got %s" % data_root_path)
+        expected_data_root_path = os.expanduser("~/Library/Application Support/test")
+        self.assertEqual(expected_data_root_path, data_root_path)
 
     #
     # getCacheStorageRootPath() tests
@@ -94,22 +78,21 @@ class TestResources(TestCase):
             self.skipTest("not on Windows")
 
         cache_root_path = Resources._getCacheStorageRootPath()
-        expected_cache_root_path = os.getenv("LOCALAPPDATA")
-        self.assertEqual(expected_cache_root_path, cache_root_path,
-                         "expected %s, got %s" % (expected_cache_root_path, cache_root_path))
+        expected_cache_root_path = os.path.join(os.getenv("LOCALAPPDATA"), "test", "cache")
+        self.assertEqual(expected_cache_root_path, cache_root_path)
 
     def test_getCacheStorageRootPath_Linux(self):
         if platform.system() != "Linux":
             self.skipTest("not on Linux")
 
         cache_root_path = Resources._getCacheStorageRootPath()
-        expected_cache_root_path = os.path.expanduser("~/.cache")
-        self.assertEqual(expected_cache_root_path, cache_root_path,
-                         "expected %s, got %s" % (expected_cache_root_path, cache_root_path))
+        expected_cache_root_path = os.path.expanduser("~/.cache/test")
+        self.assertEqual(expected_cache_root_path, cache_root_path)
 
     def test_getCacheStorageRootPath_Mac(self):
         if platform.system() != "Darwin":
             self.skipTest("not on mac")
 
         cache_root_path = Resources._getCacheStorageRootPath()
+        expected_cache_root_path = os.path.expanduser("~/Library/Caches/test")
         self.assertIsNone("expected None, got %s" % cache_root_path)


### PR DESCRIPTION
When fixing an issue with the storage path copy code (see https://github.com/Ultimaker/Uranium/commit/1318b11eb6fad99b36da4824fc7932da0593eda3) I realized we have missed a huge opportunity when adding that code, which is to replace our custom "root" path handling code with [QStandardPaths](http://doc.qt.io/qt-5/qstandardpaths.html). This PR fixes that by using QStandardPaths for the base resource directories.

This has a few implications for the paths we use:
- On Linux, nothing changes.
- On Windows, instead of storing preferences in AppData/Roaming, we store them in AppData/Local. QStandardPaths only uses Roaming for the application data.
- On OSX, instead of storing everything in Application Support, we now store preferences in Library/Preferences, cache data in Library/Caches and data in Library/Application Support. This actually matches what Apple recommends Application do.

Since we are already messing around with paths for 2.6, I wanted to have this done before we move to beta, as it is better to only once mess up the locations.
