### PR TITLE
Speed up loading of plugins on start

### DIFF
--- a/UM/PluginRegistry.py
+++ b/UM/PluginRegistry.py
@@ -604,22 +604,11 @@ class PluginRegistry(QObject):
             return None
 
         if folder not in self._folder_cache:
-            sub_folders = []
-            for file in os.listdir(folder):
-                file_path = os.path.join(folder, file)
-                if os.path.isdir(file_path):
-                    entry = (file, file_path)
-                    sub_folders.append(entry)
-            self._folder_cache[folder] = sub_folders
+            self._folder_cache[folder] = [(walked[0], os.path.basename(walked[0])) for walked in os.walk(folder) if "__init__.py" in walked[2]]
 
-        for file, file_path in self._folder_cache[folder]:
-            if file == plugin_id and os.path.exists(os.path.join(file_path, "__init__.py")):
-                return folder
-            else:
-                plugin_path = self._locatePlugin(plugin_id, file_path)
-                if plugin_path:
-                    return plugin_path
-
+        for folder_path, folder_name in self._folder_cache[folder]:
+            if folder_name == plugin_id:
+                return os.path.join(folder_path, "..")
         return None
 
     #   Load the plugin data from the stream and in-place update the metadata.

--- a/UM/PluginRegistry.py
+++ b/UM/PluginRegistry.py
@@ -65,7 +65,7 @@ class PluginRegistry(QObject):
         self._plugin_objects = {}     # type: Dict[str, PluginObject]
 
         self._plugin_locations = []  # type: List[str]
-        self._folder_cache = {}      # type: Dict[str, List[Tuple[str, str]]]
+        self._folder_cache = {}      # type: Dict[str, List[Tuple[str, str]]] used to speed up _locatePlugin
 
         self._bundled_plugin_cache = {}  # type: Dict[str, bool]
 
@@ -603,12 +603,16 @@ class PluginRegistry(QObject):
         if not os.path.isdir(folder):
             return None
 
+        # self._folder_cache is a per-plugin-location list of all subfolders that contain a __init__.py file
+        # This uses os.walk which recurses into nested folders and returns a list of tuples for each walked subfolder,
+        # where tuple[0] is the absolute path to the recursed subfolder, tuple[2] is a list of all files in that folder
         if folder not in self._folder_cache:
             self._folder_cache[folder] = [(walked[0], os.path.basename(walked[0])) for walked in os.walk(folder) if "__init__.py" in walked[2]]
 
         for folder_path, folder_name in self._folder_cache[folder]:
             if folder_name == plugin_id:
                 return os.path.join(folder_path, "..")
+
         return None
 
     #   Load the plugin data from the stream and in-place update the metadata.


### PR DESCRIPTION
This PR speeds up the loading of plugins on start. The original code contains recursion which I think nobody really understood and the folder cache variable did not work. Because of this, each successive loaded plugin would take longer to be located.

On my system, the "Loading plugins" stage took 47 seconds, which has now been reduced to 27 seconds. The original code was especially cumbersome because it traversed every .git and pycache folder for each plugin load, which on my system caused the _locate_plugin method to be call hundreds of thousands of time on launch.

Edit: this PR now includes the optimization in #538 