### PR TITLE
CURA-5621 Don't save "removed" containers

### DIFF
--- a/UM/Settings/ContainerRegistry.py
+++ b/UM/Settings/ContainerRegistry.py
@@ -535,6 +535,8 @@ class ContainerRegistry(ContainerRegistryInterface):
         with self.lockFile():
             # Save base files first
             for instance in self.findDirtyContainers(container_type = InstanceContainer):
+                if instance.getMetaDataEntry("removed") is True:
+                    continue
                 if instance.getId() == instance.getMetaData().get("base_file"):
                     self.saveContainer(instance)
 


### PR DESCRIPTION
If a dirty container was "removed," don't save it. Doing so creates copies of the file which was intended to be removed, and also they become conflicts if the user ever tries to install that package again.