### PR TITLE
Add "restore window geometry" preference

### DIFF
--- a/UM/Qt/Bindings/MainWindow.py
+++ b/UM/Qt/Bindings/MainWindow.py
@@ -47,6 +47,13 @@ class MainWindow(QQuickWindow):
         self._preferences.addPreference("general/window_left", 50)
         self._preferences.addPreference("general/window_top", 50)
         self._preferences.addPreference("general/window_state", Qt.WindowNoState)
+        self._preferences.addPreference("general/restore_window_geometry", True)
+
+        if not self._preferences.getValue("general/restore_window_geometry"):
+            self._preferences.resetPreference("general/window_width")
+            self._preferences.resetPreference("general/window_height")
+            self._preferences.resetPreference("general/window_left")
+            self._preferences.resetPreference("general/window_top")
 
         # Restore window geometry
         self.setWidth(int(self._preferences.getValue("general/window_width")))


### PR DESCRIPTION
This PR adds a preference around restoring the previous window position/size to the last used position/size on start up. This would be a workaround for those setups where starting Cura on a secondary screen will prevent it from working. 

Contributes to https://github.com/Ultimaker/Cura/issues/5651#issuecomment-488048392 and the rest of these issues: https://github.com/ultimaker/cura/issues?utf8=%E2%9C%93&q=is%3Aissue+window_left+is%3Aopen+

There will be a companion PR for Cura to add a checkbox for the preference.