### PR TITLE
Fix passing definitioncontainers metadata to QML

### DIFF
--- a/UM/Settings/Models/DefinitionContainersModel.py
+++ b/UM/Settings/Models/DefinitionContainersModel.py
@@ -45,7 +45,7 @@ class DefinitionContainersModel(ListModel):
         definition_containers.sort(key = self._sortKey)
 
         for metadata in definition_containers:
-            metadata = metadata.copy()
+            metadata = dict(metadata) # For fully loaded definitions, the metadata is an OrderedDict which does not pass to QML correctly
 
             items.append({
                 "name": metadata["name"],


### PR DESCRIPTION
This PR fixes passing definitioncontainers metadata to QML. For fully loaded definitions, the metadata is an OrderedDict which does not pass to QML correctly. This became apparent in Cura here:
https://github.com/Ultimaker/Cura/pull/4498#issuecomment-434966876