### PR TITLE
Disable select face feature when gl_PrimitiveID not supported by GLSL.

### DIFF
--- a/UM/View/GL/OpenGL.py
+++ b/UM/View/GL/OpenGL.py
@@ -98,6 +98,11 @@ class OpenGL:
 
         self._opengl_version = self._gl.glGetString(self._gl.GL_VERSION) #type: str
 
+        try:
+            self._opengl_shading_language_version = float(self._gl.glGetString(self._gl.GL_SHADING_LANGUAGE_VERSION))
+        except:
+            self._opengl_shading_language_version = 1.0
+
         if not self.hasFrameBufferObjects():
             Logger.log("w", "No frame buffer support, falling back to texture copies.")
 
@@ -105,6 +110,7 @@ class OpenGL:
         Logger.log("d", "OpenGL Version:  %s", self._opengl_version)
         Logger.log("d", "OpenGL Vendor:   %s", self._gl.glGetString(self._gl.GL_VENDOR))
         Logger.log("d", "OpenGL Renderer: %s", self._gpu_type)
+        Logger.log("d", "GLSL Version:    %f", self._opengl_shading_language_version)
 
     ##  Check if the current OpenGL implementation supports FrameBuffer Objects.
     #
@@ -117,6 +123,12 @@ class OpenGL:
     #   \return Version of OpenGL
     def getOpenGLVersion(self) -> str:
         return self._opengl_version
+
+    ##  Get the current OpenGL shading language version.
+    #
+    #   \return Shading language version of OpenGL
+    def getOpenGLShadingLanguageVersion(self) -> float:
+        return self._opengl_shading_language_version
 
     ##  Get the current GPU vendor name.
     #

--- a/plugins/Tools/RotateTool/RotateTool.py
+++ b/plugins/Tools/RotateTool/RotateTool.py
@@ -52,7 +52,6 @@ class RotateTool(Tool):
         self._rotating = False
         self.setExposedProperties("ToolHint", "RotationSnap", "RotationSnapAngle", "SelectFaceSupported")
         self._saved_node_positions = []
-        #self._select_face_supported = OpenGL.getInstance().getOpenGLShadingLanguageVersion() >= 1.5
 
     ##  Handle mouse and keyboard events
     #

--- a/plugins/Tools/RotateTool/RotateTool.py
+++ b/plugins/Tools/RotateTool/RotateTool.py
@@ -19,6 +19,8 @@ from UM.Operations.GroupedOperation import GroupedOperation
 from UM.Operations.SetTransformOperation import SetTransformOperation
 from UM.Operations.LayFlatOperation import LayFlatOperation
 
+from UM.View.GL.OpenGL import OpenGL
+
 from . import RotateToolHandle
 
 import math
@@ -48,8 +50,9 @@ class RotateTool(Tool):
         self._iterations = 0
         self._total_iterations = 0
         self._rotating = False
-        self.setExposedProperties("ToolHint", "RotationSnap", "RotationSnapAngle")
+        self.setExposedProperties("ToolHint", "RotationSnap", "RotationSnapAngle", "SelectFaceSupported")
         self._saved_node_positions = []
+        #self._select_face_supported = OpenGL.getInstance().getOpenGLShadingLanguageVersion() >= 1.5
 
     ##  Handle mouse and keyboard events
     #
@@ -184,6 +187,12 @@ class RotateTool(Tool):
     #   \return type(String) fully formatted string showing the angle by which the mesh(es) are rotated
     def getToolHint(self):
         return "%d°" % round(math.degrees(self._angle)) if self._angle else None
+
+    ##  Get whether the select face feature is supported
+    #
+    #   \return type(Boolean)
+    def getSelectFaceSupported(self):
+        return OpenGL.getInstance().getOpenGLShadingLanguageVersion() >= 1.5
 
     ##  Get the state of the "snap rotation to N-degree increments" option
     #

--- a/plugins/Tools/RotateTool/RotateTool.qml
+++ b/plugins/Tools/RotateTool/RotateTool.qml
@@ -61,6 +61,8 @@ Item
 
         enabled: UM.Selection.hasFaceSelected;
         onClicked: CuraActions.bottomFaceSelection();
+
+        visible: UM.ActiveTool.properties.getValue("SelectFaceSupported");
     }
 
     CheckBox
@@ -92,6 +94,8 @@ Item
 
         checked: UM.Selection.faceSelectMode
         onClicked: UM.Selection.setFaceSelectMode(checked)
+
+        visible: UM.ActiveTool.properties.getValue("SelectFaceSupported");
     }
 
     Binding

--- a/resources/shaders/selection.shader
+++ b/resources/shaders/selection.shader
@@ -18,10 +18,12 @@ fragment =
     {
         gl_FragColor = u_color;
 
+ #if __VERSION__ >= 150
         gl_FragColor.r += ( gl_PrimitiveID           % 0x10) / 255.;
         gl_FragColor.g += ((gl_PrimitiveID /   0x10) % 0x10) / 255.;
         gl_FragColor.b += ((gl_PrimitiveID /  0x100) % 0x10) / 255.;
         gl_FragColor.a += ((gl_PrimitiveID / 0x1000) % 0x10) / 255.;
+ #endif
     }
 
 vertex41core =


### PR DESCRIPTION
The new feature to select a face and then rotate the model so that the face is at the bottom relies on a GLSL feature (gl_PrimitiveID) that isn't in versions of GLSL < 1.5. Therefore, for those early versions of GLSL, the select face feature is hidden.