### PR TITLE
Improve lock file management in Windows

### DIFF
--- a/UM/Application.py
+++ b/UM/Application.py
@@ -63,6 +63,8 @@ class Application:
         self._is_headless = False #type: bool
         self._use_external_backend = False #type: bool
 
+        self.CONFIG_LOCK_FILENAME = "{name}.lock".format(name = self._app_name)
+
         self._cli_args = None #type: argparse.Namespace
         self._cli_parser = argparse.ArgumentParser(prog = self._app_name, add_help = False) #type: argparse.ArgumentParser
 

--- a/UM/Application.py
+++ b/UM/Application.py
@@ -63,7 +63,7 @@ class Application:
         self._is_headless = False #type: bool
         self._use_external_backend = False #type: bool
 
-        self.CONFIG_LOCK_FILENAME = "{name}.lock".format(name = self._app_name) # type: str
+        self._config_lock_filename = "{name}.lock".format(name = self._app_name) # type: str
 
         self._cli_args = None #type: argparse.Namespace
         self._cli_parser = argparse.ArgumentParser(prog = self._app_name, add_help = False) #type: argparse.ArgumentParser
@@ -215,7 +215,7 @@ class Application:
 
     ##  Get the lock filename
     def getApplicationLockFilename(self) -> str:
-        return self.CONFIG_LOCK_FILENAME
+        return self._config_lock_filename
 
     ##  Emitted when the application window was closed and we need to shut down the application
     applicationShuttingDown = Signal()

--- a/UM/Application.py
+++ b/UM/Application.py
@@ -63,7 +63,7 @@ class Application:
         self._is_headless = False #type: bool
         self._use_external_backend = False #type: bool
 
-        self.CONFIG_LOCK_FILENAME = "{name}.lock".format(name = self._app_name)
+        self.CONFIG_LOCK_FILENAME = "{name}.lock".format(name = self._app_name) # type: str
 
         self._cli_args = None #type: argparse.Namespace
         self._cli_parser = argparse.ArgumentParser(prog = self._app_name, add_help = False) #type: argparse.ArgumentParser
@@ -212,6 +212,10 @@ class Application:
 
     def getContainerRegistry(self):
         return self._container_registry
+
+    ##  Get the lock filename
+    def getApplicationLockFilename(self) -> str:
+        return self.CONFIG_LOCK_FILENAME
 
     ##  Emitted when the application window was closed and we need to shut down the application
     applicationShuttingDown = Signal()

--- a/UM/LockFile.py
+++ b/UM/LockFile.py
@@ -43,10 +43,11 @@ class LockFile:
                 try:
                     os.remove(self._filename)
                 except Exception as e:
+                    stats = None
                     try:
                         stats = os.stat(self._filename)
                     except:
-                        stats = None
+                        pass
                     raise RuntimeError("Failed to remove lock file with stats = {stats}. Exception: {exception}".format(stats = stats, exception = e))
             open_flags = (os.O_CREAT | os.O_EXCL | os.O_WRONLY)
             open_mode = 0o666

--- a/UM/Settings/ContainerRegistry.py
+++ b/UM/Settings/ContainerRegistry.py
@@ -628,11 +628,11 @@ class ContainerRegistry(ContainerRegistryInterface):
     ##  Get the lock filename including full path
     #   Dependent on when you call this function, Resources.getConfigStoragePath may return different paths
     def getLockFilename(self) -> str:
-        return Resources.getStoragePath(Resources.Resources, self._application.CONFIG_LOCK_FILENAME)
+        return Resources.getStoragePath(Resources.Resources, self._application.getApplicationLockFilename())
 
     ##  Get the cache lock filename including full path.
     def getCacheLockFilename(self) -> str:
-        return Resources.getStoragePath(Resources.Cache, self._application.CONFIG_LOCK_FILENAME)
+        return Resources.getStoragePath(Resources.Cache, self._application.getApplicationLockFilename())
 
     ##  Contextmanager to create a lock file and remove it afterwards.
     def lockFile(self) -> LockFile:

--- a/UM/Settings/ContainerRegistry.py
+++ b/UM/Settings/ContainerRegistry.py
@@ -30,8 +30,6 @@ if TYPE_CHECKING:
     from UM.PluginObject import PluginObject
     from UM.Qt.QtApplication import QtApplication
 
-CONFIG_LOCK_FILENAME = "uranium.lock"
-
 # The maximum amount of query results we should cache
 MaxQueryCacheSize = 1000
 
@@ -630,11 +628,11 @@ class ContainerRegistry(ContainerRegistryInterface):
     ##  Get the lock filename including full path
     #   Dependent on when you call this function, Resources.getConfigStoragePath may return different paths
     def getLockFilename(self) -> str:
-        return Resources.getStoragePath(Resources.Resources, CONFIG_LOCK_FILENAME)
+        return Resources.getStoragePath(Resources.Resources, self._application.CONFIG_LOCK_FILENAME)
 
     ##  Get the cache lock filename including full path.
     def getCacheLockFilename(self) -> str:
-        return Resources.getStoragePath(Resources.Cache, CONFIG_LOCK_FILENAME)
+        return Resources.getStoragePath(Resources.Cache, self._application.CONFIG_LOCK_FILENAME)
 
     ##  Contextmanager to create a lock file and remove it afterwards.
     def lockFile(self) -> LockFile:

--- a/UM/VersionUpgradeManager.py
+++ b/UM/VersionUpgradeManager.py
@@ -84,14 +84,14 @@ class VersionUpgradeManager:
         PluginRegistry.addType("version_upgrade", self._addVersionUpgrade)
 
         # Regular expresions of the files that should not be checked, such as log files
-        self._ignored_files = ["^.*\.lock$", "^plugins\.json$", "^\.log$"]  # type: List[str]
+        self._ignored_files = ["^.*\.lock$", "^plugins\.json$", "^.*\.log$"]  # type: List[str]
 
     ##  Registers a file to be ignored by version upgrade checks (eg log files).
     #   \param file_name The base file name of the file to be ignored.
 
     def registerIgnoredFile(self, file_name: str) -> None:
         # Convert the file name to a regular expresion to add to the ignored files
-        file_name_regex = "^" + file_name.replace(".", "\.") + "$"
+        file_name_regex = "^" + re.escape(file_name) + "$"
         self._ignored_files.append(file_name_regex)
 
     ##  Gets the paths where a specified type of file should be stored.

--- a/UM/VersionUpgradeManager.py
+++ b/UM/VersionUpgradeManager.py
@@ -3,8 +3,8 @@
 
 import collections  # For deque, for breadth-first search and to track tasks, and namedtuple.
 import os  # To get the configuration file names and to rename files.
+import re
 import traceback
-import ntpath
 from typing import Any, Dict, Callable, Iterator, List, Optional, Set, Tuple
 
 import UM.Message  # To show the "upgrade succeeded" message.
@@ -83,14 +83,16 @@ class VersionUpgradeManager:
         self._registry = PluginRegistry.getInstance()   # type: PluginRegistry
         PluginRegistry.addType("version_upgrade", self._addVersionUpgrade)
 
-        # Files that should not be checked, such as log files
-        self._ignored_files = ["uranium.lock", "plugins.json"]  # type: List[str]
+        # Regular expresions of the files that should not be checked, such as log files
+        self._ignored_files = ["^.*\.lock$", "^plugins\.json$", "^\.log$"]  # type: List[str]
 
     ##  Registers a file to be ignored by version upgrade checks (eg log files).
     #   \param file_name The base file name of the file to be ignored.
 
     def registerIgnoredFile(self, file_name: str) -> None:
-        self._ignored_files.append(file_name)
+        # Convert the file name to a regular expresion to add to the ignored files
+        file_name_regex = "^" + file_name.replace(".", "\.") + "$"
+        self._ignored_files.append(file_name_regex)
 
     ##  Gets the paths where a specified type of file should be stored.
     #
@@ -260,6 +262,7 @@ class VersionUpgradeManager:
         for key in self._storage_paths:
             self._storage_paths[key] = collections.OrderedDict(sorted(self._storage_paths[key].items()))
 
+        combined_regex_ignored_files = "(" + ")|(".join(self._ignored_files) + ")"
         for old_configuration_type, version_storage_paths_dict in self._storage_paths.items():
             for src_version, storage_paths in version_storage_paths_dict.items():
                 for prefix in storage_path_prefixes:
@@ -268,7 +271,7 @@ class VersionUpgradeManager:
                         for configuration_file in self._getFilesInDirectory(path):
                             # Get file version. Only add this upgrade task if the current file version matches with
                             # the defined version that scans through this folder.
-                            if ntpath.basename(configuration_file) in self._ignored_files:
+                            if re.match(combined_regex_ignored_files, configuration_file):
                                 continue
                             try:
                                 with open(os.path.join(path, configuration_file), "r", encoding = "utf-8") as f:

--- a/tests/Settings/conftest.py
+++ b/tests/Settings/conftest.py
@@ -8,9 +8,7 @@ import os.path
 import pytest
 import unittest.mock #For mocking the container provider priority.
 
-from UM.Application import Application
 from UM.PluginRegistry import PluginRegistry
-from UM.Signal import Signal
 from UM.VersionUpgradeManager import VersionUpgradeManager
 from UM.Resources import Resources
 from UM.MimeTypeDatabase import MimeType, MimeTypeDatabase

--- a/tests/TestTools.py
+++ b/tests/TestTools.py
@@ -8,11 +8,8 @@ from UM.Controller import Controller
 from UM.Tool import Tool
 
 
-def test_tools():
-    mock_application = MagicMock()
-
-    Application.getInstance = MagicMock(return_type = mock_application)
-    controller = Controller(mock_application)
+def test_tools(application):
+    controller = Controller(application)
 
     # Switch out the emits with a mock.
     controller.toolsChanged.emit = MagicMock()
@@ -36,7 +33,7 @@ def test_tools():
     assert controller.toolsChanged.emit.call_count == 2
     assert len(controller.getAllTools()) == 2
 
-    # Set if with an unknown name.
+    # Set active tool with an unknown name.
     controller.setActiveTool("nope nope!")
     assert controller.getActiveTool() is None
     assert controller.activeToolChanged.emit.call_count == 0
@@ -59,12 +56,3 @@ def test_tools():
     assert controller.getTool("ZOMG") is None
     assert controller.getTool("test_tool_1") == test_tool_1
     assert controller.getTool("test_tool_2") == test_tool_2
-
-
-
-
-
-
-
-
-

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,9 +1,12 @@
 # Copyright (c) 2018 Ultimaker B.V.
 # Uranium is released under the terms of the LGPLv3 or higher.
+from typing import cast
+from unittest.mock import MagicMock
 
 import pytest
 from UM.Qt.QtApplication import QtApplication #QTApplication import is required, even though it isn't used.
 from UM.Application import Application
+from UM.Qt.QtRenderer import QtRenderer
 from UM.Signal import Signal
 from UM.PluginRegistry import PluginRegistry
 from UM.VersionUpgradeManager import VersionUpgradeManager
@@ -24,6 +27,9 @@ class FixtureApplication(Application):
 
     def processEvents(self):
         pass
+
+    def getRenderer(self):
+        return MagicMock()
 
 @pytest.fixture()
 def application():


### PR DESCRIPTION
The Windows API is now used to create and delete the lock file. This file is now created with a flag DELETE_ON_CLOSE that deletes the file when closing or when the application gets interrupted.