### PR TITLE
Use the Uranium logging framework to log QML warnings, instead of using stderr.

### DIFF
--- a/UM/Qt/QtApplication.py
+++ b/UM/Qt/QtApplication.py
@@ -222,6 +222,8 @@ class QtApplication(QApplication, Application):
         Bindings.register()
 
         self._engine = QQmlApplicationEngine()
+        self._engine.setOutputWarningsToStandardError(False)
+        engine.warnings.connect(self.__onQmlWarning)
 
         for path in self._qml_import_paths:
             self._engine.addImportPath(path)
@@ -236,6 +238,11 @@ class QtApplication(QApplication, Application):
 
         self._engine.load(self._main_qml)
         self.engineCreatedSignal.emit()
+
+    @pyqtSlot("QList<QQmlError>")
+    def __onQmlWarning(self, warnings):
+        for warning in warnings:
+            Logger.log("w", warning.toString())
 
     engineCreatedSignal = Signal()
 

--- a/UM/Qt/QtApplication.py
+++ b/UM/Qt/QtApplication.py
@@ -223,7 +223,7 @@ class QtApplication(QApplication, Application):
 
         self._engine = QQmlApplicationEngine()
         self._engine.setOutputWarningsToStandardError(False)
-        engine.warnings.connect(self.__onQmlWarning)
+        self._engine.warnings.connect(self.__onQmlWarning)
 
         for path in self._qml_import_paths:
             self._engine.addImportPath(path)


### PR DESCRIPTION
This fixes the problem where QML warnings/errors are not ending up in the log files on windows, making debugging harder, as they end up in the event viewer of windows, and thus are not mixed with our normal log files.