### PR TITLE
Cache the results of the _findPlugin function

### DIFF
--- a/UM/PluginRegistry.py
+++ b/UM/PluginRegistry.py
@@ -61,6 +61,7 @@ class PluginRegistry(QObject):
         self._plugins_to_remove = []  # type: List[str]
 
         self._plugins = {}            # type: Dict[str, types.ModuleType]
+        self._found_plugins = {}      # type: Dict[str, types.ModuleType]  # Cache to speed up _findPlugin
         self._plugin_objects = {}     # type: Dict[str, PluginObject]
 
         self._plugin_locations = []  # type: List[str]
@@ -512,6 +513,8 @@ class PluginRegistry(QObject):
     #   \param plugin_id The name of the plugin to find
     #   \returns module if it was found None otherwise
     def _findPlugin(self, plugin_id: str) -> Optional[types.ModuleType]:
+        if plugin_id in self._found_plugins:
+            return self._found_plugins[plugin_id]
         location = None
         for folder in self._plugin_locations:
             location = self._locatePlugin(plugin_id, folder)
@@ -535,7 +538,7 @@ class PluginRegistry(QObject):
         finally:
             if file:
                 os.close(file) #type: ignore #MyPy gets the wrong output type from imp.find_module for some reason.
-
+        self._found_plugins[plugin_id] = module
         return module
 
     def _locatePlugin(self, plugin_id: str, folder: str) -> Optional[str]:

--- a/UM/PluginRegistry.py
+++ b/UM/PluginRegistry.py
@@ -27,6 +27,8 @@ if TYPE_CHECKING:
     from UM.Application import Application
 
 
+plugin_path_ignore_list = ["__pycache__", "tests", ".git"]
+
 ##  A central object to dynamically load modules as plugins.
 #
 #   The PluginRegistry class can load modules dynamically and use
@@ -549,6 +551,8 @@ class PluginRegistry(QObject):
             sub_folders = []
             for file in os.listdir(folder):
                 file_path = os.path.join(folder, file)
+                if file in plugin_path_ignore_list:
+                    continue
                 if os.path.isdir(file_path):
                     entry = (file, file_path)
                     sub_folders.append(entry)


### PR DESCRIPTION
When loading a single plugin, the function was called twice (once for actually loading it, once for populating the metadata). Since that is pretty wasteful, we can just cache the results the first time. This shouldn't cause any issues since plugin_id's are supposed to be unique. 