### PR TITLE
CURA-6959_collapse_categories

### DIFF
--- a/UM/PluginRegistry.py
+++ b/UM/PluginRegistry.py
@@ -774,7 +774,7 @@ class PluginRegistry(QObject):
 
     ##  Get the path to a plugin.
     #
-    #   \param plugin_id \type{string} The ID of the plugin.
+    #   \param plugin_id \type{string} The PluginObject.getPluginId() of the plugin.
     #   \return \type{string} The absolute path to the plugin or an empty string if the plugin could not be found.
     def getPluginPath(self, plugin_id: str) -> Optional[str]:
         if plugin_id in self._plugins:

--- a/UM/Qt/qml/UM/Preferences/SettingVisibilityCategory.qml
+++ b/UM/Qt/qml/UM/Preferences/SettingVisibilityCategory.qml
@@ -58,5 +58,5 @@ Button {
     checkable: true
     checked: definition? definition.expanded : ""
 
-    onClicked: definition.expanded ? settingDefinitionsModel.collapse(definition.key) : settingDefinitionsModel.expandRecursive(definition.key)
+    onClicked: definition.expanded ? settingDefinitionsModel.collapseRecursive(definition.key) : settingDefinitionsModel.expandRecursive(definition.key)
 }

--- a/UM/Settings/Models/SettingDefinitionsModel.py
+++ b/UM/Settings/Models/SettingDefinitionsModel.py
@@ -277,9 +277,9 @@ class SettingDefinitionsModel(QAbstractListModel):
         for child in definitions[0].children:
             self.expandRecursive(child.key)
 
-    ##  Hide the children of a specified SettingDefinition.
+    ##  Hide the children of a specified SettingDefinition and all children of those settings as well.
     @pyqtSlot(str)
-    def collapse(self, key: str) -> None:
+    def collapseRecursive(self, key: str) -> None:
         definitions = self._getDefinitionsByKey(key)
         if not definitions:
             return
@@ -290,7 +290,7 @@ class SettingDefinitionsModel(QAbstractListModel):
         self._expanded.remove(key)
 
         for child in definitions[0].children:
-            self.collapse(child.key)
+            self.collapseRecursive(child.key)
 
         self.expandedChanged.emit()
         self._scheduleUpdateVisibleRows()

--- a/UM/Settings/Models/SettingDefinitionsModel.py
+++ b/UM/Settings/Models/SettingDefinitionsModel.py
@@ -70,6 +70,8 @@ class SettingDefinitionsModel(QAbstractListModel):
 
         self.destroyed.connect(self._onDestroyed)
 
+        self.expandedChanged.connect(self.onExpandedChanged)
+
     ##  Emitted whenever the showAncestors property changes.
     showAncestorsChanged = pyqtSignal()
 
@@ -209,7 +211,7 @@ class SettingDefinitionsModel(QAbstractListModel):
             self.expandedChanged.emit()
             self._scheduleUpdateVisibleRows()
 
-    ##  Emitted whenever the exclude property changes
+    ##  Emitted whenever the expanded property changes
     expandedChanged = pyqtSignal()
 
     ##  This property indicates which settings should never be visibile.
@@ -294,6 +296,10 @@ class SettingDefinitionsModel(QAbstractListModel):
 
         self.expandedChanged.emit()
         self._scheduleUpdateVisibleRows()
+
+    @pyqtSlot()
+    def collapseAllCategories(self) -> None:
+        self.setExpanded([])
 
     ##  Show a single SettingDefinition.
     @pyqtSlot(str)
@@ -518,6 +524,10 @@ class SettingDefinitionsModel(QAbstractListModel):
     @pyqtSlot()
     def forceUpdate(self) -> None:
         self._update()
+
+    def onExpandedChanged(self):
+        for row in range(len(self._row_index_list)):
+            self.dataChanged.emit(self.index(row, 0), self.index(row, 0), [self.ExpandedRole])
 
     # Update the internal list of definitions and the visibility mapping.
     #

--- a/tests/Settings/TestSettingDefinitionsModel.py
+++ b/tests/Settings/TestSettingDefinitionsModel.py
@@ -217,12 +217,12 @@ def test_collapseExpand(application):
     assert "test_child_0" in model.expanded
     assert "test_child_1" in model.expanded
 
-    model.collapse("test_child_0")
+    model.collapseRecursive("test_child_0")
     assert "test_setting" in model.expanded
     assert "test_child_0" not in model.expanded
     assert "test_child_1" in model.expanded
 
-    model.collapse("test_setting")
+    model.collapseREcursive("test_setting")
     assert "test_setting" not in model.expanded
     assert "test_child_0" not in model.expanded
     assert "test_child_1" not in model.expanded
@@ -251,7 +251,7 @@ def test_expandRecursive_noDefinition():
 
 def test_collapse_no_container():
     model = SettingDefinitionsModel()
-    model.collapse("whatever")
+    model.collapseRecursive("whatever")
 
     assert model.expanded == []
 

--- a/tests/Settings/TestSettingDefinitionsModel.py
+++ b/tests/Settings/TestSettingDefinitionsModel.py
@@ -222,7 +222,7 @@ def test_collapseExpand(application):
     assert "test_child_0" not in model.expanded
     assert "test_child_1" in model.expanded
 
-    model.collapseREcursive("test_setting")
+    model.collapseRecursive("test_setting")
     assert "test_setting" not in model.expanded
     assert "test_child_0" not in model.expanded
     assert "test_child_1" not in model.expanded


### PR DESCRIPTION
Adds a menu item in the Custom Print Settings list to collapse all categories

Does not work when a search is active. See Accompanying Cura PR.