### PR TITLE
Controller: Updating warning message

### DIFF
--- a/UM/Controller.py
+++ b/UM/Controller.py
@@ -279,7 +279,7 @@ class Controller:
                 self._active_tool.event(ToolEvent(ToolEvent.ToolActivateEvent))
                 tool_changed = True
             else:
-                Logger.log("w", "Controller does not have an active tool and could not default to Translate tool.")
+                Logger.log("w", "Controller does not have an active tool and could not default to the tool, called \"{}\".".format(self._fallback_tool))
 
         if tool_changed:
             Selection.setFaceSelectMode(False)


### PR DESCRIPTION
Just noticed that the error message will keep mentioning that it couldn't default to the tool called TranslateTool, even if the tool is not our fallback tool at this moment.
This change will simply make the warning mention the currently set fallback tool.