### PR TITLE
QtApplication: Set Qt theme only when application is frozen

### DIFF
--- a/UM/Qt/QtApplication.py
+++ b/UM/Qt/QtApplication.py
@@ -122,8 +122,10 @@ class QtApplication(QApplication, Application):
         self._mesh_file_handler = MeshFileHandler(self) #type: MeshFileHandler
         self._workspace_file_handler = WorkspaceFileHandler(self) #type: WorkspaceFileHandler
 
-        # Remove this and you will get Windows 95 style for all widgets if you are using Qt 5.10+
-        self.setStyle("fusion")
+        # The following workaround is only meant to be used with Ultimaker's software distributions
+        if hasattr(sys, 'frozen'):
+            # Remove this and you will get Windows 95 style for all widgets if you are using Qt 5.10+
+            self.setStyle("fusion")
 
         self.setAttribute(Qt.AA_UseDesktopOpenGL)
         major_version, minor_version, profile = OpenGLContext.detectBestOpenGLVersion()


### PR DESCRIPTION
Together with the PPA on Ubuntu/Linux the problem does not occur, because the system theme is properly fetched without this line being applied.
This simple check should avoid that the workaround is applied, when installing Cura via PPA on Ubuntu/Linux.