### PR TITLE
Ignore cura.log when checking for files to be updated

### DIFF
--- a/UM/Resources.py
+++ b/UM/Resources.py
@@ -496,7 +496,7 @@ class Resources:
         temp_root_dir_path = tempfile.mkdtemp("cura-copy")
         temp_dir_path = os.path.join(temp_root_dir_path, base_dir_name)
         # src -> temp -> dest
-        shutil.copytree(src_path, temp_dir_path)
+        shutil.copytree(src_path, temp_dir_path, ignore=shutil.ignore_patterns("*.log", "old"))
         shutil.move(temp_dir_path, dest_path)
 
     @classmethod

--- a/UM/VersionUpgradeManager.py
+++ b/UM/VersionUpgradeManager.py
@@ -286,16 +286,6 @@ class VersionUpgradeManager:
                             yield UpgradeTask(storage_path = path, file_name = configuration_file,
                                               configuration_type = old_configuration_type)
 
-    def copyVersionFolder(self, src_path: str, dest_path: str) -> None:
-        Logger.log("i", "Copying directory from '%s' to '%s'", src_path, dest_path)
-        # we first copy everything to a temporary folder, and then move it to the new folder
-        base_dir_name = os.path.basename(src_path)
-        temp_root_dir_path = tempfile.mkdtemp("cura-copy")
-        temp_dir_path = os.path.join(temp_root_dir_path, base_dir_name)
-        # src -> temp -> dest
-        shutil.copytree(src_path, temp_dir_path)
-        shutil.move(temp_dir_path, dest_path)
-
     ##  Gets the version of the given file data
     def getFileVersion(self, configuration_type: str, file_data: str) -> Optional[int]:
         if configuration_type not in self._get_version_functions:

--- a/UM/VersionUpgradeManager.py
+++ b/UM/VersionUpgradeManager.py
@@ -4,6 +4,7 @@
 import collections  # For deque, for breadth-first search and to track tasks, and namedtuple.
 import os  # To get the configuration file names and to rename files.
 import traceback
+import ntpath
 from typing import Any, Dict, Callable, Iterator, List, Optional, Set, Tuple
 
 import UM.Message  # To show the "upgrade succeeded" message.
@@ -83,6 +84,11 @@ class VersionUpgradeManager:
 
         self._registry = PluginRegistry.getInstance()
         PluginRegistry.addType("version_upgrade", self._addVersionUpgrade)
+
+        self._ignored_files = ["uranium.lock", "plugins.json"]
+
+    def registerIgnoredFile(self, file: str) -> None:
+        self._ignored_files.append(file)
 
     ##  Gets the paths where a specified type of file should be stored.
     #
@@ -260,6 +266,8 @@ class VersionUpgradeManager:
                         for configuration_file in self._getFilesInDirectory(path):
                             # Get file version. Only add this upgrade task if the current file version matches with
                             # the defined version that scans through this folder.
+                            if ntpath.basename(configuration_file) in self._ignored_files:
+                                continue
                             try:
                                 with open(os.path.join(path, configuration_file), "r", encoding = "utf-8") as f:
                                     current_version = self._get_version_functions[old_configuration_type](f.read())

--- a/UM/VersionUpgradeManager.py
+++ b/UM/VersionUpgradeManager.py
@@ -85,10 +85,14 @@ class VersionUpgradeManager:
         self._registry = PluginRegistry.getInstance()
         PluginRegistry.addType("version_upgrade", self._addVersionUpgrade)
 
+        # Files that should not be checked, such as log files
         self._ignored_files = ["uranium.lock", "plugins.json"]
 
-    def registerIgnoredFile(self, file: str) -> None:
-        self._ignored_files.append(file)
+    ##  Registers a file to be ignored by version upgrade checks (eg log files).
+    #   \param file_name The base file name of the file to be ignored.
+
+    def registerIgnoredFile(self, file_name: str) -> None:
+        self._ignored_files.append(file_name)
 
     ##  Gets the paths where a specified type of file should be stored.
     #

--- a/plugins/FileLogger/FileLogger.py
+++ b/plugins/FileLogger/FileLogger.py
@@ -3,6 +3,7 @@
 
 from UM.Logger import LogOutput
 from UM.Resources import Resources
+from UM.VersionUpgradeManager import VersionUpgradeManager
 
 import logging
 import sys
@@ -18,6 +19,7 @@ class FileLogger(LogOutput):
         # location to save the log file. Instead, try and save in the settings location since
         # that should be writeable.
         self.setFileName(Resources.getStoragePath(Resources.Resources, file_name))
+        VersionUpgradeManager.getInstance().registerIgnoredFile(file_name)
 
     def setFileName(self, file_name):
         if ".log" in file_name:


### PR DESCRIPTION
This PR stops VersionUpgradeManager from opening and reading Cura.log (multiple times!) to see whether it needs updating. The application log can not be upgraded, so this is a waste of memory and cpu cycles.

Ignoring a 220 MB accumulated Cura.log file bumped the boot time down from more than 22 seconds to less than 10 on my system.