### PR TITLE
CURA-7090/Added function reEvaluateDismissedPackages() in the Package Manager

### DIFF
--- a/UM/PackageManager.py
+++ b/UM/PackageManager.py
@@ -345,17 +345,13 @@ class PackageManager(QObject):
     def getToRemovePackageIDs(self) -> Set[str]:
         return self._to_remove_package_set
 
-    def dismissPackage(self, package_id: str) -> None:
-        self._dismissed_packages.add(package_id)
+    def dismissAllIncompatiblePackages(self, incompatible_packages: List[str]) -> None:
+        self._dismissed_packages.update(incompatible_packages)
         self._saveManagementData()
+        Logger.debug("Dismissed Incompatible package(s): {}".format(incompatible_packages))
 
     def getDismissedPackages(self) -> List[str]:
         return list(self._dismissed_packages)
-
-    def removeFromDismissedPackages(self, package: str) -> None:
-        if package in self._dismissed_packages:
-            self._dismissed_packages.remove(package)
-            Logger.debug("Removed package [%s] from the dismissed packages list" % package)
 
     def reEvaluateDismissedPackages(self, subscribed_packages_payload: List[Dict[str, Any]], sdk_version: str) -> None:
         '''
@@ -372,6 +368,11 @@ class PackageManager(QObject):
             for package in subscribed_packages_payload:
                 if package["package_id"] in dismissed_packages and sdk_version in package["sdk_versions"]:
                     self.removeFromDismissedPackages(package["package_id"])
+
+    def removeFromDismissedPackages(self, package: str) -> None:
+        if package in self._dismissed_packages:
+            self._dismissed_packages.remove(package)
+            Logger.debug("Removed package [%s] from the dismissed packages list" % package)
 
     # Checks if the given package is installed (at all).
     def isPackageInstalled(self, package_id: str) -> bool:

--- a/UM/PackageManager.py
+++ b/UM/PackageManager.py
@@ -357,13 +357,21 @@ class PackageManager(QObject):
             self._dismissed_packages.remove(package)
             Logger.debug("Removed package [%s] from the dismissed packages list" % package)
 
-    def reEvaluateDismissedPackages(self, json_data: List[Dict[str, List[Any]]], sdk_version: str) -> None:
+    def reEvaluateDismissedPackages(self, subscribed_packages_payload: List[Dict[str, Any]], sdk_version: str) -> None:
+        '''
+        It removes a package from the "dismissed incompatible packages" list, if it gets updated in the meantime.
+        We check every package from the payload against our current CURA SDK version, and if it is in there -
+        we remove the already dismissed package from the above mentioned list.
+
+        :param subscribed_packages_payload: The response from Web CURA, a list of packages that a user is subscribed to.
+        :param sdk_version: Current CURA SDK version.
+        :return: None.
+        '''
         dismissed_packages = self.getDismissedPackages()
-        for package in dismissed_packages:
-            for item in json_data:
-                if item["package_id"] == package:
-                    if sdk_version in item["sdk_versions"]:
-                        self.removeFromDismissedPackages(package)
+        if dismissed_packages:
+            for package in subscribed_packages_payload:
+                if package["package_id"] in dismissed_packages and sdk_version in package["sdk_versions"]:
+                    self.removeFromDismissedPackages(package["package_id"])
 
     # Checks if the given package is installed (at all).
     def isPackageInstalled(self, package_id: str) -> bool:

--- a/UM/PackageManager.py
+++ b/UM/PackageManager.py
@@ -345,8 +345,25 @@ class PackageManager(QObject):
     def getToRemovePackageIDs(self) -> Set[str]:
         return self._to_remove_package_set
 
+    def dismissPackage(self, package_id: str) -> None:
+        self._dismissed_packages.add(package_id)
+        self._saveManagementData()
+
     def getDismissedPackages(self) -> List[str]:
         return list(self._dismissed_packages)
+
+    def removeFromDismissedPackages(self, package: str) -> None:
+        if package in self._dismissed_packages:
+            self._dismissed_packages.remove(package)
+            Logger.debug("Removed package [%s] from the dismissed packages list" % package)
+
+    def reEvaluateDismissedPackages(self, data) -> None:
+        dismissed_packages = self.getDismissedPackages()
+        for dismissed in dismissed_packages:
+            for item in data:
+                if item['package_id'] == dismissed:
+                    if self.sdk_version in item["sdk_versions"]:
+                        self.removeFromDismissedPackages(dismissed)
 
     # Checks if the given package is installed (at all).
     def isPackageInstalled(self, package_id: str) -> bool:
@@ -443,9 +460,7 @@ class PackageManager(QObject):
             self._packages_with_update_available.add(package_id)
             self.packagesWithUpdateChanged.emit()
 
-    def dismissPackage(self, package_id: str) -> None:
-        self._dismissed_packages.add(package_id)
-        self._saveManagementData()
+
 
     ##  Is the package an user installed package?
     def isUserInstalledPackage(self, package_id: str) -> bool:

--- a/UM/PackageManager.py
+++ b/UM/PackageManager.py
@@ -11,9 +11,6 @@ import urllib.parse  # For interpreting escape characters using unquote_plus.
 
 from PyQt5.QtCore import pyqtSlot, QObject, pyqtSignal, QUrl, pyqtProperty
 
-from cura import ApplicationMetadata
-
-
 from UM import i18nCatalog
 from UM.Logger import Logger
 from UM.Message import Message
@@ -36,7 +33,6 @@ class PackageManager(QObject):
         self._application = application
         self._container_registry = self._application.getContainerRegistry()
         self._plugin_registry = self._application.getPluginRegistry()
-        self._sdk_version = ApplicationMetadata.CuraSDKVersion
 
         # JSON files that keep track of all installed packages.
         self._user_package_management_file_path = None  # type: Optional[str]

--- a/UM/PackageManager.py
+++ b/UM/PackageManager.py
@@ -361,7 +361,7 @@ class PackageManager(QObject):
         dismissed_packages = self.getDismissedPackages()
         for package in dismissed_packages:
             for item in json_data:
-                if item['package_id'] == package:
+                if item["package_id"] == package:
                     if sdk_version in item["sdk_versions"]:
                         self.removeFromDismissedPackages(package)
 


### PR DESCRIPTION
Added two functions to the Package Manager:
1. A function that marks a package as "dismissed" and puts it in a list called `dismissed` in the `packages.json` file in the user's local data folder.
2. A function that re-evaluates the dismissed incompatible packages, and if needed removes them from the dismissed_packages list.

Is being used in: https://github.com/Ultimaker/Cura/pull/7011