### PR TITLE
Add support for SemVer postfixes in Version.py

### DIFF
--- a/tests/TestVersion.py
+++ b/tests/TestVersion.py
@@ -1,0 +1,24 @@
+# Copyright (c) 2018 Ultimaker B.V.
+# Uranium is released under the terms of the LGPLv3 or higher.
+
+from UM.Version import Version
+from unittest import TestCase
+
+
+class TestResources(TestCase):
+    def test_version(self):
+        self.assertTrue(Version("1.1.0") > Version("1.0.0"))
+        self.assertTrue(Version("2.1.0") > Version("1.5.0"))
+        self.assertTrue(Version("2.1.0") > Version("1.1.0"))
+        self.assertTrue(Version("1.1.2") > Version("1.1.1"))
+
+    def test_version2(self):
+        self.assertTrue(Version("1.1.0-alpha.2") > Version("1.1.0-alpha.1"))
+        self.assertFalse(Version("1.1.0-alpha.2") > Version("1.1.1-alpha.1"))
+        self.assertTrue(Version("2.1.0-beta") > Version("1.5.0"))
+        self.assertFalse(Version("1.1.2-beta.2") > Version("1.1.2.alpha.1"))
+
+    def test_malformed_versions(self):
+        v1 = Version("This is a strange version number")
+        v2 = Version("2.3.4.5-beta.2.3")
+        v1 > v2  # Just don't crash

--- a/tests/TestVersion.py
+++ b/tests/TestVersion.py
@@ -11,9 +11,11 @@ class TestResources(TestCase):
         self.assertTrue(Version("2.1.0") > Version("1.5.0"))
         self.assertTrue(Version("2.1.0") > Version("1.1.0"))
         self.assertTrue(Version("1.1.2") > Version("1.1.1"))
+        self.assertTrue(Version("1.1.2") == Version("1.1.2"))
 
     def test_version2(self):
         self.assertTrue(Version("1.1.0-alpha.2") > Version("1.1.0-alpha.1"))
+        self.assertTrue(Version("1.1.0-alpha.2") == Version("1.1.0-alpha.2"))
         self.assertFalse(Version("1.1.0-alpha.2") > Version("1.1.1-alpha.1"))
         self.assertTrue(Version("2.1.0-beta") > Version("1.5.0"))
         self.assertFalse(Version("1.1.2-beta.2") > Version("1.1.2.alpha.1"))


### PR DESCRIPTION
SemVer is not only X.X.X, but can also be X.X.X-SOMETHING.X. A version is higher when SOMETHING is the **same** as the other version and the X after SOMETHING is higher again.