### PR TITLE
Fix a startup crash when using Cura.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -45,6 +45,8 @@ add_custom_target(extract-messages ${CMAKE_SOURCE_DIR}/scripts/extract-messages 
 # Build Translations
 CREATE_TRANSLATION_TARGETS()
 
+configure_file(${CMAKE_SOURCE_DIR}/LibraryDir.py.in ${CMAKE_SOURCE_DIR}/UM/LibraryDir.py @ONLY)
+
 if(EXISTS /etc/debian_version)
     install(DIRECTORY UM DESTINATION lib${LIB_SUFFIX}/python${PYTHON_VERSION_MAJOR}/dist-packages)
 else()

--- a/LibraryDir.py.in
+++ b/LibraryDir.py.in
@@ -1,0 +1,5 @@
+# This file is generated
+# Uranium is released under the terms of the LGPLv3 or higher.
+
+# Name of the library dir
+UraniumLibraryDir = "lib@LIB_SUFFIX@"

--- a/UM/Application.py
+++ b/UM/Application.py
@@ -26,6 +26,11 @@ from UM.Workspace.WorkspaceFileHandler import WorkspaceFileHandler
 
 import UM.Settings
 
+try:
+    from UM.LibraryDir import UraniumLibraryDir
+except ImportError:
+    UraniumLibraryDir = "lib"
+
 from typing import TYPE_CHECKING, Dict, List, Callable, Any, Optional
 if TYPE_CHECKING:
     from UM.Backend.Backend import Backend
@@ -114,7 +119,7 @@ class Application:
 
         self._plugin_registry = PluginRegistry.getInstance() #type: PluginRegistry
 
-        self._plugin_registry.addPluginLocation(os.path.join(Application.getInstallPrefix(), "lib", "uranium"))
+        self._plugin_registry.addPluginLocation(os.path.join(Application.getInstallPrefix(), UraniumLibraryDir, "uranium"))
         self._plugin_registry.addPluginLocation(os.path.join(os.path.dirname(sys.executable), "plugins"))
         self._plugin_registry.addPluginLocation(os.path.join(Application.getInstallPrefix(), "Resources", "uranium", "plugins"))
         self._plugin_registry.addPluginLocation(os.path.join(Application.getInstallPrefix(), "Resources", self.getApplicationName(), "plugins"))


### PR DESCRIPTION
If LIB_SUFFIX is used when invoking CMake, we have to let Cura know where the
plugins can be found.

Fixes #347