### PR TITLE
Remove unused import and declaration of i18n in plugins

### DIFF
--- a/plugins/ConsoleLogger/__init__.py
+++ b/plugins/ConsoleLogger/__init__.py
@@ -4,9 +4,6 @@
 #Shoopdawoop
 from . import ConsoleLogger
 
-from UM.i18n import i18nCatalog
-i18n_catalog = i18nCatalog("uranium")
-
 
 def getMetaData():
     return {}

--- a/plugins/FileLogger/__init__.py
+++ b/plugins/FileLogger/__init__.py
@@ -4,8 +4,6 @@
 #Shoopdawoop
 from . import FileLogger
 
-from UM.i18n import i18nCatalog
-i18n_catalog = i18nCatalog("uranium")
 
 def getMetaData():
     return {

--- a/plugins/LocalFileOutputDevice/__init__.py
+++ b/plugins/LocalFileOutputDevice/__init__.py
@@ -3,8 +3,6 @@
 
 from . import LocalFileOutputDevicePlugin
 
-from UM.i18n import i18nCatalog
-catalog = i18nCatalog("uranium")
 
 def getMetaData():
     return {

--- a/plugins/Tools/CameraTool/__init__.py
+++ b/plugins/Tools/CameraTool/__init__.py
@@ -3,8 +3,6 @@
 
 from . import CameraTool
 
-from UM.i18n import i18nCatalog
-i18n_catalog = i18nCatalog("uranium")
 
 def getMetaData():
     return {

--- a/plugins/Tools/SelectionTool/__init__.py
+++ b/plugins/Tools/SelectionTool/__init__.py
@@ -3,8 +3,6 @@
 
 from . import SelectionTool
 
-from UM.i18n import i18nCatalog
-i18n_catalog = i18nCatalog("uranium")
 
 def getMetaData():
     return {

--- a/plugins/UpdateChecker/__init__.py
+++ b/plugins/UpdateChecker/__init__.py
@@ -3,8 +3,6 @@
 
 from . import UpdateChecker
 
-from UM.i18n import i18nCatalog
-i18n_catalog = i18nCatalog("uranium")
 
 def getMetaData():
     return {


### PR DESCRIPTION
This PR removes unused imports and declaration of i18n in plugins. There's also a PR for Cura that does the same thing there.