### PR TITLE
Don't fallback to the global stack when checking the visibility of a

### DIFF
--- a/UM/Settings/Models/SettingDefinitionsModel.py
+++ b/UM/Settings/Models/SettingDefinitionsModel.py
@@ -611,7 +611,7 @@ class SettingDefinitionsModel(QAbstractListModel):
                 continue
 
             if child.key in self._visible:
-                if Application.getInstance().getGlobalContainerStack().getProperty(child.key, "enabled"):
+                if self._container.getProperty(child.key, "enabled"):
                     return True
 
             if self._isAnyDescendantVisible(child):


### PR DESCRIPTION
descendant setting. Instead look at the current container.