### PR TITLE
CURA-6120 arrange child nodes fix

### DIFF
--- a/UM/Math/Polygon.py
+++ b/UM/Math/Polygon.py
@@ -161,7 +161,7 @@ class Polygon:
         if polygon_union.area == 0:
             return Polygon()
 
-        return Polygon(points = [list(p) for p in polygon_union.exterior.coords[:4]])
+        return Polygon(points = [list(p) for p in polygon_union.exterior.coords[:-1]])
 
     ##  Check to see whether this polygon intersects with another polygon.
     #

--- a/UM/Math/Polygon.py
+++ b/UM/Math/Polygon.py
@@ -141,6 +141,28 @@ class Polygon:
 
         return Polygon(points = [list(p) for p in polygon_intersection.exterior.coords[:4]])
 
+    #  Computes the convex hull of the union of the convex hulls of this and another polygon.
+    #
+    #   \param other The other polygon to combine convex hulls with.
+    #   \return The convex hull of the union of the two polygons' convex hulls.
+    def unionConvexHulls(self, other: "Polygon") -> "Polygon":
+        my_hull = self.getConvexHull()
+        other_hull = other.getConvexHull()
+
+        if len(my_hull._points) <= 2:
+            return other_hull
+        if len(other_hull._points) <= 2:
+            return my_hull
+
+        my_polygon = ShapelyUtil.polygon2ShapelyPolygon(my_hull)
+        other_polygon = ShapelyUtil.polygon2ShapelyPolygon(other_hull)
+
+        polygon_union = my_polygon.union(other_polygon).convex_hull
+        if polygon_union.area == 0:
+            return Polygon()
+
+        return Polygon(points = [list(p) for p in polygon_union.exterior.coords[:4]])
+
     ##  Check to see whether this polygon intersects with another polygon.
     #
     #   \param other \type{Polygon} The polygon to check for intersection.

--- a/UM/Math/Polygon.py
+++ b/UM/Math/Polygon.py
@@ -56,7 +56,7 @@ class Polygon:
         return "[" + ", ".join(coordinates) + "]"
 
     def isValid(self) -> bool:
-        return bool(self._points is not None and len(self._points))
+        return bool(self._points is not None and len(self._points) >= 3)
 
     def getPoints(self):
         return self._points
@@ -149,9 +149,9 @@ class Polygon:
         my_hull = self.getConvexHull()
         other_hull = other.getConvexHull()
 
-        if len(my_hull._points) <= 2:
+        if not my_hull.isValid():
             return other_hull
-        if len(other_hull._points) <= 2:
+        if not other_hull.isValid():
             return my_hull
 
         my_polygon = ShapelyUtil.polygon2ShapelyPolygon(my_hull)

--- a/tests/Math/TestPolygon.py
+++ b/tests/Math/TestPolygon.py
@@ -25,7 +25,6 @@ class TestPolygon:
         ({ "points": [[0.0, 0.0], [2.0, 0.0], [1.0, 2.0]], "axis_point": [0, 0], "axis_direction": [1, 0], "answer": [[1.0, -2.0], [2.0, 0.0], [0.0, 0.0]], "label": "Mirror Vertical", "description": "Test mirroring a polygon vertically." }),
         ({ "points": [[0.0, 0.0], [2.0, 0.0], [1.0, 2.0]], "axis_point": [10, 0], "axis_direction": [0, 1], "answer": [[19.0, 2.0], [18.0, 0.0], [20.0, 0.0]], "label": "Mirror Horizontal Far", "description": "Test mirrorring a polygon horizontally on an axis that is not through the origin." }),
         ({ "points": [[0.0, 0.0], [2.0, 0.0], [1.0, 2.0]], "axis_point": [0, 4], "axis_direction": [1, 1], "answer": [[-2.0, 5.0], [-4.0, 6.0], [-4.0, 4.0]], "label": "Mirror Diagonal", "description": "Test mirroring a polygon diagonally." }),
-        ({ "points": [[10.0, 0.0]], "axis_point": [0, 0], "axis_direction": [0, 1], "answer": [[-10.0, 0.0]], "label": "Mirror Single Vertex", "description": "Test mirroring a polygon with only one vertex." }),
         ({ "points": [], "axis_point": [0, 0], "axis_direction": [1, 0], "answer": [], "label": "Mirror Empty", "description": "Test mirroring an empty polygon." })
     ]
 
@@ -107,8 +106,8 @@ class TestPolygon:
                     assert result is not None
                     for i in range(0, len(data["answer"])):
                         assert Float.fuzzyCompare(result[i], data["answer"][i])
-                p2.setPoints(numpy.roll(p2.getPoints(), 1, axis = 0)) #Shift p2.
-            p1.setPoints(numpy.roll(p1.getPoints(), 1, axis = 0)) #Shift p1.
+                p2 = Polygon(numpy.roll(p2.getPoints(), 1, axis = 0)) #Shift p2.
+            p1 = Polygon(numpy.roll(p1.getPoints(), 1, axis = 0)) #Shift p1.
 
     ##  The individual test cases for convex hull intersection tests.
     test_intersectConvex_data = [
@@ -138,5 +137,38 @@ class TestPolygon:
             if thisCorrect:  # All vertices checked and it's still correct.
                 isCorrect = True
                 break
-            result.setPoints(numpy.roll(result.getPoints(), 1, axis = 0)) #Perform the rotation for the next check.
+            result = Polygon(numpy.roll(result.getPoints(), 1, axis = 0)) #Perform the rotation for the next check.
+        assert isCorrect
+
+    ##  The individual test cases for convex hull union tests.
+    test_unionConvex_data = [
+        ({"p1": [[1, 1], [1.5, 1], [2, 2], [2, 0]], "p2": [[3, 2], [3.5, 1], [4, 1], [3, 0]], "answer": [[1, 1], [2, 2], [3, 2], [4, 1], [3, 0], [2, 0]], "label": "ConvexHull Union Separate", "description": "Two disparate shapes."}),
+        ({"p1": [[1, 1], [3, 3], [3, -1]], "p2": [[2, 1], [4, 2], [4, 0]], "answer": [[1, 1], [3, 3], [4, 2], [4, 0], [3, -1]], "label": "ConvexHull Union Inside", "description": "One triangle partially inside the other."}),
+        ({"p1": [[1, 1], [5, 5], [5, -4]], "p2": [[2, 1], [3, 2], [3, 1]], "answer": [[1, 1], [5, 5], [5, -4]], "label": "ConvexHull Union Enclosed", "description": "One triangle completely inside the other."}),
+        ({"p1": [[1, 1], [2, 2], [2, 0]], "p2": [], "answer": [[1, 1], [2, 2], [2, 0]], "label": "ConvexHull Union Single", "description": "One triangle."})
+    ]
+
+    ##  Tests the convex hull of convex hulls
+    #
+    #   \param data The data of the test case.
+    @pytest.mark.parametrize("data", test_unionConvex_data)
+    def test_unionConvexHull(self, data) -> None:
+        p1 = Polygon(numpy.array(data["p1"]))
+        p2 = Polygon(numpy.array(data["p2"]))
+        result = p1.unionConvexHulls(p2)
+        assert len(result.getPoints()) == len(data["answer"])  # Same amount of vertices.
+        isCorrect = False
+        for rotation in range(0, len(result.getPoints())):  # The order of vertices doesn't matter, so rotate the result around and if any check succeeds, the answer is correct.
+            thisCorrect = True  # Is this rotation correct?
+            for vertex in range(0, len(result.getPoints())):
+                for dimension in range(0, len(result.getPoints()[vertex])):
+                    if not Float.fuzzyCompare(result.getPoints()[vertex][dimension], data["answer"][vertex][dimension]):
+                        thisCorrect = False
+                        break  # Break out of two loops.
+                if not thisCorrect:
+                    break
+            if thisCorrect:  # All vertices checked and it's still correct.
+                isCorrect = True
+                break
+            result = Polygon(numpy.roll(result.getPoints(), 1, axis = 0)) #Perform the rotation for the next check.
         assert isCorrect


### PR DESCRIPTION
Need this polygon operation for a fix in Cura (child-nodes like support-blocker where arranged separatelty when 'Arrange Models' was selected).