### PR TITLE
Fix restore window size if application is closed maximized

### DIFF
--- a/UM/Qt/Bindings/MainWindow.py
+++ b/UM/Qt/Bindings/MainWindow.py
@@ -239,11 +239,14 @@ class MainWindow(QQuickWindow):
 
     @pyqtSlot()
     def _onWindowGeometryChanged(self):
-        self._preferences.setValue("general/window_width", self.width())
-        self._preferences.setValue("general/window_height", self.height())
-        self._preferences.setValue("general/window_left", self.x())
-        self._preferences.setValue("general/window_top", self.y())
-        # This is a workaround for QTBUG-30085
+        # Do not store maximised window geometry, but store state instead
+        # Using windowState instead of isMaximized is a workaround for QTBUG-30085
+        if self.windowState() == Qt.WindowNoState:
+            self._preferences.setValue("general/window_width", self.width())
+            self._preferences.setValue("general/window_height", self.height())
+            self._preferences.setValue("general/window_left", self.x())
+            self._preferences.setValue("general/window_top", self.y())
+
         if self.windowState() in (Qt.WindowNoState, Qt.WindowMaximized):
             self._preferences.setValue("general/window_state", self.windowState())
 

--- a/UM/Qt/Bindings/MainWindow.py
+++ b/UM/Qt/Bindings/MainWindow.py
@@ -54,6 +54,7 @@ class MainWindow(QQuickWindow):
             self._preferences.resetPreference("general/window_height")
             self._preferences.resetPreference("general/window_left")
             self._preferences.resetPreference("general/window_top")
+            self._preferences.resetPreference("general/window_state")
 
         # Restore window geometry
         self.setWidth(int(self._preferences.getValue("general/window_width")))


### PR DESCRIPTION
This PR fixes restoring the window to its "normal" size and location after closing it in maximized state. In addition to that, it also excludes the maximised/normal state of the window when the `restore_window_geometry` preference is unset.

Fixes https://github.com/Ultimaker/cura/issues/6904

Steps to reproduce issue that is fixed by this PR:
* load Cura and set the window to a custom size and position
* make sure the "Restore window position on start" option is checked
* restart Cura
-> windows is correctly placed in the custom position and size

* now maximize the window
* restart Cura
-> window is (correctly) maximized on startup

* now restore the window to not maximized
-> window (incorrectly!) does not restore to previous custom position and size