### PR TITLE
Make hull using points returned from ConvexHull

### DIFF
--- a/UM/Math/Polygon.py
+++ b/UM/Math/Polygon.py
@@ -322,7 +322,7 @@ class Polygon:
             except scipy.spatial.qhull.QhullError:
                 return Polygon(numpy.zeros((0, 2), numpy.float64))
 
-            return Polygon(numpy.flipud(self._points[hull.vertices]))
+            return Polygon(numpy.flipud(hull.points[hull.vertices]))
     else:
         def getConvexHull(self):
             unique = {}


### PR DESCRIPTION
This change is a no-op when using the original scipy.spatial.ConvexHull, as that implementation will return the original array in hull_result.points.

However, this change makes the code more robust and will make it operate correctly even if the underlying library returns a changed points array. I ran into this issue when creating my own version of "scipy.spatial.ConvexHull" that used a different underlying algorithm.