### PR TITLE
Remove tray icon while the application is still alive

### DIFF
--- a/UM/Qt/QtApplication.py
+++ b/UM/Qt/QtApplication.py
@@ -417,6 +417,9 @@ class QtApplication(QApplication, Application):
         Logger.log("d", "Shutting down %s", self.getApplicationName())
         self._is_shutting_down = True
 
+        # garbage collect tray icon so it gets properly closed before the application is closed
+        self._tray_icon_widget = None
+
         if save_data:
             try:
                 self.savePreferences()


### PR DESCRIPTION
This PR actively removes the tray icon before the application is shut down, so the tray icon does not get orphaned. Without this PR, an orphan tray icon is left behind each time Cura is shut down.

![prevents this](https://content.invisioncic.com/ultimake/monthly_2018_10/CuraIsAGremlin.jpg.cf2848c4ef67ef52ef8ea9b64de2ba71.jpg)