### PR TITLE
".umplugin" added to the list of excluded extensions

### DIFF
--- a/create_plugin.py
+++ b/create_plugin.py
@@ -27,7 +27,7 @@ def zipDirectory(path, zip_handle):
                 if extension not in excluded_extentions:
                     zip_handle.write(os.path.join(root, file), os.path.relpath(os.path.join(root, file), os.path.join(path, '..')))
 
-excluded_extentions = [".pyc"]
+excluded_extentions = [".pyc", ".umplugin"]
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()


### PR DESCRIPTION
On ubuntu linux I had trouble using `create_plugin.py` since it tried to zip the newly created umplugin-file into itself until my laptop ran out of disk space.

This pr adds the extension `.umplugin` to the list of excluded extensions to solve this issue.