### PR TITLE
Switch out the implementation of decompose for a faster variant

### DIFF
--- a/UM/Math/Matrix.py
+++ b/UM/Math/Matrix.py
@@ -62,6 +62,9 @@ class Matrix:
         # Note that actually using Matrix(self._data) (without the deepcopy) is another factor 3 faster.
         return Matrix(self._data)
 
+    def copy(self) -> "Matrix":
+        return Matrix(self._data)
+
     def __eq__(self, other: object) -> bool:
         if self is other:
             return True

--- a/UM/Math/Matrix.py
+++ b/UM/Math/Matrix.py
@@ -10,7 +10,7 @@ from UM.Math.Vector import Vector
 from typing import cast, Dict, List, Optional, Tuple, TYPE_CHECKING, Union
 
 numpy.seterr(divide="ignore")
-
+from UM.Decorators import timeit
 
 if TYPE_CHECKING:
     from UM.Math.Quaternion import Quaternion
@@ -402,64 +402,70 @@ class Matrix:
         self._data[2, 3] = -1.
         self._data[3, 2] = (2. * far * near) / (near - far)
 
-    ##  Return sequence of transformations from transformation matrix.
-    #   @return Tuple containing scale (vector), shear (vector), angles (vector), translation (vector) and mirror (vector)
-    #   It will raise a ValueError if matrix is of wrong type or degenerative.
-    def decompose(self) -> Tuple[Vector, Vector, Vector, Vector, Vector]:
-        M = numpy.array(self._data, dtype = numpy.float64, copy = True).T
-        if abs(M[3, 3]) < self._EPS:
-            raise ValueError("M[3, 3] is zero")
-        M /= M[3, 3]
-        P = M.copy()
-        P[:, 3] = 0.0, 0.0, 0.0, 1.0
-        if not numpy.linalg.det(P):
-            raise ValueError("matrix is singular")
+    def decompose(self):
+        '''
+        SOURCE: https://github.com/matthew-brett/transforms3d/blob/e402e56686648d9a88aa048068333b41daa69d1a/transforms3d/affines.py
+        Decompose 4x4 homogenous affine matrix into parts.
+        The parts are translations, rotations, zooms, shears.
+        This is the same as :func:`decompose` but specialized for 4x4 affines.
+        Decomposes `A44` into ``T, R, Z, S``, such that::
+           Smat = np.array([[1, S[0], S[1]],
+                            [0,    1, S[2]],
+                            [0,    0,    1]])
+           RZS = np.dot(R, np.dot(np.diag(Z), Smat))
+           A44 = np.eye(4)
+           A44[:3,:3] = RZS
+           A44[:-1,-1] = T
+        The order of transformations is therefore shears, followed by
+        zooms, followed by rotations, followed by translations.
+        This routine only works for shape (4,4) matrices
+        Parameters
+        ----------
+        A44 : array shape (4,4)
+        Returns
+        -------
+        T : array, shape (3,)
+           Translation vector
+        R : array shape (3,3)
+            rotation matrix
+        Z : array, shape (3,)
+           Zoom vector.  May have one negative zoom to prevent need for negative
+           determinant R matrix above
+        S : array, shape (3,)
+           Shear vector, such that shears fill upper triangle above
+           diagonal to form shear matrix (type ``striu``).
+        '''
+        A44 = numpy.asarray(self._data, dtype = numpy.float64)
+        T = A44[:-1, -1]
+        RZS = A44[:-1, :-1]
+        # compute scales and shears
+        M0, M1, M2 = numpy.array(RZS).T
+        # extract x scale and normalize
+        sx = math.sqrt(numpy.sum(M0 ** 2))
+        M0 /= sx
+        # orthogonalize M1 with respect to M0
+        sx_sxy = numpy.dot(M0, M1)
+        M1 -= sx_sxy * M0
+        # extract y scale and normalize
+        sy = math.sqrt(numpy.sum(M1 ** 2))
+        M1 /= sy
+        sxy = sx_sxy / sx
+        # orthogonalize M2 with respect to M0 and M1
+        sx_sxz = numpy.dot(M0, M2)
+        sy_syz = numpy.dot(M1, M2)
+        M2 -= (sx_sxz * M0 + sy_syz * M1)
+        # extract z scale and normalize
+        sz = math.sqrt(numpy.sum(M2 ** 2))
+        M2 /= sz
+        sxz = sx_sxz / sx
+        syz = sy_syz / sy
+        # Reconstruct rotation matrix, ensure positive determinant
+        Rmat = numpy.array([M0, M1, M2]).T
+        if numpy.linalg.det(Rmat) < 0:
+            sx *= -1
+            Rmat[:, 0] *= -1
 
-        scale = numpy.zeros((3, ))
-        shear = [0.0, 0.0, 0.0]
-        angles = [0.0, 0.0, 0.0]
-        mirror = [1, 1, 1]
-
-        translate = M[3, :3].copy()
-        M[3, :3] = 0.0
-
-        row = M[:3, :3].copy()
-        scale[0] = math.sqrt(numpy.dot(row[0], row[0]))
-        row[0] /= scale[0]
-        shear[0] = numpy.dot(row[0], row[1])
-        row[1] -= row[0] * shear[0]
-        scale[1] = math.sqrt(numpy.dot(row[1], row[1]))
-        row[1] /= scale[1]
-        shear[0] /= scale[1]
-        shear[1] = numpy.dot(row[0], row[2])
-        row[2] -= row[0] * shear[1]
-        shear[2] = numpy.dot(row[1], row[2])
-        row[2] -= row[1] * shear[2]
-        scale[2] = math.sqrt(numpy.dot(row[2], row[2]))
-        row[2] /= scale[2]
-        shear[1:] /= scale[2]
-
-        if numpy.dot(row[0], numpy.cross(row[1], row[2])) < 0:
-            numpy.negative(scale, scale)
-            numpy.negative(row, row)
-
-        # If the scale was negative, we give back a seperate mirror vector to indicate this.
-        if M[0, 0] < 0:
-            mirror[0] = -1
-        if M[1, 1] < 0:
-            mirror[1] = -1
-        if M[2, 2] < 0:
-            mirror[2] = -1
-
-        angles[1] = math.asin(-row[0, 2])
-        if math.cos(angles[1]):
-            angles[0] = math.atan2(row[1, 2], row[2, 2])
-            angles[2] = math.atan2(row[0, 1], row[0, 0])
-        else:
-            angles[0] = math.atan2(-row[2, 1], row[1, 1])
-            angles[2] = 0.0
-
-        return Vector(data = scale), Vector(data = shear), Vector(data = angles), Vector(data = translate), Vector(data = mirror)
+        return Vector(data = T), Matrix(data=Rmat), Vector(data = numpy.array([sx, sy, sz])), Vector(data=numpy.array([sxy, sxz, syz]))
 
     def _unitVector(self, data: numpy.array, axis: Optional[int] = None, out: Optional[numpy.array] = None) -> numpy.array:
         """Return ndarray normalized by length, i.e. Euclidean norm, along axis.

--- a/UM/Math/Matrix.py
+++ b/UM/Math/Matrix.py
@@ -10,7 +10,6 @@ from UM.Math.Vector import Vector
 from typing import cast, Dict, List, Optional, Tuple, TYPE_CHECKING, Union
 
 numpy.seterr(divide="ignore")
-from UM.Decorators import timeit
 
 if TYPE_CHECKING:
     from UM.Math.Quaternion import Quaternion

--- a/UM/Math/Quaternion.py
+++ b/UM/Math/Quaternion.py
@@ -23,7 +23,7 @@ class Quaternion(object):
 
     def __init__(self, x=0.0, y=0.0, z=0.0, w=1.0):
         # Components are stored as XYZW
-        self._data = numpy.array([x, y, z, w], dtype=numpy.float32)
+        self._data = numpy.array([x, y, z, w], dtype=numpy.float64)
 
     def getData(self):
         return self._data
@@ -182,7 +182,7 @@ class Quaternion(object):
         self.normalize()
 
     def toMatrix(self):
-        m = numpy.zeros((4, 4), dtype=numpy.float32)
+        m = numpy.zeros((4, 4), dtype=numpy.float64)
 
         s = 2.0 / (self.x ** 2 + self.y ** 2 + self.z ** 2 + self.w ** 2)
 

--- a/UM/Operations/SetTransformOperation.py
+++ b/UM/Operations/SetTransformOperation.py
@@ -48,15 +48,7 @@ class SetTransformOperation(Operation.Operation):
         else:
             self._new_shear = node.getShear()
 
-        if mirror:
-            self._new_mirror = mirror
-        else:
-            # Scale will either be negative or positive. If it's negative, we need to use the inverse mirror.
-            if self._node.getScale().x < 0:
-                self._new_mirror = Vector(-node.getMirror().x, -node.getMirror().y, -node.getMirror().z)
-            else:
-                self._new_mirror = node.getMirror()
-
+        self._new_mirror = Vector(1, 1, 1)
         self._new_transformation = Matrix()
 
         euler_orientation = self._new_orientation.toMatrix().getEuler()

--- a/UM/Scene/Camera.py
+++ b/UM/Scene/Camera.py
@@ -95,6 +95,7 @@ class Camera(SceneNode.SceneNode):
     #   \param matrix The projection matrix to use for this camera.
     def setProjectionMatrix(self, matrix: Matrix) -> None:
         self._projection_matrix = matrix
+        self._cached_view_projection_matrix = None
 
     def isPerspective(self) -> bool:
         return self._perspective

--- a/UM/Scene/Camera.py
+++ b/UM/Scene/Camera.py
@@ -141,7 +141,8 @@ class Camera(SceneNode.SceneNode):
     ##  Project a 3D position onto the 2D view plane.
     def project(self, position: Vector) -> Tuple[float, float]:
         projection = self._projection_matrix
-        view = self.getWorldTransformation().invert()
+        view = self.getWorldTransformation()
+        view.invert()
 
         position = position.preMultiply(view)
         position = position.preMultiply(projection)

--- a/UM/Scene/Camera.py
+++ b/UM/Scene/Camera.py
@@ -128,7 +128,7 @@ class Camera(SceneNode.SceneNode):
     ##  Project a 3D position onto the 2D view plane.
     def project(self, position: Vector) -> Tuple[float, float]:
         projection = self._projection_matrix
-        view = self.getWorldTransformation().getInverse()
+        view = self.getWorldTransformation().invert()
 
         position = position.preMultiply(view)
         position = position.preMultiply(projection)

--- a/UM/Scene/Camera.py
+++ b/UM/Scene/Camera.py
@@ -33,6 +33,7 @@ class Camera(SceneNode.SceneNode):
         self._window_height = 0  # type: int
         self._auto_adjust_view_port_size = True  # type: bool
         self.setCalculateBoundingBox(False)
+        self._cached_view_projection_matrix = None # type: Optional[Matrix]
 
     def __deepcopy__(self, memo: Dict[int, object]) -> "Camera":
         copy = cast(Camera, super().__deepcopy__(memo))
@@ -68,6 +69,17 @@ class Camera(SceneNode.SceneNode):
     def setViewportSize(self, width: int, height: int) -> None:
         self._viewport_width = width
         self._viewport_height = height
+
+    def getViewProjectionMatrix(self):
+        if self._cached_view_projection_matrix is None:
+            inverted_transformation = self.getWorldTransformation()
+            inverted_transformation.invert()
+            self._cached_view_projection_matrix = self._projection_matrix.multiply(inverted_transformation, copy = True)
+        return self._cached_view_projection_matrix
+
+    def _updateWorldTransformation(self):
+        self._cached_view_projection_matrix = None
+        super()._updateWorldTransformation()
     
     def getViewportHeight(self) -> int:
         return self._viewport_height

--- a/UM/Scene/SceneNode.py
+++ b/UM/Scene/SceneNode.py
@@ -468,7 +468,7 @@ class SceneNode:
         if not self._enabled or orientation == self._orientation:
             return
 
-        new_transform_matrix = Matrix()
+
         if transform_space == SceneNode.TransformSpace.World:
             if self.getWorldOrientation() == orientation:
                 return
@@ -478,7 +478,7 @@ class SceneNode:
             orientation_matrix = orientation.toMatrix()
 
         euler_angles = orientation_matrix.getEuler()
-
+        new_transform_matrix = Matrix()
         new_transform_matrix.compose(scale = self._scale, angles = euler_angles, translate = self._position, shear = self._shear)
         self._transformation = new_transform_matrix
         self._transformChanged()

--- a/UM/Scene/SceneNode.py
+++ b/UM/Scene/SceneNode.py
@@ -679,7 +679,7 @@ class SceneNode:
         self._orientation = orientation
 
         if self._parent:
-            self._world_transformation = self._parent.getWorldTransformation().multiply(self._transformation, copy = True)
+            self._world_transformation = self._parent.getWorldTransformation().multiply(self._transformation)
         else:
             self._world_transformation = self._transformation
 

--- a/UM/Scene/SceneNode.py
+++ b/UM/Scene/SceneNode.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2018 Ultimaker B.V.
+# Copyright (c) 2019 Ultimaker B.V.
 # Uranium is released under the terms of the LGPLv3 or higher.
 
 from copy import deepcopy
@@ -14,8 +14,6 @@ from UM.Mesh.MeshData import MeshData
 from UM.Signal import Signal, signalemitter
 from UM.Mesh.MeshBuilder import MeshBuilder
 from UM.Logger import Logger
-
-from UM.Decorators import timeit
 
 from UM.Scene.SceneNodeDecorator import SceneNodeDecorator
 
@@ -82,10 +80,9 @@ class SceneNode:
         self._decorators = []  # type: List[SceneNodeDecorator]
 
         # Store custom settings to be compatible with Savitar SceneNode
-        self._settings = {} #type: Dict[str, Any]
+        self._settings = {}  # type: Dict[str, Any]
 
         ## Signals
-        self.boundingBoxChanged.connect(self.calculateBoundingBoxMesh)
         self.parentChanged.connect(self._onParentChanged)
 
         if parent:
@@ -131,6 +128,8 @@ class SceneNode:
     ##  Get the MeshData of the bounding box
     #   \returns \type{MeshData} Bounding box mesh.
     def getBoundingBoxMesh(self) -> Optional[MeshData]:
+        if self._bounding_box_mesh is None:
+            self.calculateBoundingBoxMesh()
         return self._bounding_box_mesh
 
     ##  (re)Calculate the bounding box mesh.
@@ -692,6 +691,7 @@ class SceneNode:
         if not self._calculate_aabb:
             return
         self._aabb = None
+        self._bounding_box_mesh = None
         if self._parent:
             self._parent._resetAABB()
         self.boundingBoxChanged.emit()

--- a/UM/Scene/SceneNode.py
+++ b/UM/Scene/SceneNode.py
@@ -418,7 +418,7 @@ class SceneNode:
     #   \returns 4x4 transformation matrix
     def getWorldTransformation(self) -> Matrix:
         if self._world_transformation is None:
-            self._updateTransformation()
+            self._updateWorldTransformation()
 
         return Matrix(self._world_transformation.getData())
 
@@ -426,7 +426,7 @@ class SceneNode:
     #   \retuns transformation 4x4 (homogenous) matrix
     def getLocalTransformation(self) -> Matrix:
         if self._transformation is None:
-            self._updateTransformation()
+            self._updateLocalTransformation()
 
         return Matrix(self._transformation.getData())
 
@@ -667,7 +667,7 @@ class SceneNode:
         for child in self._children:
             child._transformChanged()
 
-    def _updateTransformation(self) -> None:
+    def _updateLocalTransformation(self):
         translation, euler_angle_matrix, scale, shear = self._transformation.decompose()
 
         self._position = translation
@@ -677,6 +677,7 @@ class SceneNode:
         orientation.setByMatrix(euler_angle_matrix)
         self._orientation = orientation
 
+    def _updateWorldTransformation(self):
         if self._parent:
             self._world_transformation = self._parent.getWorldTransformation().multiply(self._transformation)
         else:
@@ -686,6 +687,10 @@ class SceneNode:
         self._derived_position = world_translation
         self._derived_scale = world_scale
         self._derived_orientation.setByMatrix(world_euler_angle_matrix)
+
+    def _updateTransformation(self) -> None:
+        self._updateLocalTransformation()
+        self._updateWorldTransformation()
 
     def _resetAABB(self) -> None:
         if not self._calculate_aabb:

--- a/UM/Scene/SceneNode.py
+++ b/UM/Scene/SceneNode.py
@@ -15,6 +15,8 @@ from UM.Signal import Signal, signalemitter
 from UM.Mesh.MeshBuilder import MeshBuilder
 from UM.Logger import Logger
 
+from UM.Decorators import timeit
+
 from UM.Scene.SceneNodeDecorator import SceneNodeDecorator
 
 ##  A scene node object.
@@ -667,27 +669,23 @@ class SceneNode:
             child._transformChanged()
 
     def _updateTransformation(self) -> None:
-        scale, shear, euler_angles, translation, mirror = self._transformation.decompose()
+        translation, euler_angle_matrix, scale, shear = self._transformation.decompose()
+
         self._position = translation
         self._scale = scale
         self._shear = shear
-        self._mirror = mirror
         orientation = Quaternion()
-        euler_angle_matrix = Matrix()
-        euler_angle_matrix.setByEuler(euler_angles.x, euler_angles.y, euler_angles.z)
         orientation.setByMatrix(euler_angle_matrix)
         self._orientation = orientation
+
         if self._parent:
             self._world_transformation = self._parent.getWorldTransformation().multiply(self._transformation, copy = True)
         else:
             self._world_transformation = self._transformation
 
-        world_scale, world_shear, world_euler_angles, world_translation, world_mirror = self._world_transformation.decompose()
+        world_translation, world_euler_angle_matrix, world_scale, world_shear = self._world_transformation.decompose()
         self._derived_position = world_translation
         self._derived_scale = world_scale
-
-        world_euler_angle_matrix = Matrix()
-        world_euler_angle_matrix.setByEuler(world_euler_angles.x, world_euler_angles.y, world_euler_angles.z)
         self._derived_orientation.setByMatrix(world_euler_angle_matrix)
 
     def _resetAABB(self) -> None:

--- a/UM/Scene/SceneNode.py
+++ b/UM/Scene/SceneNode.py
@@ -420,7 +420,7 @@ class SceneNode:
         if self._world_transformation is None:
             self._updateWorldTransformation()
 
-        return Matrix(self._world_transformation.getData())
+        return self._world_transformation.copy()
 
     ##  \brief Returns the local transformation with respect to its parent. (from parent to local)
     #   \retuns transformation 4x4 (homogenous) matrix
@@ -428,10 +428,10 @@ class SceneNode:
         if self._transformation is None:
             self._updateLocalTransformation()
 
-        return Matrix(self._transformation.getData())
+        return self._transformation.copy()
 
     def setTransformation(self, transformation: Matrix):
-        self._transformation = Matrix(transformation.getData()) # Make a copy to ensure we never change the given transformation
+        self._transformation = transformation.copy() # Make a copy to ensure we never change the given transformation
         self._transformChanged()
 
     ##  Get the local orientation value.
@@ -550,7 +550,7 @@ class SceneNode:
         elif transform_space == SceneNode.TransformSpace.Parent:
             self._transformation.preMultiply(translation_matrix)
         elif transform_space == SceneNode.TransformSpace.World:
-            world_transformation = Matrix(self._world_transformation.getData())
+            world_transformation = self._world_transformation.copy()
             self._transformation.multiply(self._world_transformation.getInverse())
             self._transformation.multiply(translation_matrix)
             self._transformation.multiply(world_transformation)

--- a/UM/Scene/SceneNode.py
+++ b/UM/Scene/SceneNode.py
@@ -16,7 +16,6 @@ from UM.Mesh.MeshBuilder import MeshBuilder
 from UM.Logger import Logger
 
 from UM.Scene.SceneNodeDecorator import SceneNodeDecorator
-
 ##  A scene node object.
 #
 #   These objects can hold a mesh and multiple children. Each node has a transformation matrix
@@ -473,7 +472,7 @@ class SceneNode:
         if transform_space == SceneNode.TransformSpace.World:
             if self.getWorldOrientation() == orientation:
                 return
-            new_orientation = orientation * (self.getWorldOrientation() * self._orientation.getInverse()).getInverse()
+            new_orientation = orientation * (self.getWorldOrientation() * self._orientation.getInverse()).invert()
             orientation_matrix = new_orientation.toMatrix()
         else:  # Local
             orientation_matrix = orientation.toMatrix()

--- a/UM/View/RenderBatch.py
+++ b/UM/View/RenderBatch.py
@@ -192,9 +192,10 @@ class RenderBatch():
         if self._state_setup_callback:
             self._state_setup_callback(self._gl)
 
-        self._view_matrix = camera.getWorldTransformation().getInverse()
+        self._view_matrix = camera.getWorldTransformation()
+        self._view_matrix.invert()
         self._projection_matrix = camera.getProjectionMatrix()
-        self._view_projection_matrix = self._projection_matrix .multiply(self._view_matrix, copy = True)
+        self._view_projection_matrix = self._projection_matrix.multiply(self._view_matrix, copy = True)
 
         self._shader.updateBindings(
             view_matrix = self._view_matrix,

--- a/UM/View/RenderBatch.py
+++ b/UM/View/RenderBatch.py
@@ -195,7 +195,7 @@ class RenderBatch():
         self._view_matrix = camera.getWorldTransformation()
         self._view_matrix.invert()
         self._projection_matrix = camera.getProjectionMatrix()
-        self._view_projection_matrix = self._projection_matrix.multiply(self._view_matrix, copy = True)
+        self._view_projection_matrix = camera.getViewProjectionMatrix()
 
         self._shader.updateBindings(
             view_matrix = self._view_matrix,


### PR DESCRIPTION
On my machine, this made the decompose step 67% faster. This, in turn, made all scene operations 24.4% faster. Mileage may vary from system to system but I'm pretty sure that this should be better on most systems.

