### PR TITLE
Make hidden OpenGL detect prefs. less confusing.

### DIFF
--- a/UM/Qt/QtApplication.py
+++ b/UM/Qt/QtApplication.py
@@ -69,6 +69,11 @@ if int(major) < 5 or (int(major) == 5 and int(minor) < 9):
 ##  Application subclass that provides a Qt application object.
 @signalemitter
 class QtApplication(QApplication, Application):
+    class OpenGlVersionDetect:
+        Autodetect = "autodetect"
+        ForceLegacy = "force_legacy"
+        ForceModern = "force_modern"
+
     pluginsLoaded = Signal()
     applicationRunning = Signal()
     
@@ -125,9 +130,9 @@ class QtApplication(QApplication, Application):
     def initialize(self) -> None:
         super().initialize()
 
-        Application.getInstance().getPreferences().addPreference("view/force_empty_shader_cache", False)
-        Application.getInstance().getPreferences().addPreference("view/force_legacy_opengl", False)
-        Application.getInstance().getPreferences().addPreference("view/force_modern_opengl", False)
+        preferences = Application.getInstance().getPreferences()
+        preferences.addPreference("view/force_empty_shader_cache", False)
+        preferences.addPreference("view/opengl_version_detect", self.OpenGlVersionDetect.Autodetect)
 
         # Read preferences here (upgrade won't work) to get:
         #  - The language in use, so the splash window can be shown in the correct language.
@@ -147,12 +152,12 @@ class QtApplication(QApplication, Application):
         # Remove this and you will get Windows 95 style for all widgets if you are using Qt 5.10+
         self.setStyle("fusion")
 
-        if Application.getInstance().getPreferences().getValue("view/force_empty_shader_cache"):
+        if preferences.getValue("view/force_empty_shader_cache"):
             self.setAttribute(Qt.AA_DisableShaderDiskCache)
         self.setAttribute(Qt.AA_UseDesktopOpenGL)
-        if not Application.getInstance().getPreferences().getValue("view/force_modern_opengl"):
-            force_legacy_opengl = Application.getInstance().getPreferences().getValue("view/force_legacy_opengl")
-            major_version, minor_version, profile = OpenGLContext.detectBestOpenGLVersion(force_legacy_opengl)
+        if preferences.getValue("view/opengl_version_detect") != self.OpenGlVersionDetect.ForceModern:
+            major_version, minor_version, profile = OpenGLContext.detectBestOpenGLVersion(
+                preferences.getValue("view/opengl_version_detect") == self.OpenGlVersionDetect.ForceLegacy)
         else:
             Logger.info("Force 'modern' OpenGL (4.1 core) -- overrides 'force legacy opengl' preference.")
             major_version, minor_version, profile = (4, 1, QSurfaceFormat.CoreProfile)

--- a/UM/Qt/QtApplication.py
+++ b/UM/Qt/QtApplication.py
@@ -69,11 +69,6 @@ if int(major) < 5 or (int(major) == 5 and int(minor) < 9):
 ##  Application subclass that provides a Qt application object.
 @signalemitter
 class QtApplication(QApplication, Application):
-    class OpenGlVersionDetect:
-        Autodetect = "autodetect"
-        ForceLegacy = "force_legacy"
-        ForceModern = "force_modern"
-
     pluginsLoaded = Signal()
     applicationRunning = Signal()
     
@@ -132,7 +127,7 @@ class QtApplication(QApplication, Application):
 
         preferences = Application.getInstance().getPreferences()
         preferences.addPreference("view/force_empty_shader_cache", False)
-        preferences.addPreference("view/opengl_version_detect", self.OpenGlVersionDetect.Autodetect)
+        preferences.addPreference("view/opengl_version_detect", OpenGLContext.OpenGlVersionDetect.Autodetect)
 
         # Read preferences here (upgrade won't work) to get:
         #  - The language in use, so the splash window can be shown in the correct language.
@@ -155,9 +150,9 @@ class QtApplication(QApplication, Application):
         if preferences.getValue("view/force_empty_shader_cache"):
             self.setAttribute(Qt.AA_DisableShaderDiskCache)
         self.setAttribute(Qt.AA_UseDesktopOpenGL)
-        if preferences.getValue("view/opengl_version_detect") != self.OpenGlVersionDetect.ForceModern:
+        if preferences.getValue("view/opengl_version_detect") != OpenGLContext.OpenGlVersionDetect.ForceModern:
             major_version, minor_version, profile = OpenGLContext.detectBestOpenGLVersion(
-                preferences.getValue("view/opengl_version_detect") == self.OpenGlVersionDetect.ForceLegacy)
+                preferences.getValue("view/opengl_version_detect") == OpenGLContext.OpenGlVersionDetect.ForceLegacy)
         else:
             Logger.info("Force 'modern' OpenGL (4.1 core) -- overrides 'force legacy opengl' preference.")
             major_version, minor_version, profile = (4, 1, QSurfaceFormat.CoreProfile)

--- a/UM/View/GL/OpenGLContext.py
+++ b/UM/View/GL/OpenGLContext.py
@@ -9,6 +9,10 @@ from UM.Platform import Platform
 
 
 class OpenGLContext:
+    class OpenGlVersionDetect:
+        Autodetect = "autodetect"
+        ForceLegacy = "force_legacy"
+        ForceModern = "force_modern"
 
     ##  Set OpenGL context, given major, minor version + core using QOpenGLContext
     #   Unfortunately, what you get back does not have to be the requested version.


### PR DESCRIPTION
During the windows bug fix, some hidden preferences where created that we decided to leave in. This makes them less ad-hoc.