### PR TITLE
Fix shift+rotate tool

### DIFF
--- a/plugins/Tools/RotateTool/RotateTool.py
+++ b/plugins/Tools/RotateTool/RotateTool.py
@@ -56,13 +56,11 @@ class RotateTool(Tool):
 
         if event.type == Event.KeyPressEvent and event.key == KeyEvent.ShiftKey:
             # Snap is toggled when pressing the shift button
-            self._snap_rotation = (not self._snap_rotation)
-            self.propertyChanged.emit()
+            self.setRotationSnap(not self._snap_rotation)
 
         if event.type == Event.KeyReleaseEvent and event.key == KeyEvent.ShiftKey:
             # Snap is "toggled back" when releasing the shift button
-            self._snap_rotation = (not self._snap_rotation)
-            self.propertyChanged.emit()
+            self.setRotationSnap(not self._snap_rotation)
 
         if event.type == Event.MousePressEvent and self._controller.getToolsEnabled():
             # Start a rotate operation

--- a/plugins/Tools/RotateTool/RotateTool.qml
+++ b/plugins/Tools/RotateTool/RotateTool.qml
@@ -47,6 +47,7 @@ Item
 
     CheckBox
     {
+        id: snapRotationCheckbox
         anchors.left: parent.left;
         anchors.top: resetRotationButton.bottom;
         anchors.topMargin: UM.Theme.getSize("default_margin").width;
@@ -58,5 +59,12 @@ Item
 
         checked: UM.ActiveTool.properties.getValue("RotationSnap");
         onClicked: UM.ActiveTool.setProperty("RotationSnap", checked);
+    }
+
+    Binding
+    {
+        target: snapRotationCheckbox
+        property: "checked"
+        value: UM.ActiveTool.properties.getValue("RotationSnap")
     }
 }

--- a/plugins/Tools/ScaleTool/ScaleTool.py
+++ b/plugins/Tools/ScaleTool/ScaleTool.py
@@ -77,19 +77,17 @@ class ScaleTool(Tool):
         # Handle modifier keys: Shift toggles snap, Control toggles uniform scaling
         if event.type == Event.KeyPressEvent:
             if event.key == KeyEvent.ShiftKey:
-                self._snap_scale = False
-                self.propertyChanged.emit()
+                self.setScaleSnap(not self._snap_scale)
+
             elif event.key == KeyEvent.ControlKey:
-                self._non_uniform_scale = True
-                self.propertyChanged.emit()
+                self.setNonUniformScale(not self._non_uniform_scale)
 
         if event.type == Event.KeyReleaseEvent:
             if event.key == KeyEvent.ShiftKey:
-                self._snap_scale = True
-                self.propertyChanged.emit()
+                self.setScaleSnap(not self._snap_scale)
+
             elif event.key == KeyEvent.ControlKey:
-                self._non_uniform_scale = False
-                self.propertyChanged.emit()
+                self.setNonUniformScale(not self._non_uniform_scale)
 
         if event.type == Event.MousePressEvent and self._controller.getToolsEnabled():
             # Initialise a scale operation

--- a/plugins/Tools/ScaleTool/ScaleTool.qml
+++ b/plugins/Tools/ScaleTool/ScaleTool.qml
@@ -90,7 +90,6 @@ Item
             id: snapScalingCheckbox
 
             width: parent.width //Use a width instead of anchors to allow the flow layout to resolve positioning.
-
             text: catalog.i18nc("@option:check", "Snap Scaling")
 
             style: UM.Theme.styles.checkbox;
@@ -105,16 +104,30 @@ Item
             }
         }
 
+        Binding
+        {
+            target: snapScalingCheckbox
+            property: "checked"
+            value: UM.ActiveTool.properties.getValue("ScaleSnap")
+        }
+
         CheckBox
         {
-            width: parent.width //Use a width instead of anchors to allow the flow layout to resolve positioning.
+            id: uniformScalingCheckbox
 
+            width: parent.width //Use a width instead of anchors to allow the flow layout to resolve positioning.
             text: catalog.i18nc("@option:check", "Uniform Scaling")
 
             style: UM.Theme.styles.checkbox;
-
             checked: !UM.ActiveTool.properties.getValue("NonUniformScale");
             onClicked: UM.ActiveTool.setProperty("NonUniformScale", !checked);
+        }
+
+        Binding
+        {
+            target: uniformScalingCheckbox
+            property: "checked"
+            value: !UM.ActiveTool.properties.getValue("NonUniformScale")
         }
     }
 


### PR DESCRIPTION
Add a binding that will update the value of the checkboxes when using the shift key for the snap rotate and the snap scale.

Also change the behavior, now the shift key should inverse the value that the user has selected.

Contributes to CURA-5865.