### PR TITLE
Disallow disabling plugins by clicking their name

### DIFF
--- a/UM/Qt/qml/UM/Preferences/PluginsPage.qml
+++ b/UM/Qt/qml/UM/Preferences/PluginsPage.qml
@@ -85,6 +85,7 @@ PreferencesPage
                 {
                     id: pluginText //is a button so the user doesn't have te click inconvenientley precise to enable or disable the checkbox
                     text: model.name
+                    enabled: !model.required
                     onClicked:
                     {
                         pluginCheckbox.checked = !pluginCheckbox.checked;


### PR DESCRIPTION
This PR fixes the Plugins pane of preferences so it is no longer possible to disable required plugins by clicking on their names. Previously only the checkbox would be disabled for required plugins.

Contributes to https://github.com/Ultimaker/Cura/issues/2569