### PR TITLE
Fix a crash when a definition for a setting is not available

### DIFF
--- a/UM/Settings/Models/SettingPropertyProvider.py
+++ b/UM/Settings/Models/SettingPropertyProvider.py
@@ -351,9 +351,10 @@ class SettingPropertyProvider(QObject):
             if property_value is None:
                 if not self._validator:
                     definition = self._stack.getSettingDefinition(self._key)
-                    validator_type = SettingDefinition.getValidatorForType(definition.type)
-                    if validator_type:
-                        self._validator = validator_type(self._key)
+                    if definition:
+                        validator_type = SettingDefinition.getValidatorForType(definition.type)
+                        if validator_type:
+                            self._validator = validator_type(self._key)
                 if self._validator:
                     property_value = self._validator(self._stack)
         return str(property_value)


### PR DESCRIPTION
This PR fixes a crash when switching to a machine for which a setting is not defined which is defined for the current machine. This can happen if a machine defines settings in its def.json file.

I don't remember this being an issue in 3.0, so that would make the crash a regression.