### PR TITLE
Do not call the finished callback when a HTTP request errors

### DIFF
--- a/tests/TaskManagement/TestHttpRequestManager.py
+++ b/tests/TaskManagement/TestHttpRequestManager.py
@@ -39,12 +39,19 @@ def test_getFail404() -> None:
     http_request_manager = HttpRequestManager.getInstance()
 
     cbo = mock.Mock()
+
+    def callback(*args, **kwargs):
+        cbo.callback(*args, **kwargs)
+        # quit now so we don't need to wait
+        http_request_manager.callLater(0, app.quit)
+
     def error_callback(*args, **kwargs):
         cbo.error_callback(*args, **kwargs)
         # quit now so we don't need to wait
         http_request_manager.callLater(0, app.quit)
 
     request_data = http_request_manager.get(url = "http://localhost:8080/do_not_exist",
+                                            callback = callback,
                                             error_callback = error_callback)
     # Make sure that if something goes wrong, we quit after 10 seconds
     http_request_manager.callLater(10.0, app.quit)
@@ -53,6 +60,7 @@ def test_getFail404() -> None:
     http_request_manager.cleanup()  # Remove all unscheduled events
 
     cbo.error_callback.assert_called_once_with(request_data.reply, QNetworkReply.ContentNotFoundError)
+    cbo.callback.assert_not_called()
 
 
 #


### PR DESCRIPTION
As a result of a request, either callback (success case) or
error_callback (failure case) should be called. Not both