### PR TITLE
Ignore plugins folder when checking files for version upgrade

### DIFF
--- a/UM/VersionUpgradeManager.py
+++ b/UM/VersionUpgradeManager.py
@@ -84,7 +84,7 @@ class VersionUpgradeManager:
         PluginRegistry.addType("version_upgrade", self._addVersionUpgrade)
 
         #Regular expressions of the files that should not be checked, such as log files.
-        self._ignored_files = ["^.*\.lock$", "^plugins\.json$", "^packages.json$", "^.*\.log$"]  # type: List[str]
+        self._ignored_files = ["^.*\.lock$", "^.*plugins\.json$", "^.*packages\.json$", "^.*\.log$", "^plugins\\.*"]  # type: List[str]
 
     ##  Registers a file to be ignored by version upgrade checks (eg log files).
     #   \param file_name The base file name of the file to be ignored.


### PR DESCRIPTION
This PR ignores the plugins folder when checking files for version upgrade. https://github.com/Ultimaker/Uranium/pull/421 changed the version upgrade manager to recurse into all configuration folders, which also causes plugin folders to be examined. VersionUpgradeManager cannot handle plugin files, so the logs get spammed with lots of files being skipped.

The PR also changes the regex for plugins.json and package.json, to be able to handle .\plugins.json and .\package.json