### PR TITLE
Theme inheritance

### DIFF
--- a/UM/Application.py
+++ b/UM/Application.py
@@ -101,6 +101,12 @@ class Application:
 
         self._operation_stack = OperationStack(self.getController())
 
+        # Ensure configuration folder has a folder for themes
+        try:
+            os.makedirs(os.path.join(Resources.getStoragePath(Resources.Resources), "themes"))
+        except OSError:
+            pass
+
         self._plugin_registry = PluginRegistry.getInstance()
 
         self._plugin_registry.addPluginLocation(os.path.join(Application.getInstallPrefix(), "lib", "uranium"))

--- a/UM/Application.py
+++ b/UM/Application.py
@@ -101,12 +101,6 @@ class Application:
 
         self._operation_stack = OperationStack(self.getController())
 
-        # Ensure configuration folder has a folder for themes
-        try:
-            os.makedirs(os.path.join(Resources.getStoragePath(Resources.Resources), "themes"))
-        except OSError:
-            pass
-
         self._plugin_registry = PluginRegistry.getInstance()
 
         self._plugin_registry.addPluginLocation(os.path.join(Application.getInstallPrefix(), "lib", "uranium"))

--- a/UM/Qt/Bindings/Theme.py
+++ b/UM/Qt/Bindings/Theme.py
@@ -160,7 +160,14 @@ class Theme(QObject):
             Logger.log("d", "Loading theme file: %s", os.path.join(self._path, "theme.json"))
             data = json.load(f)
 
-        self._initializeDefaults()
+        # Iteratively load inherited themes
+        try:
+            theme_id = data["metadata"]["inherits"]
+            self.load(Resources.getPath(Resources.Themes, theme_id))
+        except FileNotFoundError:
+            Logger.log("e", "Could not find inherited theme %s", theme_id)
+        except KeyError:
+            pass # No metadata or no inherits keyword in the theme.json file
 
         if "colors" in data:
             for name, color in data["colors"].items():

--- a/UM/Qt/Bindings/Theme.py
+++ b/UM/Qt/Bindings/Theme.py
@@ -46,6 +46,40 @@ class Theme(QObject):
 
     themeLoaded = pyqtSignal()
 
+    @pyqtSlot(result = "QVariantList")
+    def getThemes(self):
+        themes = []
+        for path in Resources.getAllPathsForType(Resources.Themes):
+            try:
+                for file in os.listdir(path):
+                    folder = os.path.join(path, file)
+                    theme_file = os.path.join(folder, "theme.json")
+                    if os.path.isdir(folder) and os.path.isfile(theme_file):
+                        theme_id = os.path.basename(folder)
+
+                        with open(theme_file) as f:
+                            try:
+                                data = json.load(f)
+                            except json.decoder.JSONDecodeError:
+                                Logger.log("w", "Could not parse theme %s", theme_id)
+                                continue # do not add this theme to the list, but continue looking for other themes
+
+                            try:
+                                theme_name = data["metadata"]["name"]
+                            except KeyError:
+                                Logger.log("w", "Theme %s does not have a name; using its id instead", theme_id)
+                                theme_name = theme_id # fallback if no name is specified in json
+
+                        themes.append({
+                            "id": theme_id,
+                            "name": theme_name
+                        })
+            except FileNotFoundError:
+                pass
+        themes.sort(key = lambda k: k["name"])
+
+        return themes
+
     @pyqtSlot(str, result = "QColor")
     def getColor(self, color):
         if color in self._colors:

--- a/UM/Resources.py
+++ b/UM/Resources.py
@@ -498,4 +498,5 @@ class Resources:
         Cache: "",
         InstanceContainers: "instances",
         ContainerStacks: "stacks",
+        Themes: "themes",
     }


### PR DESCRIPTION
This PR implements simple theme inheritance. Themes no longer have to be complete; they can simply inherit a default theme.

A very minimal theme that only changes the background of the sidebar to read could be as simple as this theme.json file:
```
{
    "metadata": {
        "name": "Red Sidebar",
        "inherits": "cura"
    },
    "colors": {
        "sidebar": [255, 0, 0, 255]
    }
}
```

In addition to this inheritance, the PR also adds a small function to list all themes in the relevant resource locations (ie: both in the application folder and in the configuration folder). For this to be useful, a small change in Cura is required. See the separate Cura PR: https://github.com/Ultimaker/Cura/pull/1878