### PR TITLE
Show configuration errors

### DIFF
--- a/UM/ConfigurationErrorMessage.py
+++ b/UM/ConfigurationErrorMessage.py
@@ -30,7 +30,7 @@ class ConfigurationErrorMessage(Message):
         super().__init__(*args, **kwargs)
         self._faulty_containers = set()
 
-        self.addAction("reset", name = "Reset", icon = None, description = "Reset your configuration to factory defaults.")
+        self.addAction("reset", name = i18n_catalog.i18nc("@action:button", "Reset"), icon = None, description = "Reset your configuration to factory defaults.")
         self.actionTriggered.connect(self._actionTriggered)
 
     ##  Show more containers which we know are faulty.

--- a/UM/ConfigurationErrorMessage.py
+++ b/UM/ConfigurationErrorMessage.py
@@ -42,7 +42,7 @@ class ConfigurationErrorMessage(Message):
             self._faulty_containers.add(container)
 
         if initial_length != len(self._faulty_containers):
-            self.setText(i18n_catalog.i18nc("@info:status", "Your configuration seems to be corrupt. Something seems to be wrong with the following profiles: {profiles}").format(profiles = "\n".join(self._faulty_containers)))
+            self.setText(i18n_catalog.i18nc("@info:status", "Your configuration seems to be corrupt. Something seems to be wrong with the following profiles:\n- {profiles}\nWould you like to reset to factory defaults?").format(profiles = "\n- ".join(self._faulty_containers)))
             self.show()
 
     ##  Creates an instance of this class if one doesn't exist yet.

--- a/UM/ConfigurationErrorMessage.py
+++ b/UM/ConfigurationErrorMessage.py
@@ -2,10 +2,11 @@
 # Uranium is released under the terms of the LGPLv3 or higher.
 
 import itertools
-from typing import Iterable, Mapping, Union
+from typing import Iterable, Union
 
 from UM.i18n import i18nCatalog
 from UM.Message import Message
+from UM.Resources import Resources
 
 i18n_catalog = i18nCatalog("uranium")
 
@@ -28,6 +29,9 @@ class ConfigurationErrorMessage(Message):
 
         super().__init__(*args, **kwargs)
         self._faulty_containers = set()
+
+        self.addAction("reset", name = "Reset", icon = None, description = "Reset your configuration to factory defaults.")
+        self.actionTriggered.connect(self._actionTriggered)
 
     ##  Show more containers which we know are faulty.
     def addFaultyContainers(self, faulty_containers: Union[Iterable, str], *args):
@@ -53,3 +57,8 @@ class ConfigurationErrorMessage(Message):
                 title = i18n_catalog.i18nc("@info:title", "Configuration errors")
             )
         return cls._instance
+
+    def _actionTriggered(self, _, action_id):
+        if action_id == "reset":
+            Resources.factoryReset()
+            exit(1)

--- a/UM/ConfigurationErrorMessage.py
+++ b/UM/ConfigurationErrorMessage.py
@@ -1,0 +1,55 @@
+# Copyright (c) 2018 Ultimaker B.V.
+# Uranium is released under the terms of the LGPLv3 or higher.
+
+import itertools
+from typing import Iterable, Mapping, Union
+
+from UM.i18n import i18nCatalog
+from UM.Message import Message
+
+i18n_catalog = i18nCatalog("uranium")
+
+
+##  This is a specialised message that shows errors in the configuration.
+#
+#   This class coalesces all errors in the configuration. Whenever there are new
+#   errors the message gets updated (and shown if it was hidden).
+class ConfigurationErrorMessage(Message):
+    ##  This class is a singleton. You can't make it static since it needs to
+    #   inherit from UM.Message.Message.
+    _instance = None
+
+    ##  Creates an instance of this object.
+    #
+    #   This initializer forces the Singleton pattern by checking if there is an
+    #   instance first and giving an error if there is already an instance.
+    def __init__(self, *args, **kwargs):
+        assert self._instance is None and "Don't call the constructor of this Singleton! Use getInstance() instead."
+
+        super().__init__(*args, **kwargs)
+        self._faulty_containers = set()
+
+    ##  Show more containers which we know are faulty.
+    def addFaultyContainers(self, faulty_containers: Union[Iterable, str], *args):
+        initial_length = len(self._faulty_containers)
+        if isinstance(faulty_containers, str):
+            faulty_containers = [faulty_containers]
+        for container in itertools.chain(faulty_containers, args):
+            self._faulty_containers.add(container)
+
+        if initial_length != len(self._faulty_containers):
+            self.setText(i18n_catalog.i18nc("@info:status", "Your configuration seems to be corrupt. Something seems to be wrong with the following profiles: {profiles}").format(profiles = "\n".join(self._faulty_containers)))
+            self.show()
+
+    ##  Creates an instance of this class if one doesn't exist yet.
+    #
+    #   If an instance does exist, this gets that instance.
+    @classmethod
+    def getInstance(cls) -> "ConfigurationErrorMessage":
+        if cls._instance is None:
+            cls._instance = ConfigurationErrorMessage(
+                i18n_catalog.i18nc("@info:status", "Your configuration seems to be corrupt."),
+                lifetime = 0,
+                title = i18n_catalog.i18nc("@info:title", "Configuration errors")
+            )
+        return cls._instance

--- a/UM/Resources.py
+++ b/UM/Resources.py
@@ -272,16 +272,15 @@ class Resources:
         data_path = cls.getDataStoragePath()
         cache_path = cls.getCacheStoragePath()
 
-        folders_to_backup = []
-        folders_to_remove = []  # only cache folder needs to be removed
+        folders_to_backup = set()
+        folders_to_remove = set()  # only cache folder needs to be removed
 
-        folders_to_backup.append(config_path)
-        if data_path != config_path:
-            folders_to_backup.append(data_path)
+        folders_to_backup.add(config_path)
+        folders_to_backup.add(data_path)
 
         # Only remove the cache folder if it's not the same as data or config
-        if cache_path not in (config_path, data_path):
-            folders_to_remove.append(cache_path)
+        if cache_path not in folders_to_backup:
+            folders_to_remove.add(cache_path)
 
         for folder in folders_to_remove:
             shutil.rmtree(folder, ignore_errors = True)

--- a/UM/Resources.py
+++ b/UM/Resources.py
@@ -1,6 +1,7 @@
 # Copyright (c) 2018 Ultimaker B.V.
 # Uranium is released under the terms of the LGPLv3 or higher.
 
+import datetime
 import os
 import os.path
 import re
@@ -288,7 +289,6 @@ class Resources:
             base_name = os.path.basename(folder)
             root_dir = os.path.dirname(folder)
 
-            import datetime
             date_now = datetime.datetime.now().strftime("%Y%m%d_%H%M%S")
             idx = 0
             file_name = base_name + "_" + date_now

--- a/UM/Settings/ContainerStack.py
+++ b/UM/Settings/ContainerStack.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017 Ultimaker B.V.
+# Copyright (c) 2018 Ultimaker B.V.
 # Uranium is released under the terms of the LGPLv3 or higher.
 
 import configparser
@@ -8,6 +8,7 @@ from typing import Any, cast, Dict, List, Optional, Set
 from PyQt5.QtCore import QObject, pyqtProperty, pyqtSignal
 import UM.FlameProfiler
 
+from UM.ConfigurationErrorMessage import ConfigurationErrorMessage
 from UM.Settings.SettingDefinition import SettingDefinition
 from UM.Signal import Signal, signalemitter
 from UM.PluginObject import PluginObject
@@ -375,7 +376,8 @@ class ContainerStack(QObject, ContainerInterface, PluginObject):
                     containers[0].propertyChanged.connect(self._collectPropertyChanges)
                     self._containers.append(containers[0])
                 else:
-                    raise Exception("When trying to deserialize %s, we received an unknown ID (%s) for container" % (self.getId(), container_id))
+                    ConfigurationErrorMessage.getInstance().addFaultyContainers(container_id, self.getId())
+                    raise Exception("When trying to deserialize %s, we received an unknown container ID (%s)" % (self.getId(), container_id))
 
         elif parser.has_option("general", "containers"):
             # Backward compatibility with 2.3.1: The containers used to be saved in a single comma-separated list.

--- a/plugins/LocalContainerProvider/LocalContainerProvider.py
+++ b/plugins/LocalContainerProvider/LocalContainerProvider.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017 Ultimaker B.V.
+# Copyright (c) 2018 Ultimaker B.V.
 # Uranium is released under the terms of the LGPLv3 or higher.
 
 import os  # For getting the IDs from a filename.
@@ -8,6 +8,7 @@ from typing import Any, Dict, Iterable, Optional
 import urllib.parse  # For interpreting escape characters using unquote_plus.
 
 from UM.Application import Application  # To get the current version for finding the cache directory.
+from UM.ConfigurationErrorMessage import ConfigurationErrorMessage
 from UM.Settings.ContainerRegistry import ContainerRegistry  # To get the resource types for containers.
 from UM.Logger import Logger
 from UM.MimeTypeDatabase import MimeTypeDatabase, MimeType  # To get the type of container we're loading.
@@ -120,10 +121,12 @@ class LocalContainerProvider(ContainerProvider):
                 result_metadatas = clazz.deserializeMetadata(f.read(), container_id) #pylint: disable=no-member
         except IOError as e:
             Logger.log("e", "Unable to load metadata from file {filename}: {error_msg}".format(filename = filename, error_msg = str(e)))
-            raise RuntimeError("Unable to load metadata from file {filename}: {error_msg}".format(filename = filename, error_msg = str(e)))
+            ConfigurationErrorMessage.getInstance().addFaultyContainers(container_id)
+            return None
         except Exception as e:
             Logger.logException("e", "Unable to deserialize metadata for container {filename}: {container_id}: {error_msg}".format(filename = filename, container_id = container_id, error_msg = str(e)))
-            raise RuntimeError("Unable to deserialize metadata for container {filename}: {container_id}: {error_msg}".format(filename = filename, container_id = container_id, error_msg = str(e)))
+            ConfigurationErrorMessage.getInstance().addFaultyContainers(container_id)
+            return None
 
         for metadata in result_metadatas:
             if "id" not in metadata:


### PR DESCRIPTION
This introduces a ConfigurationErrorMessage class that aggregates and shows errors in the user's configuration. When deserialisation fails, the error is shown to the user.

The message also allows the user to reset their configuration to factory defaults, as a reliable (but destructive) way to recover from the error.

Implements CURA-5045.