### PR TITLE
RotateTool: Check whether tool is enabled

### DIFF
--- a/plugins/Tools/RotateTool/RotateTool.py
+++ b/plugins/Tools/RotateTool/RotateTool.py
@@ -75,7 +75,7 @@ class RotateTool(Tool):
             # Snap is "toggled back" when releasing the shift button
             self.setRotationSnap(not self._snap_rotation)
 
-        if event.type == Event.MousePressEvent and self._controller.getToolsEnabled():
+        if event.type == Event.MousePressEvent and self.getEnabled():
             # Start a rotate operation
             if MouseEvent.LeftButton not in event.buttons:
                 return False

--- a/plugins/Tools/RotateTool/RotateTool.py
+++ b/plugins/Tools/RotateTool/RotateTool.py
@@ -75,7 +75,7 @@ class RotateTool(Tool):
             # Snap is "toggled back" when releasing the shift button
             self.setRotationSnap(not self._snap_rotation)
 
-        if event.type == Event.MousePressEvent and self.getEnabled():
+        if event.type == Event.MousePressEvent and self._controller.getToolsEnabled() and self.getEnabled():
             # Start a rotate operation
             if MouseEvent.LeftButton not in event.buttons:
                 return False


### PR DESCRIPTION
Probably the original code is doing the same check, but I believe that we want to check here simply whether the tool is enabled or not.
If that is the case (which I hope), then this might be better readable at least.