### PR TITLE
Support Pytest 4, config.warn is no more

### DIFF
--- a/tests/benchmarks/conftest.py
+++ b/tests/benchmarks/conftest.py
@@ -2,6 +2,7 @@
 # Uranium is released under the terms of the LGPLv3 or higher.
 
 import pytest
+import warnings
 
 warn = True
 
@@ -12,7 +13,7 @@ def pytest_ignore_collect(path, config):
     else:
         global warn
         if warn:
-            config.warn("", "Skipping benchmarks because pytest-benchmark plugin was not found.", "tests/benchmarks/conftest.py")
+            warnings.warn(pytest.PytestWarning("Skipping benchmarks because pytest-benchmark plugin was not found."))
             warn = False
 
         return True


### PR DESCRIPTION
https://docs.pytest.org/en/latest/deprecations.html#config-warn-and-node-warn