### PR TITLE
Fix the watched files feature

### DIFF
--- a/UM/Scene/Scene.py
+++ b/UM/Scene/Scene.py
@@ -6,7 +6,7 @@ import os.path  # To watch files for changes.
 import threading
 from typing import Optional, List
 
-from PyQt5.QtCore import QFileSystemWatcher  # To watch files for changes.
+from PyQt5.QtCore import QFileSystemWatcher, QFileInfo  # To watch files for changes.
 
 from UM.Decorators import deprecated
 from UM.Logger import Logger
@@ -156,7 +156,7 @@ class Scene:
 
     ##  Triggered whenever a file is changed that we currently have loaded.
     def _onFileChanged(self, file_path: str) -> None:
-        if not os.path.isfile(file_path): #File doesn't exist any more.
+        if not os.path.isfile(file_path) or os.path.getsize(file_path) == 0: #File doesn't exist any more, or it is empty
             return
 
         #Multiple nodes may be loaded from the same file at different stages. Reload them all.


### PR DESCRIPTION
Before, this feature was broken, since it showed 2 messages every time the file is modified and the "Reload" button did nothing when clicking.

Both the double message and the button are fixed in this PR.