### PR TITLE
Add evaluation context processing for ContainerStack and SettingFunction

### DIFF
--- a/UM/Settings/SettingFunction.py
+++ b/UM/Settings/SettingFunction.py
@@ -76,6 +76,9 @@ class SettingFunction:
         g = {}  # type: Dict[str, Any]
         g.update(globals())
         g.update(self.__operators)
+        # override operators if there is any in the context
+        if context is not None:
+            g.update(context.context.get("override_operators", {}))
 
         try:
             return eval(self._compiled, g, locals)


### PR DESCRIPTION
CURA-4358

- Make getProperty() and getRawProperty() in ContainerStack to be
  evaluation-context-aware.
- Allow getRawProperty() to skip some containers if this info is
  provided by the context.
- SettingFunction can now override operators with those provided in the
  evaluation context.