### PR TITLE
Only show update once

### DIFF
--- a/plugins/UpdateChecker/UpdateChecker.py
+++ b/plugins/UpdateChecker/UpdateChecker.py
@@ -31,7 +31,7 @@ class UpdateChecker(Extension):
 
         self._download_url = None
 
-        #Which version was the latest shown in the version upgrade dialog. Don't show these updates twice.
+        # Which version was the latest shown in the version upgrade dialog. Don't show these updates twice.
         Application.getInstance().getPreferences().addPreference("info/latest_update_version_shown", "0.0.0")
 
     ##  Connect with software.ultimaker.com, load latest.json and check version info.

--- a/plugins/UpdateChecker/UpdateChecker.py
+++ b/plugins/UpdateChecker/UpdateChecker.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017 Ultimaker B.V.
+# Copyright (c) 2018 Ultimaker B.V.
 # Copyright (c) 2013 David Braam
 # Uranium is released under the terms of the LGPLv3 or higher.
 
@@ -30,6 +30,9 @@ class UpdateChecker(Extension):
             self.checkNewVersion(True)
 
         self._download_url = None
+
+        #Which version was the latest shown in the version upgrade dialog. Don't show these updates twice.
+        Application.getInstance().getPreferences().addPreference("info/latest_update_version_shown", "0.0.0")
 
     ##  Connect with software.ultimaker.com, load latest.json and check version info.
     #   If the version info is higher then the current version, spawn a message to

--- a/plugins/UpdateChecker/UpdateChecker.py
+++ b/plugins/UpdateChecker/UpdateChecker.py
@@ -27,7 +27,7 @@ class UpdateChecker(Extension):
 
         Application.getInstance().getPreferences().addPreference("info/automatic_update_check", True)
         if Application.getInstance().getPreferences().getValue("info/automatic_update_check"):
-            self.checkNewVersion(True)
+            self.checkNewVersion(silent = True, display_same_version = False)
 
         self._download_url = None
 
@@ -38,11 +38,15 @@ class UpdateChecker(Extension):
     #   If the version info is higher then the current version, spawn a message to
     #   allow the user to download it.
     #
-    #   \param silent type(boolean) Suppresses messages other than "new version found" messages.
-    #                               This is used when checking for a new version at startup.
-    def checkNewVersion(self, silent = False):
+    #   \param silent Suppresses messages other than "new version found"
+    #   messages. This is used when checking for a new version at startup.
+    #   \param display_same_version Whether to display the same update message
+    #   twice (True) or suppress the update message if the user has already seen
+    #   the update for a particular version. When manually checking for updates,
+    #   the user wants to display the update even if he's already seen it.
+    def checkNewVersion(self, silent = False, display_same_version = True):
         self._download_url = None
-        job = UpdateCheckerJob(silent, self.url, self._onActionTriggered, self._onSetDownloadUrl)
+        job = UpdateCheckerJob(silent, display_same_version, self.url, self._onActionTriggered, self._onSetDownloadUrl)
         job.start()
 
     def _onSetDownloadUrl(self, download_url):

--- a/plugins/UpdateChecker/UpdateCheckerJob.py
+++ b/plugins/UpdateChecker/UpdateCheckerJob.py
@@ -69,6 +69,11 @@ class UpdateCheckerJob(Job):
                         if platform.system() == os: #TODO: add architecture check
                             newest_version = Version([int(value["major"]), int(value["minor"]), int(value["revision"])])
                             if local_version < newest_version:
+                                preferences = Application.getInstance().getPreferences()
+                                latest_version_shown = preferences.getValue("info/latest_update_version_shown")
+                                if latest_version_shown == newest_version and not self.display_same_version:
+                                    continue #Don't show this update again. The user already clicked it away and doesn't want it again.
+                                preferences.setValue("info/latest_update_version_shown", str(newest_version))
                                 Logger.log("i", "Found a new version of the software. Spawning message")
                                 self.showUpdate(newest_version, value["url"])
                                 no_new_version = False
@@ -86,12 +91,6 @@ class UpdateCheckerJob(Job):
             Message(i18n_catalog.i18nc("@info", "No new version was found."), title = i18n_catalog.i18nc("@info:title", "Version Upgrade")).show()
 
     def showUpdate(self, newest_version: Version, download_url: str) -> None:
-        preferences = Application.getInstance().getPreferences()
-        latest_version_shown = preferences.getValue("info/latest_update_version_shown")
-        if latest_version_shown == newest_version and not self.display_same_version:
-            return #Don't show this update again. The user already clicked it away and doesn't want it again.
-        preferences.setValue("info/latest_update_version_shown", str(newest_version))
-
         application_name = Application.getInstance().getApplicationName()
         title_message = i18n_catalog.i18nc("@info:status","{application_name} {version_number} is available!".format(application_name = application_name.title(), version_number = newest_version))
         content_message = i18n_catalog.i18nc("@info:status","{application_name} {version_number} provides a better and more reliable printing experience.".format(application_name = application_name.title(), version_number = newest_version))

--- a/plugins/UpdateChecker/UpdateCheckerJob.py
+++ b/plugins/UpdateChecker/UpdateCheckerJob.py
@@ -69,21 +69,7 @@ class UpdateCheckerJob(Job):
                             newest_version = Version([int(value["major"]), int(value["minor"]), int(value["revision"])])
                             if local_version < newest_version:
                                 Logger.log("i", "Found a new version of the software. Spawning message")
-
-                                title_message = i18n_catalog.i18nc("@info:status","{application_name} {version_number} is available!".format(application_name = application_name.title(), version_number = newest_version))
-                                content_message = i18n_catalog.i18nc("@info:status","{application_name} {version_number} provides a better and more reliable printing experience.".format(application_name = application_name.title(), version_number = newest_version))
-
-                                message = Message(text = content_message, title = title_message)
-                                message.addAction("download", i18n_catalog.i18nc("@action:button", "Download"), "[no_icon]", "[no_description]")
-
-                                message.addAction("new_features", i18n_catalog.i18nc("@action:button", "Learn more about the new features"), "[no_icon]", "[no_description]",
-                                                  button_style = Message.ActionButtonStyle.LINK,
-                                                  button_align = Message.ActionButtonStyle.BUTTON_ALIGN_LEFT)
-
-                                if self._set_download_url_callback:
-                                    self._set_download_url_callback(value["url"])
-                                message.actionTriggered.connect(self._callback)
-                                message.show()
+                                self.showUpdate(newest_version, value["url"])
                                 no_new_version = False
                                 break
                     else:
@@ -97,3 +83,20 @@ class UpdateCheckerJob(Job):
 
         if no_new_version and not self.silent:
             Message(i18n_catalog.i18nc("@info", "No new version was found."), title = i18n_catalog.i18nc("@info:title", "Version Upgrade")).show()
+
+    def showUpdate(self, newest_version: Version, download_url: str) -> None:
+        application_name = Application.getInstance().getApplicationName()
+        title_message = i18n_catalog.i18nc("@info:status","{application_name} {version_number} is available!".format(application_name = application_name.title(), version_number = newest_version))
+        content_message = i18n_catalog.i18nc("@info:status","{application_name} {version_number} provides a better and more reliable printing experience.".format(application_name = application_name.title(), version_number = newest_version))
+
+        message = Message(text = content_message, title = title_message)
+        message.addAction("download", i18n_catalog.i18nc("@action:button", "Download"), "[no_icon]", "[no_description]")
+
+        message.addAction("new_features", i18n_catalog.i18nc("@action:button", "Learn more about the new features"), "[no_icon]", "[no_description]",
+                          button_style = Message.ActionButtonStyle.LINK,
+                          button_align = Message.ActionButtonStyle.BUTTON_ALIGN_LEFT)
+
+        if self._set_download_url_callback:
+            self._set_download_url_callback(download_url)
+        message.actionTriggered.connect(self._callback)
+        message.show()

--- a/plugins/UpdateChecker/UpdateCheckerJob.py
+++ b/plugins/UpdateChecker/UpdateCheckerJob.py
@@ -18,9 +18,10 @@ i18n_catalog = i18nCatalog("uranium")
 
 ##  This job checks if there is an update available on the provided URL.
 class UpdateCheckerJob(Job):
-    def __init__(self, silent = False, url = None, callback = None, set_download_url_callback = None):
+    def __init__(self, silent = False, display_same_version = True, url = None, callback = None, set_download_url_callback = None):
         super().__init__()
         self.silent = silent
+        self.display_same_version = display_same_version
         self._url = url
         self._callback = callback
         self._set_download_url_callback = set_download_url_callback
@@ -87,8 +88,8 @@ class UpdateCheckerJob(Job):
     def showUpdate(self, newest_version: Version, download_url: str) -> None:
         preferences = Application.getInstance().getPreferences()
         latest_version_shown = preferences.getValue("info/latest_update_version_shown")
-        if latest_version_shown == newest_version:
-            return #Don't show this update again. The user already clicked it away.
+        if latest_version_shown == newest_version and not self.display_same_version:
+            return #Don't show this update again. The user already clicked it away and doesn't want it again.
         preferences.setValue("info/latest_update_version_shown", str(newest_version))
 
         application_name = Application.getInstance().getApplicationName()

--- a/plugins/UpdateChecker/UpdateCheckerJob.py
+++ b/plugins/UpdateChecker/UpdateCheckerJob.py
@@ -85,6 +85,12 @@ class UpdateCheckerJob(Job):
             Message(i18n_catalog.i18nc("@info", "No new version was found."), title = i18n_catalog.i18nc("@info:title", "Version Upgrade")).show()
 
     def showUpdate(self, newest_version: Version, download_url: str) -> None:
+        preferences = Application.getInstance().getPreferences()
+        latest_version_shown = preferences.getValue("info/latest_update_version_shown")
+        if latest_version_shown == newest_version:
+            return #Don't show this update again. The user already clicked it away.
+        preferences.setValue("info/latest_update_version_shown", str(newest_version))
+
         application_name = Application.getInstance().getApplicationName()
         title_message = i18n_catalog.i18nc("@info:status","{application_name} {version_number} is available!".format(application_name = application_name.title(), version_number = newest_version))
         content_message = i18n_catalog.i18nc("@info:status","{application_name} {version_number} provides a better and more reliable printing experience.".format(application_name = application_name.title(), version_number = newest_version))


### PR DESCRIPTION
When automatically checking for updates, only show the same update once. So it'll say once that there is an update for 3.5.1, but not again unless you manually check for updates. Once 3.6 rolls around, it'll show that there is an update again.

This is in line with how most update systems behave in other applications.