### PR TITLE
Fix loading values that start with a semi-colon

### DIFF
--- a/UM/Settings/InstanceContainer.py
+++ b/UM/Settings/InstanceContainer.py
@@ -425,7 +425,9 @@ class InstanceContainer(QObject, ContainerInterface, PluginObject):
         return stream.getvalue()
 
     def _readAndValidateSerialized(self, serialized: str) -> configparser.ConfigParser:
-        parser = configparser.ConfigParser(interpolation=None)
+        # Disable comments in the ini files, so text values can start with a ;
+        # without being removed as a comment
+        parser = configparser.ConfigParser(interpolation=None, comment_prefixes = ())
         parser.read_string(serialized)
 
         has_general = "general" in parser


### PR DESCRIPTION
This PR fixes loading values from INI files when they start with a semicolon, eg comments in start/end gcode.

Caveat: this removes the possibility to add comments in the INI files, since they would be considered part of the values now. In the past 2 years there has not been a single cfg.ini file in the Cura distribution that uses ; for non-value comments. 

Fixes https://github.com/Ultimaker/Cura/issues/1237