### PR TITLE
Fix tools when dragging over mouseareas

### DIFF
--- a/UM/Qt/QtMouseDevice.py
+++ b/UM/Qt/QtMouseDevice.py
@@ -17,19 +17,19 @@ class QtMouseDevice(InputDevice):
 
     def handleEvent(self, event):
         if event.type() == QEvent.MouseButtonPress:
-            ex, ey = self._normalizeCoordinates(event.x(), event.y())
+            ex, ey = self._normalizeCoordinates(event.windowPos().x(), event.windowPos().y())
             e = MouseEvent(MouseEvent.MousePressEvent, ex, ey, self._x, self._y, self._qtButtonsToButtonList(event.buttons()))
             self._x = ex
             self._y = ey
             self.event.emit(e)
         elif event.type() == QEvent.MouseMove:
-            ex, ey = self._normalizeCoordinates(event.x(), event.y())
+            ex, ey = self._normalizeCoordinates(event.windowPos().x(), event.windowPos().y())
             e = MouseEvent(MouseEvent.MouseMoveEvent, ex, ey, self._x, self._y, self._qtButtonsToButtonList(event.buttons()))
             self._x = ex
             self._y = ey
             self.event.emit(e)
         elif event.type() == QEvent.MouseButtonRelease:
-            ex, ey = self._normalizeCoordinates(event.x(), event.y())
+            ex, ey = self._normalizeCoordinates(event.windowPos().x(), event.windowPos().y())
             e = MouseEvent(MouseEvent.MouseReleaseEvent, ex, ey, self._x, self._y, self._qtButtonsToButtonList(event.button()))
             self._x = ex
             self._y = ey


### PR DESCRIPTION
This PR fixes the behavior of tools (translate, rotate, scale) when dragging the mouse over QML elements that contain a MouseArea (such as SettingItems in the sidebar, or the object list) during the operation.

Steps to reproduce the issue:
* load a model
* select the model
* drag the red axis, all the way over the settings float/sidebar

Result:
While over parts of the settings floater, the model jumps to the left of the window, until the pointer is dragged off the QML element that contains a MouseArea.
