### PR TITLE
'Trust' Updates

### DIFF
--- a/UM/Trust.py
+++ b/UM/Trust.py
@@ -197,7 +197,7 @@ class Trust:
                     return False
 
                 file_count = 0
-                for root, dirnames, filenames in os.walk(path):
+                for root, dirnames, filenames in os.walk(path, followlinks = True):
                     for filename in filenames:
                         if filename == TrustBasics.getSignaturesLocalFilename() and root == path:
                             continue

--- a/UM/Trust.py
+++ b/UM/Trust.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2019 Ultimaker B.V.
+# Copyright (c) 2020 Ultimaker B.V.
 # Uranium is released under the terms of the LGPLv3 or higher.
 
 import base64
@@ -6,6 +6,9 @@ import json
 import os
 from typing import Optional, Tuple
 
+# Note that we unfortunately need to use 'hazmat' code, as there apparently is no way to do what we want otherwise.
+# (Even if what we want should be relatively commonplace in security.)
+# Noted because if we _can_ make the change away from 'hazmat' (as opposed to lib-cryptography in general) we _should_.
 from cryptography.hazmat.backends import default_backend
 from cryptography.hazmat.primitives import hashes, serialization
 from cryptography.hazmat.primitives.asymmetric import padding, rsa
@@ -16,11 +19,15 @@ from cryptography.hazmat.primitives.serialization import load_pem_public_key, lo
 from UM.Logger import Logger
 
 
-# Anything shared between the main code and the (keygen/signing) scripts, does not need state:
 class TrustBasics:
+    """ Anything shared between the main code and the (keygen/signing) scripts which does not need state.
+    See 'Trust' (below) and the 'createkeypair.py', 'signfile.py' and 'signfolder.py' scripts in the 'scripts' folder.
+    """
+
+    # Considered SHA256 at first, but this is reportedly robust against something called 'length extension attacks'.
     __hash_algorithm = hashes.SHA384()
 
-    # For directories (plugins for example):
+    # For (in) directories (plugins for example):
     __signatures_relative_filename = "signature.json"
     __root_signatures_category = "root_signatures"
 
@@ -30,39 +37,62 @@ class TrustBasics:
 
     @classmethod
     def getHashAlgorithm(cls):
+        """ To ensure the same hash-algorithm is used by every part of this code.
+        :return: The hash-algorithm used for the entire 'suite'.
+        """
         return cls.__hash_algorithm
 
-    # Only used for in folders, there's another mechanism for 'loose' files:
     @classmethod
     def getSignaturesLocalFilename(cls) -> str:
+        """ 'Signed folder' scenario: Get the filename the signature file in a folder has.
+        :return: The filename of the signatures file (not the path).
+        """
         return cls.__signatures_relative_filename
 
-    # Only used for in folders, there's another mechanism for 'loose' files:
     @classmethod
     def getRootSignatureCategory(cls) -> str:
+        """ 'Signed folder' scenario: In anticipation of other keys, put the 'master' signature into this category.
+        :return: The json 'name' for the main signatures category.
+        """
         return cls.__root_signatures_category
 
-    # Only used for single files, there's another mechanism for folders:
     @classmethod
     def getSignaturePathForFile(cls, filename: str) -> str:
+        """ 'Single signed file' scenario: Get the name of the signature-file that should be located next to the file.
+        :param filename: The file that has (or needs to be) signed.
+        :return: The path of the signature-file of this file.
+        """
         return os.path.join(
             os.path.dirname(filename),
             os.path.basename(filename).split(".")[0] + cls.__signature_filename_extension
         )
 
-    # Only used for single files, there's another mechanism for folders:
     @classmethod
     def getRootSignatureEntry(cls) -> str:
+        """ 'Single signed file' scenario: In anticipation of other keys, put the 'master' signature into this entry.
+        :return: The json 'name' for the main signature.
+        """
         return cls.__root_signature_entry
 
     @classmethod
     def getFilePathInfo(cls, base_folder_path: str, current_full_path: str, local_filename: str) -> Tuple[str, str]:
+        """ 'Signed folder' scenario: When walking over directory, it's convenient to have the full path on one hand,
+        and the 'name' of the file in the signature json file just below the signed directory on the other.
+        :param base_folder_path: The signed folder(name), where the signature file resides.
+        :param current_full_path: The full path to the current folder.
+        :param local_filename: The local filename of the current file.
+        :return: A tuple with the full path to the file on disk and the 'signed-folder-local' path of that same file.
+        """
         name_on_disk = os.path.join(current_full_path, local_filename)
         name_in_data = name_on_disk.replace(base_folder_path, "").replace("\\", "/")
         return name_on_disk, name_in_data if not name_in_data.startswith("/") else name_in_data[1:]
 
     @classmethod
     def getFileHash(cls, filename: str) -> Optional[str]:
+        """ Gets the hash for the provided file.
+        :param filename: The filename of the file to be hashed.
+        :return: The hash of the file.
+        """
         hasher = hashes.Hash(cls.__hash_algorithm, backend = default_backend())
         try:
             with open(filename, "rb") as file:
@@ -74,6 +104,11 @@ class TrustBasics:
 
     @classmethod
     def getFileSignature(cls, filename: str, private_key: RSAPrivateKey) -> Optional[str]:
+        """ Creates the signature for the (hash of the) provided file, given a private key.
+        :param filename: The file to be signed.
+        :param private_key: The private key used for signing.
+        :return: The signature if successful, 'None' otherwise.
+        """
         file_hash = cls.getFileHash(filename)
         if file_hash is None:
             return None
@@ -91,11 +126,19 @@ class TrustBasics:
 
     @staticmethod
     def generateNewKeyPair() -> Tuple[RSAPrivateKeyWithSerialization, RSAPublicKey]:
+        """ Create a new private-public key-pair.
+        :return: A tulple of private-key/public key.
+        """
         private_key = rsa.generate_private_key(public_exponent = 65537, key_size = 4096, backend = default_backend())
         return private_key, private_key.public_key()
 
     @staticmethod
     def loadPrivateKey(private_filename: str, optional_password: Optional[str]) -> Optional[RSAPrivateKey]:
+        """ Load a private key from a file.
+        :param private_filename: The filename of the file containing the private key.
+        :param optional_password: The key can be signed with a password as well (or not).
+        :return: The private key contained in the file.
+        """
         try:
             password_bytes = None if optional_password is None else optional_password.encode()
             with open(private_filename, "rb") as file:
@@ -107,6 +150,13 @@ class TrustBasics:
 
     @staticmethod
     def saveKeyPair(private_key: "RSAPrivateKeyWithSerialization", private_path: str, public_path: str, optional_password: Optional[str] = None) -> bool:
+        """ Save a key-pair to two distinct files.
+        :param private_key: The private key to save. The public one will be generated from it.
+        :param private_path: Path to the filename where the private key will be saved.
+        :param public_path: Path to the filename where the public key will be saved.
+        :param optional_password: The private key can be signed with a password as well (or not).
+        :return: True on success.
+        """
         try:
             encrypt_method = serialization.NoEncryption()  # type: ignore
             if optional_password is not None:
@@ -134,29 +184,49 @@ class TrustBasics:
         return False
 
 
-# Trust as a singleton class for the main code, as opposed to the (keygen/signing) scripts:
 class Trust:
+    """ Trust for use in the main-application code, as opposed to the (keygen/signing) scripts.
+    Can be seen as an elaborate wrapper around a public-key.
+    Currently used as a singleton, as we currently have only one single 'master' public key for the entire app.
+    See the 'createkeypair.py', 'signfile.py' and 'signfolder.py' scripts in the 'scripts' folder.
+    """
+
     __instance = None
 
     @staticmethod
     def getPublicRootKeyPath() -> str:
+        """ It is assumed that the application will have a 'master' public key.
+        :return: Path to the 'master' public key of this application.
+        """
         from UM.Application import Application
         return os.path.abspath(os.path.join(Application.getAppFolderPrefix(), "public_key.pem"))
 
     @classmethod
     def getInstance(cls):
+        """ Get the 'canonical' Trusts object for this application. See also 'getPublicRootKeyPath'.
+        Throws and exception if no Trust object was created.
+        :return: The Trust singleton.
+        """
         if cls.__instance is None:
             cls.__instance = Trust(Trust.getPublicRootKeyPath())
         return cls.__instance
 
     @classmethod
     def getInstanceOrNone(cls):
+        """ Get the  'canonical' Trust object or None. Useful if only optional verification is needed.
+        :return: (Optional) Trust singleton.
+        """
         try:
             return cls.getInstance()
         except:  # Yes, we  do really want this on _every_ exception that might occur.
             return None
 
     def __init__(self, public_key_filename: str) -> None:
+        """ Initializes a Trust object. A Trust object represents a public key and related utility methods on that key.
+        Will raise an exception if the public key file can't be found or parsed.
+        If the application only has a single public key, it's best to use 'getInstance' or 'getInstanceOrNone'.
+        :param public_key_filename: Path to the file that holds the public key.
+        """
         self._public_key = None  #type: Optional[RSAPublicKey]
         try:
             with open(public_key_filename, "rb") as file:
@@ -186,6 +256,10 @@ class Trust:
         return False
 
     def signedFolderCheck(self, path: str) -> bool:
+        """ In the 'singed folder' case, check whether the folder is signed according to the Trust-objects' public key.
+        :param path: The path to the folder to be checked (not the signature-file).
+        :return: True if the folder is signed (contains a signatures-file) and signed correctly.
+        """
         try:
             json_filename = os.path.join(path, TrustBasics.getSignaturesLocalFilename())
 
@@ -225,6 +299,10 @@ class Trust:
         return False
 
     def signedFileCheck(self, filename: str) -> bool:
+        """ In the 'single signed file' case, check whether a file is signed according to the Trust-objects' public key.
+        :param filename: The path to the file to be checked (not the signature-file).
+        :return: True if the file is signed (is next to a signature file) and signed correctly.
+        """
         try:
             signature_filename = TrustBasics.getSignaturePathForFile(filename)
 
@@ -248,4 +326,8 @@ class Trust:
 
     @staticmethod
     def signatureFileExistsFor(filename: str) -> bool:
+        """ Whether or not a signature file _exist_ (so _not_ necessarily correct)  for the provided (single file) path.
+        :param filename: The filename that should be checked for.
+        :return: Returns True if there is a signature file next to the provided single file (as opposed to folder).
+        """
         return os.path.exists(TrustBasics.getSignaturePathForFile(filename))

--- a/UM/Trust.py
+++ b/UM/Trust.py
@@ -263,6 +263,7 @@ class Trust:
         try:
             json_filename = os.path.join(path, TrustBasics.getSignaturesLocalFilename())
 
+            # Open the file containing signatures:
             with open(json_filename, "r", encoding = "utf-8") as data_file:
                 json_data = json.load(data_file)
                 signatures_json = json_data.get(TrustBasics.getRootSignatureCategory(), None)
@@ -270,6 +271,7 @@ class Trust:
                     Logger.logException("e", "Can't parse (folder) signature file '{0}'.".format(data_file))
                     return False
 
+                # Loop over all files within the folder (excluding the signature file):
                 file_count = 0
                 for root, dirnames, filenames in os.walk(path, followlinks = True):
                     for filename in filenames:
@@ -278,15 +280,18 @@ class Trust:
                         file_count += 1
                         name_on_disk, name_in_data = TrustBasics.getFilePathInfo(path, root, filename)
 
+                        # Get the signature for the current to-verify file:
                         signature = signatures_json.get(name_in_data, None)
                         if signature is None:
                             Logger.logException("e", "File '{0}' was not signed with a checksum.".format(name_on_disk))
                             return False
 
+                        # Verify the file:
                         if not self._verifyFile(name_on_disk, signature):
                             Logger.logException("e", "File '{0}' didn't match with checksum.".format(name_on_disk))
                             return False
 
+                # The number of correctly signed files should be the same as the number of signatures:
                 if len(signatures_json.keys()) != file_count:
                     Logger.logException("e", "Mismatch: # entries in '{0}' vs. real files.".format(json_filename))
                     return False

--- a/scripts/createkeypair.py
+++ b/scripts/createkeypair.py
@@ -13,22 +13,26 @@ DEFAULT_PASSWORD = ""
 
 
 def createAndStoreNewKeyPair(private_filename: str, public_filename: str, optional_password: Optional[str]) -> None:
-    """ Creates a new public and private key, and saves them to the provided filenames.
+    """Creates a new public and private key, and saves them to the provided filenames.
+
     :param private_filename: Filename to save the private key to.
     :param public_filename: Filename to save the public key to.
     :param optional_password: Private keys can have a password (or not).
     """
+
     password = None if optional_password == "" else optional_password
     private_key, public_key = TrustBasics.generateNewKeyPair()
     TrustBasics.saveKeyPair(private_key, private_filename, public_filename, password)
 
 
 def mainfunc():
-    """ Arguments:
+    """Arguments:
+
     `-k <filename>` or `--private <filename>` will store the generated private key to <filename>
     `-p <filename>` or `--public <filename>` will store the generated public key to <filename>
     `-w <password>` or `--password <password>` will give the private key a password (none if omitted, which is default)
     """
+
     parser = argparse.ArgumentParser()
     parser.add_argument("-k", "--private", type = str, default = DEFAULT_PRIVATE_KEY_PATH)
     parser.add_argument("-p", "--public", type = str, default = DEFAULT_PUBLIC_KEY_PATH)

--- a/scripts/createkeypair.py
+++ b/scripts/createkeypair.py
@@ -6,18 +6,29 @@ import sys
 
 from UM.Trust import TrustBasics
 
+# Default arguments, if arguments to the script are omitted, these values are used:
 DEFAULT_PRIVATE_KEY_PATH = "./private_key.pem"
 DEFAULT_PUBLIC_KEY_PATH = "./public_key.pem"
 DEFAULT_PASSWORD = ""
 
 
 def createAndStoreNewKeyPair(private_filename: str, public_filename: str, optional_password: Optional[str]) -> None:
+    """ Creates a new public and private key, and saves them to the provided filenames.
+    :param private_filename: Filename to save the private key to.
+    :param public_filename: Filename to save the public key to.
+    :param optional_password: Private keys can have a password (or not).
+    """
     password = None if optional_password == "" else optional_password
     private_key, public_key = TrustBasics.generateNewKeyPair()
     TrustBasics.saveKeyPair(private_key, private_filename, public_filename, password)
 
 
 def mainfunc():
+    """ Arguments:
+    `-k <filename>` or `--private <filename>` will store the generated private key to <filename>
+    `-p <filename>` or `--public <filename>` will store the generated public key to <filename>
+    `-w <password>` or `--password <password>` will give the private key a password (none if omitted, which is default)
+    """
     parser = argparse.ArgumentParser()
     parser.add_argument("-k", "--private", type = str, default = DEFAULT_PRIVATE_KEY_PATH)
     parser.add_argument("-p", "--public", type = str, default = DEFAULT_PUBLIC_KEY_PATH)

--- a/scripts/signfile.py
+++ b/scripts/signfile.py
@@ -8,12 +8,24 @@ from typing import Optional
 from UM.Logger import Logger
 from UM.Trust import TrustBasics
 
+# Default arguments, if arguments to the script are omitted, these values are used:
 DEFAULT_PRIVATE_KEY_PATH = "private_key.pem"
 DEFAULT_TO_SIGN_FILE = "material.fdm_material.json"
 DEFAULT_PASSWORD = ""
 
 
 def signFile(private_key_path: str, filename: str, optional_password: Optional[str]) -> bool:
+    """ Generate a signature for a file (given a private key) and save it to a json signature file.
+    A json signature file for a single file looks like this:
+    {
+      "root_signature": "...<key in base-64>..."
+    }
+
+    :param private_key_path: Path to the file containing the private key.
+    :param filename: The file to be signed.
+    :param optional_password: If the private key has a password, it should be provided here.
+    :return: Whether a valid signature file has been generated and saved.
+    """
     password = None if optional_password == "" else optional_password
     private_key = TrustBasics.loadPrivateKey(private_key_path, password)
     if private_key is None:
@@ -40,6 +52,11 @@ def signFile(private_key_path: str, filename: str, optional_password: Optional[s
 
 
 def mainfunc():
+    """ Arguments:
+    `-k <filename>` or `--private <filename>` path to the private key
+    `-f <filename>` or `--file <filename>` path to the file to be signed
+    `-w <password>` or `--password <password>` if the private key file has a password, it should be specified like this
+    """
     parser = argparse.ArgumentParser()
     parser.add_argument("-k", "--private", type = str, default = DEFAULT_PRIVATE_KEY_PATH)
     parser.add_argument("-f", "--file", type = str, default = DEFAULT_TO_SIGN_FILE)

--- a/scripts/signfile.py
+++ b/scripts/signfile.py
@@ -15,7 +15,8 @@ DEFAULT_PASSWORD = ""
 
 
 def signFile(private_key_path: str, filename: str, optional_password: Optional[str]) -> bool:
-    """ Generate a signature for a file (given a private key) and save it to a json signature file.
+    """Generate a signature for a file (given a private key) and save it to a json signature file.
+
     A json signature file for a single file looks like this:
     {
       "root_signature": "...<key in base-64>..."
@@ -26,6 +27,7 @@ def signFile(private_key_path: str, filename: str, optional_password: Optional[s
     :param optional_password: If the private key has a password, it should be provided here.
     :return: Whether a valid signature file has been generated and saved.
     """
+
     password = None if optional_password == "" else optional_password
     private_key = TrustBasics.loadPrivateKey(private_key_path, password)
     if private_key is None:
@@ -52,11 +54,13 @@ def signFile(private_key_path: str, filename: str, optional_password: Optional[s
 
 
 def mainfunc():
-    """ Arguments:
+    """Arguments:
+
     `-k <filename>` or `--private <filename>` path to the private key
     `-f <filename>` or `--file <filename>` path to the file to be signed
     `-w <password>` or `--password <password>` if the private key file has a password, it should be specified like this
     """
+
     parser = argparse.ArgumentParser()
     parser.add_argument("-k", "--private", type = str, default = DEFAULT_PRIVATE_KEY_PATH)
     parser.add_argument("-f", "--file", type = str, default = DEFAULT_TO_SIGN_FILE)

--- a/scripts/signfolder.py
+++ b/scripts/signfolder.py
@@ -17,10 +17,12 @@ DEFAULT_PASSWORD = ""
 
 
 def signFolder(private_key_path: str, path: str, ignore_folders: List[str], optional_password: Optional[str]) -> bool:
-    """ Generate a signature for a folder (given a private key) and save it to a json signature file within that folder.
+    """Generate a signature for a folder (given a private key) and save it to a json signature file within that folder.
+
     - The signature file itself will not be signed.
     - On validation, any 'extra' files not in the ignored (cache) folders should also trigger failure.
     - Be careful, symlinks will be followed!
+
     A json signature file for a folder looks like this:
     {
       "root_signatures": {
@@ -36,6 +38,7 @@ def signFolder(private_key_path: str, path: str, ignore_folders: List[str], opti
     :param optional_password: If the private key has a password, it should be provided here.
     :return: Whether a valid signature file has been generated and saved.
     """
+
     password = None if optional_password == "" else optional_password
     private_key = TrustBasics.loadPrivateKey(private_key_path, password)
     if private_key is None:
@@ -76,12 +79,14 @@ def signFolder(private_key_path: str, path: str, ignore_folders: List[str], opti
 
 
 def mainfunc():
-    """ Arguments:
+    """Arguments:
+
     `-k <filename>` or `--private <filename>` path to the private key
     `-f <path>` or `--folder <path>` path to the folder to be signed
     `-i <local-path>` or `--ignore <local-path>` sub-folders to be ignored (useful for cache files that'll be deleted)
     `-w <password>` or `--password <password>` if the private key file has a password, it should be specified like this
     """
+
     parser = argparse.ArgumentParser()
     parser.add_argument("-k", "--private", type = str, default = DEFAULT_PRIVATE_KEY_PATH)
     parser.add_argument("-f", "--folder", type = str, default = DEFAULT_TO_SIGN_FOLDER)

--- a/scripts/signfolder.py
+++ b/scripts/signfolder.py
@@ -9,6 +9,7 @@ from typing import Optional, List
 from UM.Logger import Logger
 from UM.Trust import TrustBasics
 
+# Default arguments, if arguments to the script are omitted, these values are used:
 DEFAULT_PRIVATE_KEY_PATH = "../private_key.pem"
 DEFAULT_TO_SIGN_FOLDER = "."
 DEFAULT_IGNORE_SUBFOLDERS = ["__pycache__"]
@@ -16,6 +17,25 @@ DEFAULT_PASSWORD = ""
 
 
 def signFolder(private_key_path: str, path: str, ignore_folders: List[str], optional_password: Optional[str]) -> bool:
+    """ Generate a signature for a folder (given a private key) and save it to a json signature file within that folder.
+    - The signature file itself will not be signed.
+    - On validation, any 'extra' files not in the ignored (cache) folders should also trigger failure.
+    - Be careful, symlinks will be followed!
+    A json signature file for a folder looks like this:
+    {
+      "root_signatures": {
+        "text.txt": "...<key in base-64>...",
+        "img.png": "...<key in base-64>...",
+        "subfolder/text.txt": "...<key in base-64>..."
+      }
+    }
+
+    :param private_key_path: Path to the file containing the private key.
+    :param path: The folder to be signed.
+    :param ignore_folders: Local cache folders (that should be deleted on restart of the app) can be ignored.
+    :param optional_password: If the private key has a password, it should be provided here.
+    :return: Whether a valid signature file has been generated and saved.
+    """
     password = None if optional_password == "" else optional_password
     private_key = TrustBasics.loadPrivateKey(private_key_path, password)
     if private_key is None:
@@ -53,6 +73,12 @@ def signFolder(private_key_path: str, path: str, ignore_folders: List[str], opti
 
 
 def mainfunc():
+    """ Arguments:
+    `-k <filename>` or `--private <filename>` path to the private key
+    `-f <path>` or `--folder <path>` path to the folder to be signed
+    `-i <local-path>` or `--ignore <local-path>` sub-folders to be ignored (useful for cache files that'll be deleted)
+    `-w <password>` or `--password <password>` if the private key file has a password, it should be specified like this
+    """
     parser = argparse.ArgumentParser()
     parser.add_argument("-k", "--private", type = str, default = DEFAULT_PRIVATE_KEY_PATH)
     parser.add_argument("-f", "--folder", type = str, default = DEFAULT_TO_SIGN_FOLDER)

--- a/scripts/signfolder.py
+++ b/scripts/signfolder.py
@@ -44,6 +44,7 @@ def signFolder(private_key_path: str, path: str, ignore_folders: List[str], opti
     try:
         signatures = {}  # Dict[str, str]
 
+        # Loop over all files in the folder:
         for root, dirnames, filenames in os.walk(path, followlinks = True):
             if os.path.basename(root) in ignore_folders:
                 continue
@@ -51,6 +52,7 @@ def signFolder(private_key_path: str, path: str, ignore_folders: List[str], opti
                 if filename == TrustBasics.getSignaturesLocalFilename() and root == path:
                     continue
 
+                # Generate a signature for the current file:
                 name_on_disk, name_in_data = TrustBasics.getFilePathInfo(path, root, filename)
                 signature = TrustBasics.getFileSignature(name_on_disk, private_key)
                 if signature is None:
@@ -58,6 +60,7 @@ def signFolder(private_key_path: str, path: str, ignore_folders: List[str], opti
                     return False
                 signatures[name_in_data] = signature
 
+        # Save signatures to json:
         wrapped_signatures = {TrustBasics.getRootSignatureCategory(): signatures}
 
         json_filename = os.path.join(path, TrustBasics.getSignaturesLocalFilename())

--- a/scripts/signfolder.py
+++ b/scripts/signfolder.py
@@ -24,7 +24,7 @@ def signFolder(private_key_path: str, path: str, ignore_folders: List[str], opti
     try:
         signatures = {}  # Dict[str, str]
 
-        for root, dirnames, filenames in os.walk(path):
+        for root, dirnames, filenames in os.walk(path, followlinks = True):
             if os.path.basename(root) in ignore_folders:
                 continue
             for filename in filenames:


### PR DESCRIPTION
- Don't skip symbolic links anymore when walking over a directory, either when generating a signature file for a folder, or when validating.
- There was almost no documentation. Now there rather more.