### PR TITLE
Fix system text rendering

### DIFF
--- a/UM/Qt/qml/UM/Preferences/MachinesPage.qml
+++ b/UM/Qt/qml/UM/Preferences/MachinesPage.qml
@@ -36,8 +36,8 @@ ManagementPage {
             elide: Text.ElideRight
         }
 
-        Text { text: catalog.i18nc("@label", "Type"); width: parent.width * 0.2; }
-        Text { text: base.currentItem && base.currentItem.typeName ? base.currentItem.typeName : ""; width: parent.width * 0.7; }
+        Text { text: catalog.i18nc("@label", "Type"); width: (parent.width * 0.2) | 0; }
+        Text { text: base.currentItem && base.currentItem.typeName ? base.currentItem.typeName : ""; width: (parent.width * 0.7) | 0; }
 
         UM.I18nCatalog { id: catalog; name: "uranium"; }
 

--- a/UM/Qt/qml/UM/Preferences/MachinesPage.qml
+++ b/UM/Qt/qml/UM/Preferences/MachinesPage.qml
@@ -29,15 +29,15 @@ ManagementPage {
         anchors.fill: parent;
         spacing: UM.Theme.getSize("default_margin").height;
 
-        Text {
+        Label {
             text: base.currentItem && base.currentItem.name ? base.currentItem.name : ""
             font: UM.Theme.getFont("large")
             width: parent.width
             elide: Text.ElideRight
         }
 
-        Text { text: catalog.i18nc("@label", "Type"); width: (parent.width * 0.2) | 0; }
-        Text { text: base.currentItem && base.currentItem.typeName ? base.currentItem.typeName : ""; width: (parent.width * 0.7) | 0; }
+        Label { text: catalog.i18nc("@label", "Type"); width: (parent.width * 0.2) | 0; }
+        Label { text: base.currentItem && base.currentItem.typeName ? base.currentItem.typeName : ""; width: (parent.width * 0.7) | 0; }
 
         UM.I18nCatalog { id: catalog; name: "uranium"; }
 

--- a/UM/Qt/qml/UM/Preferences/ManagementPage.qml
+++ b/UM/Qt/qml/UM/Preferences/ManagementPage.qml
@@ -82,7 +82,7 @@ PreferencesPage
                 left: parent.left;
             }
 
-            width: base.detailsVisible ? parent.width * 0.4 : parent.width;
+            width: base.detailsVisible ? (parent.width * 0.4) | 0 : parent.width;
             frameVisible: true;
 
             Rectangle {

--- a/UM/Qt/qml/UM/Preferences/PluginsPage.qml
+++ b/UM/Qt/qml/UM/Preferences/PluginsPage.qml
@@ -207,7 +207,7 @@ PreferencesPage
                 id: pluginAuthorLabel
                 //: About plugin dialog author label
                 text: catalog.i18nc("@label", "Author:");
-                width: 0.4 * parent.width
+                width: (0.4 * parent.width) | 0
                 wrapMode: Text.WordWrap
                 anchors.top: pluginCaption.bottom
                 anchors.topMargin: 10
@@ -217,7 +217,7 @@ PreferencesPage
             {
                 id: pluginAuthor;
                 text: about_window.author_text
-                width: 0.6 * parent.width
+                width: (0.6 * parent.width) | 0
                 wrapMode: Text.WordWrap
                 anchors.top: pluginCaption.bottom
                 anchors.left: pluginAuthorLabel.right

--- a/UM/Qt/qml/UM/Preferences/PreferencesDialog.qml
+++ b/UM/Qt/qml/UM/Preferences/PreferencesDialog.qml
@@ -60,11 +60,11 @@ Dialog
         StackView {
             id: stackView
             anchors {
-                left: pagesList.right;
-                leftMargin: UM.Theme.getSize("default_margin").width / 2;
-                top: parent.top;
-                bottom: parent.bottom;
-                right: parent.right;
+                left: pagesList.right
+                leftMargin: (UM.Theme.getSize("default_margin").width / 2) | 0
+                top: parent.top
+                bottom: parent.bottom
+                right: parent.right
             }
 
             initialItem: Item { property bool resetEnabled: false; }

--- a/UM/Qt/qml/UM/Preferences/PreferencesPage.qml
+++ b/UM/Qt/qml/UM/Preferences/PreferencesPage.qml
@@ -32,7 +32,7 @@ Item {
         }
     }
 
-    Text {
+    Label {
         id: titleLabel;
 
         anchors {

--- a/UM/Qt/qml/UM/Preferences/SettingVisibilityCategory.qml
+++ b/UM/Qt/qml/UM/Preferences/SettingVisibilityCategory.qml
@@ -22,7 +22,7 @@ Button {
             UM.RecolorImage
             {
                 anchors.verticalCenter: parent.verticalCenter
-                height: label.height / 2
+                height: (label.height / 2) | 0
                 width: height
                 source: control.checked ? UM.Theme.getIcon("arrow_bottom") : UM.Theme.getIcon("arrow_right");
                 color: control.hovered ? palette.highlight : palette.buttonText

--- a/UM/Qt/qml/UM/Preferences/SettingVisibilityItem.qml
+++ b/UM/Qt/qml/UM/Preferences/SettingVisibilityItem.qml
@@ -54,7 +54,7 @@ Item {
         UM.RecolorImage
         {
             anchors.centerIn: parent
-            width: check.height * 0.75
+            width: (check.height * 0.75) | 0
             height: width
 
             source: UM.Theme.getIcon("notice")

--- a/UM/Qt/qml/UM/Wizard.qml
+++ b/UM/Qt/qml/UM/Wizard.qml
@@ -121,7 +121,7 @@ UM.Dialog
                                 border.width: 0
                                 color: "transparent"
                             }
-                            label: Text
+                            label: Label
                             {
                                 id: progressText
                                 horizontalAlignment: Text.AlignHCenter

--- a/UM/Qt/qml/UM/Wizard.qml
+++ b/UM/Qt/qml/UM/Wizard.qml
@@ -148,7 +148,7 @@ UM.Dialog
                     {
                         id: progressArrow
                         anchors.top: progressButton.bottom
-                        x: (wizardProgress.width-progressArrow.width)/2
+                        x: ((wizardProgress.width - progressArrow.width) / 2) | 0
                         visible: pagesModel.get(pagesModel.count - 1) && title != pagesModel.get(pagesModel.count - 1).title ? true : false
                         UM.RecolorImage {
                             id: downArrow


### PR DESCRIPTION
This PR fixes text rendering in system-themed qml by rounding fractional widths and heights. 

Depending on window/dialog sizes, Label elements could be rendered at fractional pixel offsets. The Text.NativeRendering renderType does not handle that nicely, leading to ugly font rendering on Windows and OSX. In an attempt to fix this, some Labels were switched to Text (which uses Text.QtRendering rendertype). Unfortunately this leads to font-rendering that is distinctively non-native on Windows. Furthermore, Text does not use the system-themed colors used by Label, leading to unreadable text in dark-themed systems (black on black).

By rounding all widths/heights to whole pixels, Text.NativeRendering can be used without rendering problems.

See https://github.com/Ultimaker/Cura/issues/1748 for discussion.  

A followup Cura PR is necessary to fix all cases of fractional offsets and all uses of Text vs Label