### PR TITLE
set the font size to points instead of pixels

### DIFF
--- a/UM/Qt/Bindings/Theme.py
+++ b/UM/Qt/Bindings/Theme.py
@@ -33,7 +33,7 @@ class Theme(QObject):
             QCoreApplication.instance().setFont(default_font)
 
         self._em_height = int(QFontMetrics(QCoreApplication.instance().font()).ascent())
-        self._em_width = self._em_height;
+        self._em_width = self._em_height
 
         self._initializeDefaults()
 

--- a/UM/Qt/Bindings/Theme.py
+++ b/UM/Qt/Bindings/Theme.py
@@ -184,6 +184,7 @@ class Theme(QObject):
                     QFontDatabase.addApplicationFont(os.path.join(fontsdir, file))
 
         if "fonts" in data:
+            system_font_size = QCoreApplication.instance().font().pointSize()
             for name, font in data["fonts"].items():
                 f = QFont()
                 f.setFamily(font.get("family", QCoreApplication.instance().font().family()))
@@ -191,7 +192,7 @@ class Theme(QObject):
                 f.setBold(font.get("bold", False))
                 f.setLetterSpacing(QFont.AbsoluteSpacing, font.get("letterSpacing", 0))
                 f.setItalic(font.get("italic", False))
-                f.setPointSize(font.get("size", 1) * self._em_height)
+                f.setPointSize(int(font.get("size", 1) * system_font_size))
                 f.setCapitalization(QFont.AllUppercase if font.get("capitalize", False) else QFont.MixedCase)
 
                 self._fonts[name] = f

--- a/UM/Qt/Bindings/Theme.py
+++ b/UM/Qt/Bindings/Theme.py
@@ -191,7 +191,7 @@ class Theme(QObject):
                 f.setBold(font.get("bold", False))
                 f.setLetterSpacing(QFont.AbsoluteSpacing, font.get("letterSpacing", 0))
                 f.setItalic(font.get("italic", False))
-                f.setPixelSize(font.get("size", 1) * self._em_height)
+                f.setPointSize(font.get("size", 1) * self._em_height)
                 f.setCapitalization(QFont.AllUppercase if font.get("capitalize", False) else QFont.MixedCase)
 
                 self._fonts[name] = f

--- a/UM/Qt/qml/UM/MessageStack.qml
+++ b/UM/Qt/qml/UM/MessageStack.qml
@@ -41,7 +41,7 @@ ListView {
         border.width: UM.Theme.getSize("default_lining").width
         border.color: UM.Theme.getColor("message_border")
 
-        Text {
+        Label {
             id: messageTitle
 
             anchors {
@@ -57,7 +57,7 @@ ListView {
             wrapMode: Text.Wrap;
         }
 
-        Text {
+        Label {
             id: messageLabel
 
             anchors {


### PR DESCRIPTION
This should fix the garbled character on MacOS. Font sizes will now be calculated in points instead of pixels.