### PR TITLE
ShaderEffect crashes on Linux with Qt 5.13 so replace with ColorOverlay.

### DIFF
--- a/UM/Qt/qml/UM/RecolorImage.qml
+++ b/UM/Qt/qml/UM/RecolorImage.qml
@@ -2,6 +2,7 @@
 // Uranium is released under the terms of the LGPLv3 or higher.
 
 import QtQuick 2.1
+import QtGraphicalEffects 1.0
 import UM 1.3 as UM
 
 Item
@@ -9,7 +10,7 @@ Item
     id: base;
 
     property alias source: img.source
-    property alias color: shader.color
+    property alias color: overlay.color
     property alias sourceSize: img.sourceSize
 
     Image
@@ -21,59 +22,10 @@ Item
         sourceSize.height: parent.height
     }
 
-    ShaderEffect
-    {
-        id: shader
+    ColorOverlay {
+        id: overlay
         anchors.fill: parent
-
-        property variant src: img
-        property color color: "#fff"
-
-        vertexShader: UM.OpenGLContextProxy.isLegacyOpenGL ?
-            "
-            uniform highp mat4 qt_Matrix;
-            attribute highp vec4 qt_Vertex;
-            attribute highp vec2 qt_MultiTexCoord0;
-            varying highp vec2 coord;
-            void main() {
-                coord = qt_MultiTexCoord0;
-                gl_Position = qt_Matrix * qt_Vertex;
-            }
-            " : "
-            #version 410
-            uniform highp mat4 qt_Matrix;
-            in highp vec4 qt_Vertex;
-            in highp vec2 qt_MultiTexCoord0;
-            out highp vec2 coord;
-            void main() {
-                coord = qt_MultiTexCoord0;
-                gl_Position = qt_Matrix * qt_Vertex;
-            }
-            "
-
-        fragmentShader: UM.OpenGLContextProxy.isLegacyOpenGL ?
-            "
-            varying highp vec2 coord;
-            uniform sampler2D src;
-            uniform lowp vec4 color;
-            uniform lowp float qt_Opacity;
-            void main() {
-                lowp vec4 tex = texture2D(src, coord);
-                lowp float alpha = tex.a  * qt_Opacity;
-                gl_FragColor = vec4(color.r * alpha, color.g * alpha, color.b * alpha, alpha);
-            }
-            " : "
-            #version 410
-            in highp vec2 coord;
-            uniform sampler2D src;
-            uniform lowp vec4 color;
-            uniform lowp float qt_Opacity;
-            out vec4 frag_color;
-            void main() {
-                lowp vec4 tex = texture(src, coord);
-                lowp float alpha = tex.a  * qt_Opacity;
-                frag_color = vec4(color.r * alpha, color.g * alpha, color.b * alpha, alpha);
-            }
-            "
+        source: img
+        color: "#fff"
     }
 }


### PR DESCRIPTION
Replace ShaderEffect with ColorOverlay. As far as I can tell, the visual effect is equivalent. Tested on Linux using Qt 5.10 and Qt 5.13.

Possibly fixes https://github.com/Ultimaker/Cura/issues/6008.
