### PR TITLE
CURA-7090/Added a "dismissed" package logic.

### DIFF
--- a/UM/PackageManager.py
+++ b/UM/PackageManager.py
@@ -438,7 +438,6 @@ class PackageManager(QObject):
             self.packagesWithUpdateChanged.emit()
 
     def dismissPackage(self, package_id: str) -> None:
-        print("3")
         self._dismissed_packages.add(package_id)
         self._saveManagementData()
 

--- a/UM/PackageManager.py
+++ b/UM/PackageManager.py
@@ -214,7 +214,6 @@ class PackageManager(QObject):
         return 1
 
     def _saveManagementData(self) -> None:
-        print("4")
         # Need to use the file lock here to prevent concurrent I/O from other processes/threads
         container_registry = self._application.getContainerRegistry()
         with container_registry.lockFile():

--- a/UM/PackageManager.py
+++ b/UM/PackageManager.py
@@ -64,6 +64,7 @@ class PackageManager(QObject):
         self._installed_package_dict = {}  # type: Dict[str, Dict[str, Any]] # A dict of all installed packages
         self._to_remove_package_set = set()  # type: Set[str] # A set of packages that need to be removed at the next start
         self._to_install_package_dict = {}  # type: Dict[str, Dict[str, Any]]  # A dict of packages that need to be installed at the next start
+        self._dismissed_packages = set()    # type: Set[str] # A set of packages that are dismissed by the user
 
         # There can be plugins that provide remote packages (and thus, newer / different versions for a package).
         self._available_package_versions = {}  # type: Dict[str, Set[UMVersion]]
@@ -153,6 +154,7 @@ class PackageManager(QObject):
                     self._installed_package_dict = management_dict.get("installed", {})
                     self._to_remove_package_set = set(management_dict.get("to_remove", []))
                     self._to_install_package_dict = management_dict.get("to_install", {})
+                    self._dismissed_packages = set(management_dict.get("dismissed", []))
                     Logger.log("i", "Loaded user packages management file from %s", self._user_package_management_file_path)
             except FileNotFoundError:
                 Logger.log("i", "User package management file %s doesn't exist, do nothing", self._user_package_management_file_path)
@@ -212,6 +214,7 @@ class PackageManager(QObject):
         return 1
 
     def _saveManagementData(self) -> None:
+        print("4")
         # Need to use the file lock here to prevent concurrent I/O from other processes/threads
         container_registry = self._application.getContainerRegistry()
         with container_registry.lockFile():
@@ -219,7 +222,8 @@ class PackageManager(QObject):
                 data_dict = {"version": PackageManager.Version,
                              "installed": self._installed_package_dict,
                              "to_remove": list(self._to_remove_package_set),
-                             "to_install": self._to_install_package_dict}
+                             "to_install": self._to_install_package_dict,
+                             "dismissed": list(self._dismissed_packages)}
                 json.dump(data_dict, f, sort_keys = True, indent = 4)
                 Logger.log("i", "Package management file %s was saved", self._user_package_management_file_path)
 
@@ -342,6 +346,9 @@ class PackageManager(QObject):
     def getToRemovePackageIDs(self) -> Set[str]:
         return self._to_remove_package_set
 
+    def getDismissedPackages(self) -> List[str]:
+        return list(self._dismissed_packages)
+
     # Checks if the given package is installed (at all).
     def isPackageInstalled(self, package_id: str) -> bool:
         return self.getInstalledPackageInfo(package_id) is not None
@@ -430,6 +437,11 @@ class PackageManager(QObject):
         if self.checkIfPackageCanUpdate(package_id):
             self._packages_with_update_available.add(package_id)
             self.packagesWithUpdateChanged.emit()
+
+    def dismissPackage(self, package_id: str) -> None:
+        print("3")
+        self._dismissed_packages.add(package_id)
+        self._saveManagementData()
 
     ##  Is the package an user installed package?
     def isUserInstalledPackage(self, package_id: str) -> bool:


### PR DESCRIPTION
This PR adds one more field to the `packages.json` file called "dismissed". There shall be all the packages that the decided to dismiss, by clicking the button in the Compatibility Dialog.

It's used in https://github.com/Ultimaker/Cura/pull/6961