### PR TITLE
Fix install prefix when installing in symlinked directory

### DIFF
--- a/UM/Application.py
+++ b/UM/Application.py
@@ -398,9 +398,10 @@ class Application:
     @staticmethod
     def getInstallPrefix() -> str:
         if "python" in os.path.basename(sys.executable):
-            return os.path.abspath(os.path.join(os.path.dirname(sys.argv[0]), ".."))
+            executable = sys.argv[0]
         else:
-            return os.path.abspath(os.path.join(os.path.dirname(sys.executable), ".."))
+            executable = sys.executable
+        return os.path.abspath(os.path.join(os.path.dirname(os.path.realpath(executable)), ".."))
 
     __instance = None   # type: Application
 


### PR DESCRIPTION
If there is a symlink to the installation directory and it appears before the actual installation directory on the user's PATH, it would get a wrong path for `sys.argv[0]`. This then messes up the install location which consequently messes up the data and config storage directories.
This solution is provided by CapnKernel and should resolve the symlink so that sys.argv[0]='/usr/bin/python3' again and the storage data and config storage directories become something like /usr/share/... again.

This should fix https://github.com/Ultimaker/Cura/issues/5290 .