### PR TITLE
[3.5][regression] Make sure visible rows are updated before trying to get index of a setting

### DIFF
--- a/UM/Settings/Models/SettingDefinitionsModel.py
+++ b/UM/Settings/Models/SettingDefinitionsModel.py
@@ -370,6 +370,11 @@ class SettingDefinitionsModel(QAbstractListModel):
 
         index = self._definition_list.index(definitions[0])
 
+        # Make sure self._row_index_list is populated
+        if self._update_visible_row_scheduled:
+            self._update_visible_row_scheduled = False
+            self._updateVisibleRows()
+
         try:
             return self._row_index_list.index(index)
         except ValueError:


### PR DESCRIPTION
This PR fixes the behavior of the "manage visible settings" button, when pressing the "cog" icon of a category in Cura.

This PR fixes ... hmm... can't find the issue. Has been reported in the forum, but don't know if it has been reported properly.

The issue is that when you press the "cog", Cura 3.5 no longer scrolls the SettingVisibility page to the category corresponding to the clicked cog.

Would be good if this could be merged into 3.5.1