### PR TITLE
CURA-6979/Added function in PackageManager to get only user installed packages

### DIFF
--- a/UM/PackageManager.py
+++ b/UM/PackageManager.py
@@ -296,6 +296,17 @@ class PackageManager(QObject):
 
         return all_installed_ids
 
+    def getUserInstalledPackagesOnMarketplace(self) -> List[Tuple[str, str]]:
+        package_ids_and_version = []
+        for package in self._installed_package_dict.keys():
+            package_info = self.getInstalledPackageInfo(package)
+            if package_info is None:
+                continue
+            if 'package_version' not in package_info:
+                continue
+            package_ids_and_version.append((package, package_info['package_version']))
+        return package_ids_and_version
+
     ## Get a list of tuples that contain the package ID and version.
     #  Used by the Marketplace to check which packages have updates available.
     def getAllInstalledPackageIdsAndVersions(self) -> List[Tuple[str, str]]:

--- a/UM/PackageManager.py
+++ b/UM/PackageManager.py
@@ -296,7 +296,7 @@ class PackageManager(QObject):
 
         return all_installed_ids
 
-    def getUserInstalledPackagesOnMarketplace(self) -> List[Tuple[str, str]]:
+    def getUserSubscribedPackagesAndVersions(self) -> List[Tuple[str, str]]:
         package_ids_and_version = []
         for package in self._installed_package_dict.keys():
             package_info = self.getInstalledPackageInfo(package)

--- a/UM/PackageManager.py
+++ b/UM/PackageManager.py
@@ -296,9 +296,10 @@ class PackageManager(QObject):
 
         return all_installed_ids
 
-    def getUserSubscribedPackagesAndVersions(self) -> List[Tuple[str, str]]:
+    # Gets a list of tuples that contain user installed package ID and Version
+    def getUserInstalledPackagesAndVersions(self) -> List[Tuple[str, str]]:
         package_ids_and_version = []
-        for package in self._installed_package_dict.keys():
+        for package in self._installed_package_dict:
             package_info = self.getInstalledPackageInfo(package)
             if package_info is None:
                 continue

--- a/UM/PluginRegistry.py
+++ b/UM/PluginRegistry.py
@@ -81,6 +81,13 @@ class PluginRegistry(QObject):
 
     def setCheckIfTrusted(self, check_if_trusted: bool) -> None:
         self._check_if_trusted = check_if_trusted
+
+        # As part of CURA-7016, for now, we skip checking altogether if the public key is missing. That might not be as
+        #   bad as it sounds, as non-admin enterprise users shouldn't have access to that file's location anyway.
+        # TODO: DON'T FORGET TO REMOVE THESE (COMMENTS AND) NEXT 2 LINES WHEN WE _CAN_ START SIGNING THE PLUGINS.
+        if not os.path.exists(Trust.getPublicRootKeyPath()):
+            self._check_if_trusted = False
+
         if self._check_if_trusted:
             self._trust_checker = Trust.getInstance()
             # 'Trust.getInstance()' will raise an exception if anything goes wrong (e.g.: 'unable to read public key').


### PR DESCRIPTION
Added function in PackageManager to get only user installed packages

This function returns only user installed packages (plugins & materials) from the Marketplace, and not the bundled in.

Is used in [# 6813 from Cura repo](https://github.com/Ultimaker/Cura/pull/6813).