### PR TITLE
Opt to use OpenGL 2.0 instead of software rendered OpenGL 4.1

### DIFF
--- a/UM/Qt/QtApplication.py
+++ b/UM/Qt/QtApplication.py
@@ -135,10 +135,9 @@ class QtApplication(QApplication, Application):
             QMessageBox.critical(None, "Failed to probe OpenGL",
                                  "Could not probe OpenGL. This program requires OpenGL 2.0 or higher. Please check your video card drivers.")
             sys.exit(1)
-
-        opengl_version_str = OpenGLContext.versionAsText(major_version, minor_version, profile)
-        Logger.log("d", "Detected most suitable OpenGL context version: %s", opengl_version_str)
-
+        else:
+            opengl_version_str = OpenGLContext.versionAsText(major_version, minor_version, profile)
+            Logger.log("d", "Detected most suitable OpenGL context version: %s", opengl_version_str)
         if not self.getIsHeadLess():
             OpenGLContext.setDefaultFormat(major_version, minor_version, profile = profile)
 

--- a/UM/Qt/QtApplication.py
+++ b/UM/Qt/QtApplication.py
@@ -9,8 +9,8 @@ from typing import Any, cast, Dict, Optional
 
 from PyQt5.QtCore import Qt, QCoreApplication, QEvent, QUrl, pyqtProperty, pyqtSignal, pyqtSlot, QT_VERSION_STR, PYQT_VERSION_STR
 from PyQt5.QtQml import QQmlApplicationEngine, QQmlComponent, QQmlContext, QQmlError
-from PyQt5.QtWidgets import QApplication, QSplashScreen, QMessageBox, QSystemTrayIcon
-from PyQt5.QtGui import QIcon, QPixmap, QFontMetrics
+from PyQt5.QtWidgets import QApplication, QSplashScreen, QMessageBox, QSystemTrayIcon, QOpenGLWidget
+from PyQt5.QtGui import QIcon, QPixmap, QFontMetrics, QSurfaceFormat, QOpenGLContext
 from PyQt5.QtCore import QTimer
 
 from UM.Backend.Backend import Backend #For typing.
@@ -135,10 +135,44 @@ class QtApplication(QApplication, Application):
             QMessageBox.critical(None, "Failed to probe OpenGL",
                                  "Could not probe OpenGL. This program requires OpenGL 2.0 or higher. Please check your video card drivers.")
             sys.exit(1)
-        else:
-            opengl_version_str = OpenGLContext.versionAsText(major_version, minor_version, profile)
-            Logger.log("d", "Detected most suitable OpenGL context version: %s", opengl_version_str)
+
+        opengl_version_str = OpenGLContext.versionAsText(major_version, minor_version, profile)
+        Logger.log("d", "Detected most suitable OpenGL context version: %s", opengl_version_str)
+
         if not self.getIsHeadLess():
+            # CURA-6092: Check if we're not using software backed 4.1 context; A software 4.1 context
+            # is much slower than a hardware backed 2.0 context
+            if major_version > 2:
+                gl_widget = QOpenGLWidget()
+                gl_format = QSurfaceFormat()
+                gl_format.setVersion(major_version, minor_version)
+                gl_format.setProfile(profile)
+                gl_widget.setFormat(gl_format)
+                gl_widget.showMinimized()
+                gl = QOpenGLContext.currentContext().versionFunctions()
+
+                gpu_type = "Unknown" #type: str
+
+                result = gl.initializeOpenGLFunctions()
+                if not result:
+                    Logger.log("e", "Could not initialize OpenGL to get gpu type")
+                else:
+                    # WORKAROUND: Cura/#1117 Cura-packaging/12
+                    # Some Intel GPU chipsets return a string, which is not undecodable via PyQt5.
+                    # This workaround makes the code fall back to a "Unknown" renderer in these cases.
+                    try:
+                        gpu_type = gl.glGetString(gl.GL_RENDERER) #type: str
+                    except UnicodeDecodeError:
+                        Logger.log("e", "DecodeError while getting GL_RENDERER via glGetString!")
+
+                Logger.log("d", "OpenGL renderer type for this OpenGL version: %s", gpu_type)
+                if "software" in gpu_type.lower():
+                    Logger.log("w", "Opting to use OpenGL 2.0 instead of software rendered OpenGL %d.%d" % (major_version, minor_version))
+
+                    major_version = 2
+                    minor_version = 0
+                    profile = QSurfaceFormat.NoProfile
+
             OpenGLContext.setDefaultFormat(major_version, minor_version, profile = profile)
 
         self._qml_import_paths.append(os.path.join(os.path.dirname(sys.executable), "qml"))

--- a/UM/View/GL/OpenGLContext.py
+++ b/UM/View/GL/OpenGLContext.py
@@ -123,7 +123,10 @@ class OpenGLContext(object):
                 gl_widget.showMinimized()
 
                 gl_profile = QOpenGLVersionProfile()
-                gl_profile.setVersion(fmt.majorVersion(), fmt.minorVersion())
+                # https://riverbankcomputing.com/pipermail/pyqt/2017-January/038640.html
+                # PyQt currently only implements 2.0, 2.1 and 4.1Core
+                # If eg 4.5Core would be detected and used here, PyQt would not be able to handle it.
+                gl_profile.setVersion(4, 1)
                 gl_profile.setProfile(profile)
 
                 gl = QOpenGLContext.currentContext().versionFunctions(gl_profile) # type: Any #It's actually a protected class in PyQt that depends on the implementation of your graphics card.

--- a/UM/View/GL/OpenGLContext.py
+++ b/UM/View/GL/OpenGLContext.py
@@ -113,20 +113,19 @@ class OpenGLContext(object):
                     "Yay, we got at least OpenGL 4.1 core: %s",
                     cls.versionAsText(fmt.majorVersion(), fmt.minorVersion(), profile))
 
-                # CURA-6092: Check if we're not using software backed 4.1 context; A software 4.1 context
-                # is much slower than a hardware backed 2.0 context
-                gl_widget = QOpenGLWidget()
-                gl_format = QSurfaceFormat()
-                gl_format.setVersion(fmt.majorVersion(), fmt.minorVersion())
-                gl_format.setProfile(profile)
-                gl_widget.setFormat(gl_format)
-                gl_widget.showMinimized()
-
-                gl_profile = QOpenGLVersionProfile()
                 # https://riverbankcomputing.com/pipermail/pyqt/2017-January/038640.html
                 # PyQt currently only implements 2.0, 2.1 and 4.1Core
                 # If eg 4.5Core would be detected and used here, PyQt would not be able to handle it.
-                gl_profile.setVersion(4, 1)
+                major_version = 4
+                minor_version = 1
+
+                # CURA-6092: Check if we're not using software backed 4.1 context; A software 4.1 context
+                # is much slower than a hardware backed 2.0 context
+                gl_widget = QOpenGLWidget()
+                gl_widget.showMinimized()
+
+                gl_profile = QOpenGLVersionProfile()
+                gl_profile.setVersion(major_version, minor_version)
                 gl_profile.setProfile(profile)
 
                 gl = QOpenGLContext.currentContext().versionFunctions(gl_profile) # type: Any #It's actually a protected class in PyQt that depends on the implementation of your graphics card.
@@ -149,7 +148,7 @@ class OpenGLContext(object):
                 if "software" in gpu_type.lower():
                     Logger.log("w", "Unfortunately OpenGL 4.1 uses software rendering")
                 else:
-                    return 4, 1, QSurfaceFormat.CoreProfile
+                    return major_version, minor_version, QSurfaceFormat.CoreProfile
         else:
             Logger.log("d", "Failed to create OpenGL context 4.1.")
 


### PR DESCRIPTION
This PR checks if the best detected OpenGL version isn't using software rendering provided by the OS instead of a GPU renderer. With newer versions of Qt on OSX (and Linuxes ?), requesting a 4.1 context on a GPU that does not support hardware accelerated 4.1 rendering results in a software rendered context which is much slower than a hardware accelerated 2.0 context. This PR detects software rendering OpenGL 4.1 renderers, and falls back to OpenGL 2.0 instead. 

Contributes to https://github.com/Ultimaker/Cura/issues/4505 (CURA-6092)

This will need testing on many systems.