### PR TITLE
Complete Polish translation for version 3.5

### DIFF
--- a/resources/i18n/pl_PL/uranium.po
+++ b/resources/i18n/pl_PL/uranium.po
@@ -8,15 +8,15 @@ msgstr ""
 "Project-Id-Version: Uranium 3.5\n"
 "Report-Msgid-Bugs-To: r.dulek@ultimaker.com\n"
 "POT-Creation-Date: 2018-09-19 17:07+0200\n"
-"PO-Revision-Date: 2018-03-30 20:39+0200\n"
-"Last-Translator: 'Jaguś' Paweł Jagusiak and Andrzej 'anraf1001' Rafalski\n"
+"PO-Revision-Date: 2018-09-21 22:02+0200\n"
+"Last-Translator: 'Jaguś' Paweł Jagusiak, Andrzej 'anraf1001' Rafalski and Jakub 'drzejkopf' Świeciński\n"
 "Language-Team: reprapy.pl\n"
 "Language: pl_PL\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
-"X-Generator: Poedit 2.0.6\n"
+"X-Generator: Poedit 2.1.1\n"
 
 #: /home/ruben/Projects/Uranium/plugins/Views/SimpleView/__init__.py:12
 msgctxt "@item:inmenu"
@@ -37,13 +37,13 @@ msgstr "Plik Wavefront OBJ"
 #: /home/ruben/Projects/Uranium/plugins/FileHandlers/OBJWriter/OBJWriter.py:23
 msgctxt "@error:not supported"
 msgid "OBJWriter does not support non-text mode."
-msgstr ""
+msgstr "Zapisywacz OBJ Nie obsługuje trybu nietekstowego."
 
 #: /home/ruben/Projects/Uranium/plugins/FileHandlers/OBJWriter/OBJWriter.py:30
 #: /home/ruben/Projects/Uranium/plugins/FileHandlers/STLWriter/STLWriter.py:27
 msgctxt "@error:no mesh"
 msgid "There is no mesh to write."
-msgstr ""
+msgstr "Nie ma siatki do zapisania."
 
 #: /home/ruben/Projects/Uranium/plugins/FileHandlers/STLWriter/__init__.py:17
 msgctxt "@item:inlistbox"
@@ -58,7 +58,7 @@ msgstr "Plik STL (Binarny)"
 #: /home/ruben/Projects/Uranium/plugins/FileHandlers/STLWriter/STLWriter.py:36
 msgctxt "@error:not supported"
 msgid "Unsupported output mode writing STL to stream."
-msgstr ""
+msgstr "Nieobsługiwany tryb wyjściowy zapisu STL do strumienia."
 
 #: /home/ruben/Projects/Uranium/plugins/UpdateChecker/UpdateCheckerJob.py:42
 msgctxt "@info"
@@ -89,13 +89,13 @@ msgstr "Ostrzeżenie"
 #, python-brace-format
 msgctxt "@info:status"
 msgid "Cura {0} is available!"
-msgstr ""
+msgstr "Cura {0} jest dostępna!"
 
 #: /home/ruben/Projects/Uranium/plugins/UpdateChecker/UpdateCheckerJob.py:73
 #, python-brace-format
 msgctxt "@info:status"
 msgid "Cura {0} provides better and reliable printing experience."
-msgstr ""
+msgstr "Cura {0} zapewnia lepsze i bardziej niezawodne drukowanie."
 
 #: /home/ruben/Projects/Uranium/plugins/UpdateChecker/UpdateCheckerJob.py:76
 msgctxt "@action:button"
@@ -105,7 +105,7 @@ msgstr "Pobierz"
 #: /home/ruben/Projects/Uranium/plugins/UpdateChecker/UpdateCheckerJob.py:78
 msgctxt "@action:button"
 msgid "Learn more about new features"
-msgstr ""
+msgstr "Dowiedz się więcej o nowych funkcjach"
 
 #: /home/ruben/Projects/Uranium/plugins/UpdateChecker/UpdateCheckerJob.py:94
 msgctxt "@info"
@@ -310,11 +310,13 @@ msgid ""
 "There were some errors uninstalling the following packages:\n"
 "{packages}"
 msgstr ""
+"Wystąpiły błędy podczas odinstalowywania następujących pakietów:\n"
+"{packages}"
 
 #: /home/ruben/Projects/Uranium/UM/PackageManager.py:128
 msgctxt "@info:title"
 msgid "Uninstalling errors"
-msgstr ""
+msgstr "Błędy odinstalowywania"
 
 #: /home/ruben/Projects/Uranium/UM/PackageManager.py:335
 #, python-brace-format
@@ -324,11 +326,14 @@ msgid ""
 "{error}.\n"
 "Please try to upgrade again later."
 msgstr ""
+"Wystąpił błąd podczas odinstalowywania pakietu {package} przed instalacją nowej wersji:\n"
+"{error}.\n"
+"Spróbuj zaktualizować ponownie później."
 
 #: /home/ruben/Projects/Uranium/UM/PackageManager.py:338
 msgctxt "@info:title"
 msgid "Updating error"
-msgstr ""
+msgstr "Błąd aktualizacji"
 
 #: /home/ruben/Projects/Uranium/UM/Qt/Duration.py:111
 #, python-brace-format
@@ -445,6 +450,9 @@ msgid ""
 "- {profiles}\n"
 "Would you like to reset to factory defaults? Reset will remove all your current printers and profiles."
 msgstr ""
+"Twoja konfiguracja wygląda na uszkodzoną. Coś jest nie tak z następującymi profilami:\n"
+"- {profiles}\n"
+"Czy chcesz przywrócić ustawienia fabryczne? Przywracanie usunie wszystkie bieżące drukarki i profile."
 
 #: /home/ruben/Projects/Uranium/UM/Scene/Scene.py:167
 #, python-brace-format


### PR DESCRIPTION
Translation was incomplete, phrases related to functions implemented after version 3.3 were missing. I have translated all missing phrases in Polish translation of files cura.po, uranium.po and fdmprinter.def.json.po. For now, translation is complete. I tried running it on Cura 3.5 beta and I can't encounter any issues.