### PR TITLE
Prevent selected children of selected nodes being transformed twice

### DIFF
--- a/UM/Tool.py
+++ b/UM/Tool.py
@@ -162,15 +162,15 @@ class Tool(PluginObject):
             nodes = Selection.getAllSelectedObjects()
             self._selected_objects_without_selected_ancestors = []
             for node in nodes:
-                hasSelectedAncestor = False
+                has_selected_ancestor = False
                 ancestor = node.getParent()
                 while ancestor:
                     if Selection.isSelected(ancestor):
-                        hasSelectedAncestor = True
+                        has_selected_ancestor = True
                         break
                     ancestor = ancestor.getParent()
 
-                if not hasSelectedAncestor:
+                if not has_selected_ancestor:
                     self._selected_objects_without_selected_ancestors.append(node)
 
         return self._selected_objects_without_selected_ancestors

--- a/UM/Tool.py
+++ b/UM/Tool.py
@@ -160,7 +160,7 @@ class Tool(PluginObject):
     def _getSelectedObjectsWithoutSelectedAncestors(self):
         if type(self._selected_objects_without_selected_ancestors) != list:
             nodes = Selection.getAllSelectedObjects()
-            _selected_objects_without_selected_ancestors = []
+            self._selected_objects_without_selected_ancestors = []
             for node in nodes:
                 hasSelectedAncestor = False
                 ancestor = node.getParent()
@@ -171,6 +171,6 @@ class Tool(PluginObject):
                     ancestor = ancestor.getParent()
 
                 if not hasSelectedAncestor:
-                    _selected_objects_without_selected_ancestors.append(node)
+                    self._selected_objects_without_selected_ancestors.append(node)
 
-        return result
+        return self._selected_objects_without_selected_ancestors

--- a/UM/Tool.py
+++ b/UM/Tool.py
@@ -31,6 +31,9 @@ class Tool(PluginObject):
         self._selection_pass = None
 
         self._controller.toolEnabledChanged.connect(self._onToolEnabledChanged)
+        Selection.selectionChanged.connect(self._onSelectionChanged)
+        self._selected_objects_without_selected_ancestors = None
+
         self._shortcut_key = None
 
     ##  Should be emitted whenever a longer running operation is started, like a drag to scale an object.
@@ -150,3 +153,24 @@ class Tool(PluginObject):
     def _onToolEnabledChanged(self, tool_id: str, enabled: bool):
         if tool_id == self._plugin_id:
             self._enabled = enabled
+
+    def _onSelectionChanged(self):
+        self._selected_objects_without_selected_ancestors = None
+
+    def _getSelectedObjectsWithoutSelectedAncestors(self):
+        if type(self._selected_objects_without_selected_ancestors) != list:
+            nodes = Selection.getAllSelectedObjects()
+            _selected_objects_without_selected_ancestors = []
+            for node in nodes:
+                hasSelectedAncestor = False
+                ancestor = node.getParent()
+                while ancestor:
+                    if Selection.isSelected(ancestor):
+                        hasSelectedAncestor = True
+                        break
+                    ancestor = ancestor.getParent()
+
+                if not hasSelectedAncestor:
+                    _selected_objects_without_selected_ancestors.append(node)
+
+        return result

--- a/plugins/Tools/MirrorTool/MirrorTool.py
+++ b/plugins/Tools/MirrorTool/MirrorTool.py
@@ -70,7 +70,7 @@ class MirrorTool(Tool):
                 else:
                     op = GroupedOperation()
 
-                    for node in Selection.getAllSelectedObjects():
+                    for node in self._getSelectedObjectsWithoutSelectedAncestors():
                         if self.getLockedAxis() == ToolHandle.XAxis:
                             mirror = Vector(-1, 1, 1)
                         elif self.getLockedAxis() == ToolHandle.YAxis:

--- a/plugins/Tools/RotateTool/RotateTool.py
+++ b/plugins/Tools/RotateTool/RotateTool.py
@@ -83,7 +83,7 @@ class RotateTool(Tool):
 
             # Save the current positions of the node, as we want to rotate around their current centres
             self._saved_node_positions = []
-            for node in Selection.getAllSelectedObjects():
+            for node in self._getSelectedObjectsWithoutSelectedAncestors():
                 self._saved_node_positions.append((node, node.getPosition()))
 
             if id == ToolHandle.XAxis:
@@ -210,7 +210,7 @@ class RotateTool(Tool):
     ##  Reset the orientation of the mesh(es) to their original orientation(s)
     def resetRotation(self):
 
-        for node in Selection.getAllSelectedObjects():
+        for node in self._getSelectedObjectsWithoutSelectedAncestors():
             node.setMirror(Vector(1,1,1))
 
         Selection.applyOperation(SetTransformOperation, None, Quaternion(), None)
@@ -225,7 +225,7 @@ class RotateTool(Tool):
 
         self._iterations = 0
         self._total_iterations = 0
-        for selected_object in Selection.getAllSelectedObjects():
+        for selected_object in self._getSelectedObjectsWithoutSelectedAncestors():
             self._layObjectFlat(selected_object)
 
         self._progress_message.show()

--- a/plugins/Tools/ScaleTool/ScaleTool.py
+++ b/plugins/Tools/ScaleTool/ScaleTool.py
@@ -66,11 +66,11 @@ class ScaleTool(Tool):
         super().event(event)
 
         if event.type == Event.ToolActivateEvent:
-            for node in Selection.getAllSelectedObjects():
+            for node in self._getSelectedObjectsWithoutSelectedAncestors():
                 node.boundingBoxChanged.connect(self.propertyChanged)
 
         if event.type == Event.ToolDeactivateEvent:
-            for node in Selection.getAllSelectedObjects():
+            for node in self._getSelectedObjectsWithoutSelectedAncestors():
                 node.boundingBoxChanged.disconnect(self.propertyChanged)
 
         # Handle modifier keys: Shift toggles snap, Control toggles uniform scaling
@@ -105,7 +105,7 @@ class ScaleTool(Tool):
 
             # Save the current positions of the node, as we want to scale arround their current centres
             self._saved_node_positions = []
-            for node in Selection.getAllSelectedObjects():
+            for node in self._getSelectedObjectsWithoutSelectedAncestors():
                 self._saved_node_positions.append((node, node.getPosition()))
 
             self._scale_sum = 0.0
@@ -296,7 +296,7 @@ class ScaleTool(Tool):
                     scale_vector = Vector(scale_factor, scale_factor, scale_factor)
 
                 op = GroupedOperation()
-                for node in Selection.getAllSelectedObjects():
+                for node in self._getSelectedObjectsWithoutSelectedAncestors():
                     op.addOperation(
                         ScaleOperation(node, scale_vector, scale_around_point=node.getWorldPosition()))
                 op.push()
@@ -317,7 +317,7 @@ class ScaleTool(Tool):
                     scale_vector = Vector(scale_factor, scale_factor, scale_factor)
 
                 op = GroupedOperation()
-                for node in Selection.getAllSelectedObjects():
+                for node in self._getSelectedObjectsWithoutSelectedAncestors():
                     op.addOperation(
                         ScaleOperation(node, scale_vector, scale_around_point=node.getWorldPosition()))
                 op.push()
@@ -338,7 +338,7 @@ class ScaleTool(Tool):
                     scale_vector = Vector(scale_factor, scale_factor, scale_factor)
 
                 op = GroupedOperation()
-                for node in Selection.getAllSelectedObjects():
+                for node in self._getSelectedObjectsWithoutSelectedAncestors():
                     op.addOperation(
                         ScaleOperation(node, scale_vector, scale_around_point=node.getWorldPosition()))
                 op.push()
@@ -358,7 +358,7 @@ class ScaleTool(Tool):
                     scale_vector = Vector(scale_factor, scale_factor, scale_factor)
 
                 op = GroupedOperation()
-                for node in Selection.getAllSelectedObjects():
+                for node in self._getSelectedObjectsWithoutSelectedAncestors():
                     op.addOperation(
                         ScaleOperation(node, scale_vector, scale_around_point=node.getWorldPosition()))
                 op.push()
@@ -378,7 +378,7 @@ class ScaleTool(Tool):
                     scale_vector = Vector(scale_factor, scale_factor, scale_factor)
 
                 op = GroupedOperation()
-                for node in Selection.getAllSelectedObjects():
+                for node in self._getSelectedObjectsWithoutSelectedAncestors():
                     op.addOperation(
                         ScaleOperation(node, scale_vector, scale_around_point=node.getWorldPosition()))
                 op.push()
@@ -398,7 +398,7 @@ class ScaleTool(Tool):
                     scale_vector = Vector(scale_factor, scale_factor, scale_factor)
 
                 op = GroupedOperation()
-                for node in Selection.getAllSelectedObjects():
+                for node in self._getSelectedObjectsWithoutSelectedAncestors():
                     op.addOperation(
                         ScaleOperation(node, scale_vector, scale_around_point=node.getWorldPosition()))
                 op.push()

--- a/plugins/Tools/TranslateTool/TranslateTool.py
+++ b/plugins/Tools/TranslateTool/TranslateTool.py
@@ -102,7 +102,7 @@ class TranslateTool(Tool):
 
         op = GroupedOperation()
         if not Float.fuzzyCompare(parsed_x, float(bounding_box.center.x), DIMENSION_TOLERANCE):
-            for selected_node in Selection.getAllSelectedObjects():
+            for selected_node in self._getSelectedObjectsWithoutSelectedAncestors():
                 world_position = selected_node.getWorldPosition()
                 new_position = world_position.set(x=parsed_x + (world_position.x - bounding_box.center.x))
                 node_op = TranslateOperation(selected_node, new_position, set_position = True)
@@ -119,7 +119,7 @@ class TranslateTool(Tool):
 
         op = GroupedOperation()
         if not Float.fuzzyCompare(parsed_y, float(bounding_box.center.z), DIMENSION_TOLERANCE):
-            for selected_node in Selection.getAllSelectedObjects():
+            for selected_node in self._getSelectedObjectsWithoutSelectedAncestors():
                 # Note; The switching of z & y is intentional. We display z as up for the user,
                 # But store the data in openGL space.
                 world_position = selected_node.getWorldPosition()
@@ -139,7 +139,7 @@ class TranslateTool(Tool):
 
         op = GroupedOperation()
         if not Float.fuzzyCompare(parsed_z, float(bounding_box.bottom), DIMENSION_TOLERANCE):
-            for selected_node in Selection.getAllSelectedObjects():
+            for selected_node in self._getSelectedObjectsWithoutSelectedAncestors():
                 # Note: The switching of z & y is intentional. We display z as up for the user,
                 # But store the data in openGL space.
                 world_position = selected_node.getWorldPosition()
@@ -161,7 +161,7 @@ class TranslateTool(Tool):
     #
     #   \param value type(bool) the setting state
     def setLockPosition(self, value):
-        for selected_node in Selection.getAllSelectedObjects():
+        for selected_node in self._getSelectedObjectsWithoutSelectedAncestors():
             selected_node.setSetting(TranslateToolSettings.LockPosition, value)
 
     def getLockPosition(self):
@@ -169,7 +169,7 @@ class TranslateTool(Tool):
         false_state_counter = 0
         true_state_counter = 0
         if Selection.hasSelection():
-            for selected_node in Selection.getAllSelectedObjects():
+            for selected_node in self._getSelectedObjectsWithoutSelectedAncestors():
 
                 if selected_node.getSetting(TranslateToolSettings.LockPosition, False):
                     true_state_counter += 1
@@ -194,11 +194,11 @@ class TranslateTool(Tool):
 
         # Make sure the displayed values are updated if the bounding box of the selected mesh(es) changes
         if event.type == Event.ToolActivateEvent:
-            for node in Selection.getAllSelectedObjects():
+            for node in self._getSelectedObjectsWithoutSelectedAncestors():
                 node.boundingBoxChanged.connect(self.propertyChanged)
 
         if event.type == Event.ToolDeactivateEvent:
-            for node in Selection.getAllSelectedObjects():
+            for node in self._getSelectedObjectsWithoutSelectedAncestors():
                 node.boundingBoxChanged.disconnect(self.propertyChanged)
 
         if event.type == Event.KeyPressEvent and event.key == KeyEvent.ShiftKey:
@@ -257,8 +257,7 @@ class TranslateTool(Tool):
                     self.operationStarted.emit(self)
 
                 op = GroupedOperation()
-                for node in Selection.getAllSelectedObjects():
-
+                for node in self._getSelectedObjectsWithoutSelectedAncestors():
                     if not node.getSetting(TranslateToolSettings.LockPosition, False):
                         op.addOperation(TranslateOperation(node, drag))
 


### PR DESCRIPTION
This PR fixes an issue where if the user selects both a child object and its parent, the child object effectively gets transformed twice. 

Steps to reproduce:
* load two objects
* group the two objects
* select the group AND one of the children (ctrl+shift-click the child)
* move/rotate/scale the selection

Expected result:
The group is transformed, and the child is automatically transformed by its parenting in the scene graph

Actual result:
The group is transformed, the child is transformed twice as much as the group

Additional info:
The issue also affects Support Eraser meshes