### PR TITLE
Increase APIVersion and remove OctoPrint hack

### DIFF
--- a/UM/PluginRegistry.py
+++ b/UM/PluginRegistry.py
@@ -41,7 +41,7 @@ if TYPE_CHECKING:
 #   [plugins]: docs/plugins.md
 
 class PluginRegistry(QObject):
-    APIVersion = 4
+    APIVersion = 5
 
     def __init__(self, application: "Application", parent: QObject = None) -> None:
         if PluginRegistry.__instance is not None:
@@ -400,13 +400,6 @@ class PluginRegistry(QObject):
         if self._metadata[plugin_id].get("plugin", {}).get("api", 0) != self.APIVersion:
             Logger.log("w", "Plugin %s uses an incompatible API version, ignoring", plugin_id)
             del self._metadata[plugin_id]
-            return
-
-        #HACK: For OctoPrint plug-in version 3.2.2, it broke the start-up sequence when auto-connecting.
-        #Remove this hack once we've increased the API version number to something higher than 4.
-        version = self._metadata[plugin_id].get("plugin", {}).get("version", "0.0.0")
-        if plugin_id == "OctoPrintPlugin" and Version(version) < Version("3.3.0"):
-            Logger.log("e", "Plugin OctoPrintPlugin version {version} was disabled because it was using an old API for network connection.".format(version = version))
             return
 
         try:

--- a/plugins/ConsoleLogger/plugin.json
+++ b/plugins/ConsoleLogger/plugin.json
@@ -3,6 +3,6 @@
     "author": "Ultimaker B.V.",
     "version": "1.0.0",
     "description": "Outputs log information to the console.",
-    "api": 4,
+    "api": 5,
     "i18n-catalog": "uranium"
 }

--- a/plugins/FileHandlers/OBJReader/plugin.json
+++ b/plugins/FileHandlers/OBJReader/plugin.json
@@ -3,6 +3,6 @@
     "author": "Ultimaker B.V.",
     "version": "1.0.0",
     "description": "Makes it possible to read Wavefront OBJ files.",
-    "api": 4,
+    "api": 5,
     "i18n-catalog": "uranium"
 }

--- a/plugins/FileHandlers/OBJWriter/plugin.json
+++ b/plugins/FileHandlers/OBJWriter/plugin.json
@@ -3,6 +3,6 @@
     "author": "Ultimaker B.V.",
     "version": "1.0.0",
     "description": "Makes it possible to write Wavefront OBJ files.",
-    "api": 4,
+    "api": 5,
     "i18n-catalog": "uranium"
 }

--- a/plugins/FileHandlers/STLReader/plugin.json
+++ b/plugins/FileHandlers/STLReader/plugin.json
@@ -3,6 +3,6 @@
     "author": "Ultimaker B.V.",
     "version": "1.0.0",
     "description": "Provides support for reading STL files.",
-    "api": 4,
+    "api": 5,
     "i18n-catalog": "uranium"
 }

--- a/plugins/FileHandlers/STLWriter/plugin.json
+++ b/plugins/FileHandlers/STLWriter/plugin.json
@@ -3,6 +3,6 @@
     "author": "Ultimaker B.V.",
     "version": "1.0.0",
     "description": "Provides support for writing STL files.",
-    "api": 4,
+    "api": 5,
     "i18n-catalog": "uranium"
 }

--- a/plugins/FileLogger/plugin.json
+++ b/plugins/FileLogger/plugin.json
@@ -3,6 +3,6 @@
     "author": "Ultimaker B.V.",
     "version": "1.0.0",
     "description": "Outputs log information to a file in your settings folder.",
-    "api": 4,
+    "api": 5,
     "i18n-catalog": "uranium"
 }

--- a/plugins/LocalContainerProvider/plugin.json
+++ b/plugins/LocalContainerProvider/plugin.json
@@ -3,6 +3,6 @@
     "author": "Ultimaker B.V.",
     "version": "1.0.0",
     "description": "Provides built-in setting containers that come with the installation of the application.",
-    "api": 4,
+    "api": 5,
     "i18n-catalog": "uranium"
 }

--- a/plugins/LocalFileOutputDevice/plugin.json
+++ b/plugins/LocalFileOutputDevice/plugin.json
@@ -3,6 +3,6 @@
     "description": "Enables saving to local files.",
     "author": "Ultimaker B.V.",
     "version": "1.0.0",
-    "api": 4,
+    "api": 5,
     "i18n-catalog": "uranium"
 }

--- a/plugins/Tools/CameraTool/plugin.json
+++ b/plugins/Tools/CameraTool/plugin.json
@@ -3,6 +3,6 @@
     "author": "Ultimaker B.V.",
     "version": "1.0.0",
     "description": "Provides the tool to manipulate the camera.",
-    "api": 4,
+    "api": 5,
     "i18n-catalog": "uranium"
 }

--- a/plugins/Tools/MirrorTool/plugin.json
+++ b/plugins/Tools/MirrorTool/plugin.json
@@ -3,6 +3,6 @@
     "author": "Ultimaker B.V.",
     "version": "1.0.0",
     "description": "Provides the Mirror tool.",
-    "api": 4,
+    "api": 5,
     "i18n-catalog": "uranium"
 }

--- a/plugins/Tools/RotateTool/plugin.json
+++ b/plugins/Tools/RotateTool/plugin.json
@@ -3,6 +3,6 @@
     "author": "Ultimaker B.V.",
     "version": "1.0.0",
     "description": "Provides the Rotate tool.",
-    "api": 4,
+    "api": 5,
     "i18n-catalog": "uranium"
 }

--- a/plugins/Tools/ScaleTool/plugin.json
+++ b/plugins/Tools/ScaleTool/plugin.json
@@ -3,6 +3,6 @@
     "author": "Ultimaker B.V.",
     "version": "1.0.0",
     "description": "Provides the Scale tool.",
-    "api": 4,
+    "api": 5,
     "i18n-catalog": "uranium"
 }

--- a/plugins/Tools/SelectionTool/plugin.json
+++ b/plugins/Tools/SelectionTool/plugin.json
@@ -3,6 +3,6 @@
     "author": "Ultimaker B.V.",
     "version": "1.0.0",
     "description": "Provides the Selection tool.",
-    "api": 4,
+    "api": 5,
     "i18n-catalog": "uranium"
 }

--- a/plugins/Tools/TranslateTool/plugin.json
+++ b/plugins/Tools/TranslateTool/plugin.json
@@ -3,6 +3,6 @@
     "author": "Ultimaker B.V.",
     "version": "1.0.0",
     "description": "Provides the Move tool.",
-    "api": 4,
+    "api": 5,
     "i18n-catalog": "uranium"
 }

--- a/plugins/UpdateChecker/plugin.json
+++ b/plugins/UpdateChecker/plugin.json
@@ -3,6 +3,6 @@
     "author": "Ultimaker B.V.",
     "version": "1.0.0",
     "description": "Checks for updates of the software.",
-    "api": 4,
+    "api": 5,
     "i18n-catalog": "uranium"
 }

--- a/plugins/Views/SimpleView/plugin.json
+++ b/plugins/Views/SimpleView/plugin.json
@@ -3,6 +3,6 @@
     "author": "Ultimaker B.V.",
     "version": "1.0.0",
     "description": "Provides a simple solid mesh view.",
-    "api": 4,
+    "api": 5,
     "i18n-catalog": "uranium"
 }

--- a/tests/PluginRegistry/EmptyPlugin/plugin.json
+++ b/tests/PluginRegistry/EmptyPlugin/plugin.json
@@ -1,5 +1,5 @@
 {
     "name": "EmptyPlugin",
-    "api": 4,
+    "api": 5,
     "version": "1.0.0"
 }

--- a/tests/PluginRegistry/PluginNoVersionNumber/plugin.json
+++ b/tests/PluginRegistry/PluginNoVersionNumber/plugin.json
@@ -1,4 +1,4 @@
 {
     "name": "PluginNoVersionNumber",
-    "api": 4
+    "api": 5
 }

--- a/tests/PluginRegistry/TestNested/TestPlugin2/plugin.json
+++ b/tests/PluginRegistry/TestNested/TestPlugin2/plugin.json
@@ -1,5 +1,5 @@
 {
     "name": "TestPlugin2",
-    "api": 4,
+    "api": 5,
     "version": "1.0.0"
 }

--- a/tests/PluginRegistry/TestPlugin/plugin.json
+++ b/tests/PluginRegistry/TestPlugin/plugin.json
@@ -1,5 +1,5 @@
 {
     "name": "TestPlugin",
-    "api": 4,
+    "api": 5,
     "version": "1.0.0"
 }

--- a/tests/Settings/ContainerTestPlugin/plugin.json
+++ b/tests/Settings/ContainerTestPlugin/plugin.json
@@ -1,5 +1,5 @@
 {
     "name": "TestContainerPlugin",
-    "api": 4,
+    "api": 5,
     "version": "1.0.0"
 }


### PR DESCRIPTION
This PR increases the API Version and removes a hack to disallow certain versions of the OctoPrint plugin.

Commit 46b6c7e33e08154260db17eb1b8707604fa66d99 changed the way metadata for container stacks is handled in a way that makes certain plugins (such as the OctoPrintPlugin) incompatible with master. I can change my plugins to be compatible again, but I cannot change the 10k+ installations already in the field, so these must be invalidated by changing the plugin API version*. This means that all plugins must be updated before the next release (even if only updating their API versions, if there are no other incompatibilities).

*: note that I have already implemented a precaution in OctoPrintPlugin so it does not load with versions of Cura it has not been tested against at the time of releasing the plugin. So there will not be crashing Cura installs due to this issue, and all users must update their OctoPrintPlugin for the next release of Cura.