### PR TITLE
Add a function to create a QML component.

### DIFF
--- a/UM/Qt/QtApplication.py
+++ b/UM/Qt/QtApplication.py
@@ -4,10 +4,11 @@
 import sys
 import os
 import signal
+from typing import Dict, Optional
 
 
 from PyQt5.QtCore import Qt, QCoreApplication, QEvent, QUrl, pyqtProperty, pyqtSignal, pyqtSlot, QLocale, QTranslator, QLibraryInfo, QT_VERSION_STR, PYQT_VERSION_STR
-from PyQt5.QtQml import QQmlApplicationEngine
+from PyQt5.QtQml import QQmlApplicationEngine, QQmlComponent, QQmlContext
 from PyQt5.QtWidgets import QApplication, QSplashScreen, QMessageBox, QSystemTrayIcon
 from PyQt5.QtGui import QGuiApplication, QIcon, QPixmap, QFontMetrics
 from PyQt5.QtCore import QTimer
@@ -388,6 +389,28 @@ class QtApplication(QApplication, Application):
         if self._splash:
             self._splash.close()
             self._splash = None
+
+    ## Create a QML component from a qml file.
+    #  \param qml_file_path: The absolute file path to the root qml file.
+    #  \param context_properties: Optional dictionary containing the properties that will be set on the context of the qml instance before creation.
+    #  \return None in case the creation failed (qml error), else it returns the qml instance.
+    #  \note If the creation fails, this function will ensure any errors are logged to the logging service.
+    def createQmlComponent(self, qml_file_path: str, context_properties: Dict[str, "QObject"]=None) -> Optional["QObject"]
+        path = QUrl.fromLocalFile(qml_file_path)
+        component = QQmlComponent(self._engine, path)
+        result_context = QQmlContext(self._engine.rootContext())
+        if context_properties is not None:
+            for name, value in context_properties.items():
+                result_context.setContextProperty(name, value)
+        result = component.create(self.__dialog_context)
+        for err in component.errors():
+            Logger.log("e", str(err.toString()))
+        if result is None:
+            return None
+        
+        # We need to store the context with the qml object, else the context gets garbage collected and the qml objects no longer function correctly/application crashes.
+        result.attached_context = result_context
+        return result
 
     def _createSplashScreen(self):
         return QSplashScreen(QPixmap(Resources.getPath(Resources.Images, self.getApplicationName() + ".png")))


### PR DESCRIPTION
So plugins no longer have to touch our privates (_engine) and creation is done in the same way for all objects. As there are some notes/tricks to this.
I noticed that you have to keep a reference to the created "context" item, else it gets garbage collected and this causes some QML components to fail (for example buttons no longer respond to clicks).
The extension plugin example does this wrong for example:
https://github.com/Ultimaker/UraniumExampleExtensionPlugin/blob/master/ExampleExtension.py#L58
Which costed me quite some time to figure out why my qml window was misbehaving.


To give some examples for this new function, the function in the example can be replaced with:
```
    def _createDialogue(self):
        return Application.getInstance().createQmlComponent(os.path.join(PluginRegistry.getInstance().getPluginPath(self.getPluginId()), "Hello.qml"))
```
Another example, using the context_properties parameter:
https://github.com/Ultimaker/Cura/blob/master/plugins/ImageReader/ImageReaderUI.py#L81
```
    def _createConfigUI(self):
        if self._ui_view is None:
            Logger.log("d", "Creating ImageReader config UI")
            self._ui_view = Application.getInstance().createQmlComponent(QUrl.fromLocalFile(os.path.join(PluginRegistry.getInstance().getPluginPath("ImageReader"), "ConfigUI.qml"), {"manager", self})
            self._ui_view.setFlags(self._ui_view.flags() & ~Qt.WindowCloseButtonHint & ~Qt.WindowMinimizeButtonHint & ~Qt.WindowMaximizeButtonHint);

            self._disable_size_callbacks = False
```

(Note, I didn't test this function inside Uranium, only inside my plugin, so there could be a bug in this pull request, as I lack a full Cura build environment)