### PR TITLE
CURA-7161 Fixes simulation sliders yet again.

### DIFF
--- a/UM/View/GL/OpenGL.py
+++ b/UM/View/GL/OpenGL.py
@@ -299,7 +299,7 @@ class OpenGL:
         buffer.bind()
 
         data = cast(bytes, mesh.getIndicesAsByteArray()) # We check for None at the beginning of the method
-        if 'index_start' in kwargs and 'index_stop' in kwargs and hasattr(mesh, OpenGL.IndexBufferProperty):
+        if 'index_start' in kwargs and 'index_stop' in kwargs:
             setattr(mesh, OpenGL.IndexBufferRangeProperty, (kwargs['index_start'], kwargs['index_stop']))
             buffer.allocate(data[4 * kwargs['index_start']:4 * kwargs['index_stop']], 4*(kwargs['index_stop'] - kwargs['index_start']))
         else:

--- a/UM/View/RenderBatch.py
+++ b/UM/View/RenderBatch.py
@@ -256,10 +256,9 @@ class RenderBatch:
         if self._render_range is None:
             index_buffer = OpenGL.getInstance().createIndexBuffer(mesh)
         else:
-            # glDrawRangeElements does not work as expected and did not get the indices field working..
-            # Now we're just uploading a clipped part of the array and the start index always becomes 0.
+            top = len(mesh.getIndices())
             index_buffer = OpenGL.getInstance().createIndexBuffer(
-                mesh, index_start = self._render_range[0], index_stop = self._render_range[1])
+                mesh, index_start = min(self._render_range[0], top), index_stop = min(self._render_range[1], top))
         if index_buffer is not None:
             index_buffer.bind()
 


### PR DESCRIPTION
If a mesh is drawn with a range, make sure the current range is applicable to that mesh. (But don't reset the range to the max of that mesh.)
What this does is fix the OpenGL crash that you can get when the max is over the index-buffer length -- but without messing up the sim. sliders.

CURA-7161