### PR TITLE
Reduce drag distance

### DIFF
--- a/plugins/Tools/CameraTool/CameraTool.py
+++ b/plugins/Tools/CameraTool/CameraTool.py
@@ -38,7 +38,7 @@ class CameraTool(Tool):
         self._start_drag = None
         self._start_y = None
 
-        self._drag_distance = 0.05
+        self._drag_distance = 0.01
 
         Application.getInstance().getPreferences().addPreference("view/invert_zoom", False)
         Application.getInstance().getPreferences().addPreference("view/zoom_to_mouse", False)


### PR DESCRIPTION
This is a tiny tweak to make the camera more responsive when you rotate the camera.

When you right click and drag in the 3D view we only start rotating the camera if you move enough. This is because the user may want to just right click without moving the camera to access the context menu. When you right click and you don't have the hands of a surgeon, you may move the mouse cursor a few pixels while doing so but if we then start moving the camera immediately, you won't get the context menu you wanted.

It makes it slightly harder to access the context menu of the main window if you have Parkinson's disease, or just a very sensitive touch pad that makes you use a gesture to right click. But I think that was just way to wide of a drag distance and it's still pretty easy to right-click without dragging.

Some movement while right clicking is still allowed. About 10 pixels on my 1080p screen.

Try it out and see what you think.

This fixes https://github.com/Ultimaker/Cura/issues/2489.