### PR TITLE
Fix normals after mirroring.

### DIFF
--- a/UM/Mesh/MeshData.py
+++ b/UM/Mesh/MeshData.py
@@ -306,6 +306,26 @@ class MeshData:
         result.sort()
         return result
 
+    def invertNormals(self) -> None:
+        if self._normals is not None:
+            mirror = Matrix()
+            mirror.setToIdentity()
+            mirror.scaleByFactor(-1.0)
+            self._normals = transformNormals(self._normals, mirror)
+        if self._indices is not None:
+            new_indices = []
+            for face in self._indices:
+                new_indices.append([face[1], face[0], face[2]])
+            self._indices = NumPyUtil.immutableNDArray(new_indices)
+        else:
+            new_vertices = []
+            num_vertices = len(self._vertices)
+            for i in range(0, num_vertices, 3):
+                new_vertices.append(self._vertices[i + 1])
+                new_vertices.append(self._vertices[i])
+                new_vertices.append(self._vertices[i + 2])
+            self._vertices = NumPyUtil.immutableNDArray(new_vertices)
+
     def toString(self) -> str:
         return "MeshData(_vertices=" + str(self._vertices) + ", _normals=" + str(self._normals) + ", _indices=" + \
                str(self._indices) + ", _colors=" + str(self._colors) + ", _uvs=" + str(self._uvs) + ", _attributes=" + \

--- a/UM/Operations/MirrorOperation.py
+++ b/UM/Operations/MirrorOperation.py
@@ -28,6 +28,7 @@ class MirrorOperation(Operation.Operation):
 
     ##  Undo the operation.
     def undo(self):
+        self._node.invertNormals()
         self._node.setTransformation(self._old_transformation) #We stored the old transformation, so we can just restore that.
 
     ##  Re-apply the operation after undoing it.

--- a/UM/Operations/MirrorOperation.py
+++ b/UM/Operations/MirrorOperation.py
@@ -36,6 +36,7 @@ class MirrorOperation(Operation.Operation):
             center = self._node.getPosition()
             self._node.setPosition(-center)
         self._node.scale(self._mirror, SceneNode.TransformSpace.World) #Then mirror around the origin.
+        self._node.invertNormals()  # Because the mirror is done via a scale operation, the normals where inverted.
         if self._mirror_around_center: #If we moved the centre, move it back.
             self._node.setPosition(center)
 

--- a/UM/Scene/SceneNode.py
+++ b/UM/Scene/SceneNode.py
@@ -666,6 +666,12 @@ class SceneNode:
     def setSetting(self, key: str, value: str) -> None:
         self._settings[key] = value
 
+    def invertNormals(self) -> None:
+        for child in self._children:
+            child.invertNormals()
+        if self._mesh_data:
+            self._mesh_data.invertNormals()
+
     ##  private:
     def _transformChanged(self) -> None:
         self._updateTransformation()


### PR DESCRIPTION
A mirror operaion was done via 'scale', but that inverts the normals, which might give some issues (for example, 'Make Overhang Printable' wouldn't work correctly).

part of CURA-6924