### PR TITLE
Time estimate per print feature

### DIFF
--- a/UM/Qt/Duration.py
+++ b/UM/Qt/Duration.py
@@ -107,3 +107,7 @@ class Duration(QObject):
             return "%02d:%02d:%02d" % (self._days * 24 + self._hours, self._minutes, self._seconds)
 
         return ""
+
+    @pyqtProperty(int, notify = durationChanged)
+    def totalSeconds(self):
+        return self._days * 3600 * 24 + self._hours * 3600 + self._minutes * 60 + self._seconds


### PR DESCRIPTION
This PR adds a function to UM.Duration which helps with creating a time estimate per print feature, like support, infill, skin, etc. That lets you know where the printer spends most of its time, so you can adjust the speeds more effectively. For example you could see that the print takes 9h but 7h of that is skin, then changing the skin speed is better than changing the outer wall speed.

The normal time estimate looks the same but it only lists the details of each print feature in the tooltip of the normal time estimate. I can't make a screenshot because it's a tooltip.

Cura: https://github.com/Ultimaker/Cura/pull/1794
CuraEngine: https://github.com/Ultimaker/CuraEngine/pull/512