### PR TITLE
Hide empty categories

### DIFF
--- a/UM/Settings/Models/SettingDefinitionsModel.py
+++ b/UM/Settings/Models/SettingDefinitionsModel.py
@@ -13,6 +13,7 @@ from UM.Preferences import Preferences
 from UM.Resources import Resources
 from UM.Settings import SettingRelation
 from UM.i18n import i18nCatalog
+from UM.Application import Application
 
 from UM.Settings.ContainerRegistry import ContainerRegistry
 from UM.Settings.SettingDefinition import SettingDefinition, DefinitionPropertyType
@@ -599,7 +600,8 @@ class SettingDefinitionsModel(QAbstractListModel):
                 continue
 
             if child.key in self._visible:
-                return True
+                if Application.getInstance().getGlobalContainerStack().getProperty(child.key, "enabled"):
+                    return True
 
             if self._isAnyDescendantVisible(child):
                 return True


### PR DESCRIPTION
This PR prevents showing empty category headers in the sidebar.  SettingDefinitionModel:_isAnyDescendantVisible() only checked if there are settings that are marked to be "visible" (in the Settings Visibility page), but not if they are "enabled" for the current machine. 

eg: "Enable Prime Tower" is a setting that is made visible by default, but it is disabled (hidden) with "enabled": "machine_extruder_count > 1". So you get an empty category for all single extrusion printers.

This PR fixes https://github.com/Ultimaker/Cura/issues/2126

The performance impact of this change should be checked.