### PR TITLE
Prevent loading containers from "old" folders

### DIFF
--- a/UM/Settings/ContainerRegistry.py
+++ b/UM/Settings/ContainerRegistry.py
@@ -141,7 +141,7 @@ class ContainerRegistry(ContainerRegistryInterface):
     #   that were already added when the first call to this method happened will not be re-added.
     def load(self) -> None:
         files = []
-        old_file_expression = re.compile("\\" + os.sep + "old\\" + os.sep + "\d+\\" + os.sep)
+        old_file_expression = re.compile(r"\{sep}old\{sep}\d+\{sep}".format(sep = os.sep))
 
         for resource_type in self._resource_types:
             resources = Resources.getAllResourcesOfType(resource_type)

--- a/UM/Settings/ContainerRegistry.py
+++ b/UM/Settings/ContainerRegistry.py
@@ -2,7 +2,7 @@
 # Uranium is released under the terms of the AGPLv3 or higher.
 
 import os
-import re #For finding containers with asterisks in the constraints.
+import re #For finding containers with asterisks in the constraints and for detecting backup files.
 import urllib #For ensuring container file names are proper file names
 import urllib.parse
 import pickle #For serializing/deserializing Python classes to binary files
@@ -141,6 +141,8 @@ class ContainerRegistry(ContainerRegistryInterface):
     #   that were already added when the first call to this method happened will not be re-added.
     def load(self) -> None:
         files = []
+        old_file_expression = re.compile("\\" + os.sep + "old\\" + os.sep + "\d+\\" + os.sep)
+
         for resource_type in self._resource_types:
             resources = Resources.getAllResourcesOfType(resource_type)
 
@@ -152,6 +154,10 @@ class ContainerRegistry(ContainerRegistryInterface):
             # Pre-process the list of files to insert relevant data
             # Most importantly, we need to ensure the loading order is DefinitionContainer, InstanceContainer, ContainerStack
             for path in resources:
+                if old_file_expression.search(path):
+                    # This is a backup file, ignore it.
+                    continue
+
                 try:
                     mime = MimeTypeDatabase.getMimeTypeForFile(path)
                 except MimeTypeDatabase.MimeTypeNotFoundError:


### PR DESCRIPTION
This PR prevents loading containers from "old/" folders. These files are backups from the version upgrade system. 

This fixes https://github.com/Ultimaker/Cura/issues/1902, https://github.com/Ultimaker/Cura/issues/1855, https://github.com/Ultimaker/Cura/issues/1874 and many others in the forum

See https://github.com/Ultimaker/Cura/issues/1902#issuecomment-305257112