### PR TITLE
Fix screen scale factor

### DIFF
--- a/UM/Qt/QtApplication.py
+++ b/UM/Qt/QtApplication.py
@@ -395,7 +395,7 @@ class QtApplication(QApplication, Application):
         if sys.platform == "darwin":
             return 1.0
         else:
-            return 1.5 #self.devicePixelRatio()
+            return self.devicePixelRatio()
 
     def _getDefaultLanguage(self, file):
         # If we have a language override set in the environment, try and use that.

--- a/UM/Qt/QtApplication.py
+++ b/UM/Qt/QtApplication.py
@@ -390,10 +390,12 @@ class QtApplication(QApplication, Application):
         return QSplashScreen(QPixmap(Resources.getPath(Resources.Images, self.getApplicationName() + ".png")))
 
     def _screenScaleFactor(self):
-        physical_dpi = QGuiApplication.primaryScreen().physicalDotsPerInch()
-        # Typically 'normal' screens have a DPI around 96. Modern high DPI screens are up around 220.
-        # We scale the low DPI screens with a traditional 1, and double the high DPI ones.
-        return 1.0 if physical_dpi < 150 else 2.0
+        # OSX handles sizes of dialogs behind our backs, but other platforms need
+        # to know about the device pixel ratio
+        if sys.platform == "darwin":
+            return 1.0
+        else:
+            return 1.5 #self.devicePixelRatio()
 
     def _getDefaultLanguage(self, file):
         # If we have a language override set in the environment, try and use that.

--- a/UM/Qt/QtApplication.py
+++ b/UM/Qt/QtApplication.py
@@ -9,7 +9,7 @@ import signal
 from PyQt5.QtCore import Qt, QCoreApplication, QEvent, QUrl, pyqtProperty, pyqtSignal, pyqtSlot, QLocale, QTranslator, QLibraryInfo, QT_VERSION_STR, PYQT_VERSION_STR
 from PyQt5.QtQml import QQmlApplicationEngine
 from PyQt5.QtWidgets import QApplication, QSplashScreen, QMessageBox, QSystemTrayIcon
-from PyQt5.QtGui import QGuiApplication, QIcon, QPixmap
+from PyQt5.QtGui import QGuiApplication, QIcon, QPixmap, QFontMetrics
 from PyQt5.QtCore import QTimer
 
 from UM.FileHandler.ReadFileJob import ReadFileJob
@@ -395,7 +395,11 @@ class QtApplication(QApplication, Application):
         if sys.platform == "darwin":
             return 1.0
         else:
-            return self.devicePixelRatio()
+            # determine a device pixel ratio from font metrics, using the same logic as UM.Theme
+            fontPixelRatio = QFontMetrics(QCoreApplication.instance().font()).ascent() / 11
+            # round the font pixel ratio to quarters
+            fontPixelRatio = int(fontPixelRatio * 4)/4
+            return fontPixelRatio
 
     def _getDefaultLanguage(self, file):
         # If we have a language override set in the environment, try and use that.

--- a/UM/Qt/qml/UM/Dialog.qml
+++ b/UM/Qt/qml/UM/Dialog.qml
@@ -13,10 +13,12 @@ Window {
     modality: Qt.ApplicationModal;
     flags: Qt.Dialog | Qt.CustomizeWindowHint | Qt.WindowTitleHint | Qt.WindowCloseButtonHint;
 
-    width: Screen.devicePixelRatio * 640;
-    height: Screen.devicePixelRatio * 480;
+    minimumWidth: screenScaleFactor * 640;
+    minimumHeight: screenScaleFactor * 480;
+    width: minimumWidth
+    height: minimumHeight
 
-    property int margin: Screen.devicePixelRatio * 8;
+    property int margin: screenScaleFactor * 8;
     property bool closeOnAccept: true;  // Automatically close the window when the window is "accepted" (eg using the return key)
 
     default property alias contents: contentItem.children;

--- a/UM/Qt/qml/UM/Preferences/PluginsPage.qml
+++ b/UM/Qt/qml/UM/Preferences/PluginsPage.qml
@@ -176,8 +176,8 @@ PreferencesPage
 
             title: catalog.i18nc("@title:window", "About %1").arg(plugin_name)
 
-            minimumWidth: Screen.devicePixelRatio * 320
-            minimumHeight: Screen.devicePixelRatio * 240
+            minimumWidth: screenScaleFactor * 320
+            minimumHeight: screenScaleFactor * 240
             width: minimumWidth
             height: minimumHeight
 
@@ -210,7 +210,7 @@ PreferencesPage
                 width: (0.4 * parent.width) | 0
                 wrapMode: Text.WordWrap
                 anchors.top: pluginCaption.bottom
-                anchors.topMargin: 10
+                anchors.topMargin: 10 * screenScaleFactor
             }
 
             Label
@@ -221,7 +221,7 @@ PreferencesPage
                 wrapMode: Text.WordWrap
                 anchors.top: pluginCaption.bottom
                 anchors.left: pluginAuthorLabel.right
-                anchors.topMargin: 10
+                anchors.topMargin: 10 * screenScaleFactor
             }
 
             Label

--- a/UM/Qt/qml/UM/Preferences/PreferencesPage.qml
+++ b/UM/Qt/qml/UM/Preferences/PreferencesPage.qml
@@ -39,7 +39,7 @@ Item {
             top: parent.top;
             left: parent.left;
             right: parent.right;
-            margins: 5;
+            margins: 5 * screenScaleFactor;
         }
 
         font.pointSize: 18;
@@ -53,7 +53,7 @@ Item {
             left: parent.left;
             right: parent.right;
             bottom: parent.bottom;
-            margins: 5;
+            margins: 5 * screenScaleFactor;
             bottomMargin: 0;
         }
 

--- a/UM/Qt/qml/UM/Preferences/RenameDialog.qml
+++ b/UM/Qt/qml/UM/Preferences/RenameDialog.qml
@@ -20,8 +20,8 @@ UM.Dialog
 
     title: dialogTitle;
 
-    minimumWidth: 400 * Screen.devicePixelRatio
-    minimumHeight: 120 * Screen.devicePixelRatio
+    minimumWidth: 400 * screenScaleFactor
+    minimumHeight: 120 * screenScaleFactor
     width: minimumWidth
     height: minimumHeight
 

--- a/UM/Qt/qml/UM/Preferences/SettingVisibilityItem.qml
+++ b/UM/Qt/qml/UM/Preferences/SettingVisibilityItem.qml
@@ -16,7 +16,7 @@ Item {
         width: height;
         height: check.height;
         anchors.right: checkboxTooltipArea.left
-        anchors.rightMargin: 2
+        anchors.rightMargin: 2 * screenScaleFactor
 
         text:
         {

--- a/examples/definition_viewer/main.qml
+++ b/examples/definition_viewer/main.qml
@@ -8,8 +8,8 @@ import Example 1.0 as Example
 ApplicationWindow
 {
     visible: true
-    width: 640
-    height: 480
+    width: 640 * screenScaleFactor
+    height: 480 * screenScaleFactor
 
     toolBar: ToolBar
     {


### PR DESCRIPTION
This PR attempts to solve the Hi DPI issues on both OSX and Windows. OSX apparently no longer needs the Screen.devicePixelRatio workaround when specifying pixel sizes, but Windows certainly does.

This PR is for testing an approach where instead of using Screen.devicePixelRatio, we use a Uranium-supplied screenScaleFactor. This context variable was introduced a couple of releases ago, but never used.

When testing, also use the related Cura PR (https://github.com/Ultimaker/Cura/pull/2484), as most occurrences where a fix is needed are in the Cura repo.

For additional discussion see https://github.com/Ultimaker/Cura/commit/7bc715a9bd5e61efcfef4b54f7d004b3f6248f5a#commitcomment-24539576
