### PR TITLE
Shader optimization

### DIFF
--- a/UM/Scene/Camera.py
+++ b/UM/Scene/Camera.py
@@ -33,7 +33,6 @@ class Camera(SceneNode.SceneNode):
         self._window_height = 0  # type: int
         self._auto_adjust_view_port_size = True  # type: bool
         self.setCalculateBoundingBox(False)
-        self._cached_view_projection_matrix = None # type: Optional[Matrix]
 
     def __deepcopy__(self, memo: Dict[int, object]) -> "Camera":
         copy = cast(Camera, super().__deepcopy__(memo))
@@ -70,15 +69,7 @@ class Camera(SceneNode.SceneNode):
         self._viewport_width = width
         self._viewport_height = height
 
-    def getViewProjectionMatrix(self):
-        if self._cached_view_projection_matrix is None:
-            inverted_transformation = self.getWorldTransformation()
-            inverted_transformation.invert()
-            self._cached_view_projection_matrix = self._projection_matrix.multiply(inverted_transformation, copy = True)
-        return self._cached_view_projection_matrix
-
     def _updateWorldTransformation(self):
-        self._cached_view_projection_matrix = None
         super()._updateWorldTransformation()
     
     def getViewportHeight(self) -> int:
@@ -95,7 +86,6 @@ class Camera(SceneNode.SceneNode):
     #   \param matrix The projection matrix to use for this camera.
     def setProjectionMatrix(self, matrix: Matrix) -> None:
         self._projection_matrix = matrix
-        self._cached_view_projection_matrix = None
 
     def isPerspective(self) -> bool:
         return self._perspective

--- a/UM/View/RenderBatch.py
+++ b/UM/View/RenderBatch.py
@@ -86,7 +86,6 @@ class RenderBatch():
 
         self._view_matrix = None
         self._projection_matrix = None
-        self._view_projection_matrix = None
 
         self._gl = OpenGL.getInstance().getBindingsObject()
 
@@ -195,12 +194,10 @@ class RenderBatch():
         self._view_matrix = camera.getWorldTransformation()
         self._view_matrix.invert()
         self._projection_matrix = camera.getProjectionMatrix()
-        self._view_projection_matrix = camera.getViewProjectionMatrix()
 
         self._shader.updateBindings(
             view_matrix = self._view_matrix,
             projection_matrix = self._projection_matrix,
-            view_projection_matrix = self._view_projection_matrix,
             view_position = camera.getWorldPosition(),
             light_0_position = camera.getWorldPosition() + Vector(0, 50, 0)
         )
@@ -239,14 +236,9 @@ class RenderBatch():
             normal_matrix.invert()
             normal_matrix.transpose()
 
-        model_view_matrix = transformation.preMultiply(self._view_matrix, copy = True)
-        model_view_projection_matrix = transformation.preMultiply(self._view_projection_matrix, copy = True)
-
         self._shader.updateBindings(
             model_matrix = transformation,
-            normal_matrix = normal_matrix,
-            model_view_matrix = model_view_matrix,
-            model_view_projection_matrix = model_view_projection_matrix
+            normal_matrix = normal_matrix
         )
 
         if item["uniforms"] is not None:

--- a/resources/shaders/color.shader
+++ b/resources/shaders/color.shader
@@ -1,11 +1,13 @@
 [shaders]
 vertex =
-    uniform highp mat4 u_modelViewProjectionMatrix;
+    uniform highp mat4 u_modelMatrix;
+    uniform highp mat4 u_viewMatrix;
+    uniform highp mat4 u_projectionMatrix;
 
     attribute highp vec4 a_vertex; //Vertex coordinate.
     void main()
     {
-        gl_Position = u_modelViewProjectionMatrix * a_vertex; //Transform the vertex coordinates with the model view projection.
+        gl_Position = u_projectionMatrix * u_viewMatrix * u_modelMatrix * a_vertex; //Transform the vertex coordinates with the model view projection.
     }
 
 fragment =
@@ -18,12 +20,14 @@ fragment =
 
 vertex41core =
     #version 410
-    uniform highp mat4 u_modelViewProjectionMatrix;
+    uniform highp mat4 u_modelMatrix;
+    uniform highp mat4 u_viewMatrix;
+    uniform highp mat4 u_projectionMatrix;
 
     in highp vec4 a_vertex; //Vertex coordinate.
     void main()
     {
-        gl_Position = u_modelViewProjectionMatrix * a_vertex; //Transform the vertex coordinates with the model view projection.
+        gl_Position = u_projectionMatrix * u_viewMatrix * u_modelMatrix * a_vertex; //Transform the vertex coordinates with the model view projection.
     }
 
 fragment41core =
@@ -44,7 +48,9 @@ u_color = [0.5, 0.5, 0.5, 1.0]
 u_z_bias = 0.0
 
 [bindings]
-u_modelViewProjectionMatrix = model_view_projection_matrix
+u_modelMatrix = model_matrix
+u_viewMatrix = view_matrix
+u_projectionMatrix = projection_matrix
 
 [attributes]
 a_vertex = vertex

--- a/resources/shaders/default.shader
+++ b/resources/shaders/default.shader
@@ -1,13 +1,15 @@
 [shaders]
 vertex =
-    uniform highp mat4 u_modelViewProjectionMatrix;
+    uniform highp mat4 u_modelMatrix;
+    uniform highp mat4 u_viewMatrix;
+    uniform highp mat4 u_projectionMatrix;
 
     attribute highp vec4 a_vertex;
     attribute lowp vec4 a_color;
     varying lowp vec4 v_color;
     void main()
     {
-        gl_Position = u_modelViewProjectionMatrix * a_vertex;
+        gl_Position = u_projectionMatrix * u_viewMatrix * u_modelMatrix * a_vertex;
         v_color = a_color;
     }
 
@@ -29,14 +31,16 @@ fragment =
 
 vertex41core =
     #version 410
-    uniform highp mat4 u_modelViewProjectionMatrix;
+    uniform highp mat4 u_modelMatrix;
+    uniform highp mat4 u_viewMatrix;
+    uniform highp mat4 u_projectionMatrix;
 
     in highp vec4 a_vertex;
     in lowp vec4 a_color;
     out lowp vec4 v_color;
     void main()
     {
-        gl_Position = u_modelViewProjectionMatrix * a_vertex;
+        gl_Position = u_projectionMatrix * u_viewMatrix * u_modelMatrix * a_vertex;
         v_color = a_color;
     }
 
@@ -62,7 +66,9 @@ fragment41core =
 u_color = [0.5, 0.5, 0.5, 1.0]
 
 [bindings]
-u_modelViewProjectionMatrix = model_view_projection_matrix
+u_modelMatrix = model_matrix
+u_viewMatrix = view_matrix
+u_projectionMatrix = projection_matrix
 
 [attributes]
 a_vertex = vertex

--- a/resources/shaders/object.shader
+++ b/resources/shaders/object.shader
@@ -1,7 +1,9 @@
 [shaders]
 vertex =
     uniform highp mat4 u_modelMatrix;
-    uniform highp mat4 u_viewProjectionMatrix;
+    uniform highp mat4 u_viewMatrix;
+    uniform highp mat4 u_projectionMatrix;
+
     uniform highp mat4 u_normalMatrix;
 
     attribute highp vec4 a_vertex;
@@ -14,7 +16,7 @@ vertex =
     void main()
     {
         vec4 world_space_vert = u_modelMatrix * a_vertex;
-        gl_Position = u_viewProjectionMatrix * world_space_vert;
+        gl_Position = u_projectionMatrix * u_viewMatrix * world_space_vert;
 
         v_vertex = world_space_vert.xyz;
         v_normal = (u_normalMatrix * normalize(a_normal)).xyz;
@@ -59,7 +61,9 @@ fragment =
 vertex41core =
     #version 410
     uniform highp mat4 u_modelMatrix;
-    uniform highp mat4 u_viewProjectionMatrix;
+    uniform highp mat4 u_viewMatrix;
+    uniform highp mat4 u_projectionMatrix;
+
     uniform highp mat4 u_normalMatrix;
 
     attribute highp vec4 a_vertex;
@@ -72,7 +76,7 @@ vertex41core =
     void main()
     {
         vec4 world_space_vert = u_modelMatrix * a_vertex;
-        gl_Position = u_viewProjectionMatrix * world_space_vert;
+        gl_Position = u_projectionMatrix * u_viewMatrix * world_space_vert;
 
         v_vertex = world_space_vert.xyz;
         v_normal = (u_normalMatrix * normalize(a_normal)).xyz;
@@ -123,7 +127,8 @@ u_shininess = 20.0
 
 [bindings]
 u_modelMatrix = model_matrix
-u_viewProjectionMatrix = view_projection_matrix
+u_viewMatrix = view_matrix
+u_projectionMatrix = projection_matrix
 u_normalMatrix = normal_matrix
 u_viewPosition = view_position
 u_lightPosition = light_0_position

--- a/resources/shaders/platform.shader
+++ b/resources/shaders/platform.shader
@@ -1,7 +1,9 @@
 [shaders]
 vertex =
-    uniform highp mat4 u_viewProjectionMatrix;
     uniform highp mat4 u_modelMatrix;
+    uniform highp mat4 u_viewMatrix;
+    uniform highp mat4 u_projectionMatrix;
+
     uniform highp mat4 u_normalMatrix;
 
     attribute highp vec4 a_vertex;
@@ -15,7 +17,7 @@ vertex =
     void main()
     {
         vec4 world_space_vert = u_modelMatrix * a_vertex;
-        gl_Position = u_viewProjectionMatrix * world_space_vert;
+        gl_Position = u_projectionMatrix * u_viewMatrix * world_space_vert;
 
         v_vertex = world_space_vert.xyz;
         v_normal = (u_normalMatrix * normalize(a_normal)).xyz;
@@ -59,8 +61,10 @@ fragment =
 
 vertex41core =
     #version 410
-    uniform highp mat4 u_viewProjectionMatrix;
     uniform highp mat4 u_modelMatrix;
+    uniform highp mat4 u_viewMatrix;
+    uniform highp mat4 u_projectionMatrix;
+
     uniform highp mat4 u_normalMatrix;
 
     in highp vec4 a_vertex;
@@ -74,7 +78,7 @@ vertex41core =
     void main()
     {
         vec4 world_space_vert = u_modelMatrix * a_vertex;
-        gl_Position = u_viewProjectionMatrix * world_space_vert;
+        gl_Position = u_projectionMatrix * u_viewMatrix * world_space_vert;
 
         v_vertex = world_space_vert.xyz;
         v_normal = (u_normalMatrix * normalize(a_normal)).xyz;
@@ -125,8 +129,9 @@ u_opacity = 0.5
 u_texture = 0
 
 [bindings]
-u_viewProjectionMatrix = view_projection_matrix
 u_modelMatrix = model_matrix
+u_viewMatrix = view_matrix
+u_projectionMatrix = projection_matrix
 u_normalMatrix = normal_matrix
 u_lightPosition = light_0_position
 u_viewPosition = camera_position

--- a/resources/shaders/selection.shader
+++ b/resources/shaders/selection.shader
@@ -1,12 +1,14 @@
 [shaders]
 vertex =
-    uniform highp mat4 u_modelViewProjectionMatrix;
+    uniform highp mat4 u_modelMatrix;
+    uniform highp mat4 u_viewMatrix;
+    uniform highp mat4 u_projectionMatrix;
 
     attribute highp vec4 a_vertex;
 
     void main()
     {
-        gl_Position = u_modelViewProjectionMatrix * a_vertex;
+        gl_Position = u_projectionMatrix * u_viewMatrix * u_modelMatrix * a_vertex;
     }
 
 fragment =
@@ -19,13 +21,15 @@ fragment =
 
 vertex41core =
     #version 410
-    uniform highp mat4 u_modelViewProjectionMatrix;
+    uniform highp mat4 u_modelMatrix;
+    uniform highp mat4 u_viewMatrix;
+    uniform highp mat4 u_projectionMatrix;
 
     in highp vec4 a_vertex;
 
     void main()
     {
-        gl_Position = u_modelViewProjectionMatrix * a_vertex;
+        gl_Position = u_projectionMatrix * u_viewMatrix * u_modelMatrix * a_vertex;
     }
 
 fragment41core =
@@ -41,7 +45,9 @@ fragment41core =
 [defaults]
 
 [bindings]
-u_modelViewProjectionMatrix = model_view_projection_matrix
+u_modelMatrix = model_matrix
+u_viewMatrix = view_matrix
+u_projectionMatrix = projection_matrix
 u_color = selection_color
 
 [attributes]

--- a/resources/shaders/toolhandle.shader
+++ b/resources/shaders/toolhandle.shader
@@ -1,6 +1,8 @@
 [shaders]
 vertex =
-    uniform highp mat4 u_modelViewProjectionMatrix;
+    uniform highp mat4 u_modelMatrix;
+    uniform highp mat4 u_viewMatrix;
+    uniform highp mat4 u_projectionMatrix;
 
     attribute highp vec4 a_vertex;
     attribute lowp vec4 a_color;
@@ -9,7 +11,7 @@ vertex =
 
     void main()
     {
-        gl_Position = u_modelViewProjectionMatrix * a_vertex;
+        gl_Position = u_projectionMatrix * u_viewMatrix * u_modelMatrix * a_vertex;
         v_color = a_color;
     }
 
@@ -34,7 +36,9 @@ fragment =
 
 vertex41core =
     #version 410
-    uniform highp mat4 u_modelViewProjectionMatrix;
+    uniform highp mat4 u_modelMatrix;
+    uniform highp mat4 u_viewMatrix;
+    uniform highp mat4 u_projectionMatrix;
 
     in highp vec4 a_vertex;
     in lowp vec4 a_color;
@@ -43,7 +47,7 @@ vertex41core =
 
     void main()
     {
-        gl_Position = u_modelViewProjectionMatrix * a_vertex;
+        gl_Position = u_projectionMatrix * u_viewMatrix * u_modelMatrix * a_vertex;
         v_color = a_color;
     }
 
@@ -74,7 +78,9 @@ u_activeColor = [0.5, 0.5, 0.5, 1.0]
 u_disabledMultiplier = 0.75
 
 [bindings]
-u_modelViewProjectionMatrix = model_view_projection_matrix
+u_modelMatrix = model_matrix
+u_viewMatrix = view_matrix
+u_projectionMatrix = projection_matrix
 
 [attributes]
 a_vertex = vertex


### PR DESCRIPTION
Turns out doing the model-view-projection multiplication matrix repeatedly in the shader is still faster than doing it once per render in python.

Edit: Don't merge before the 4.1 branch is made! / CURA-6477