### PR TITLE
MeshData: Making a None check the other way around

### DIFF
--- a/UM/Mesh/MeshData.py
+++ b/UM/Mesh/MeshData.py
@@ -333,7 +333,7 @@ class MeshData:
         :return: :type{Tuple[numpy.ndarray, numpy.ndarray, numpy.ndarray]} Tuple of all three local vectors. 
         """
 
-        if not self._indices or len(self._indices) == 0:
+        if self._indices is None or len(self._indices) == 0:
             base_index = face_id * 3
             v_a = self._vertices[base_index]
             v_b = self._vertices[base_index + 1]


### PR DESCRIPTION
Looks like Python is getting more strict and wants more clear instructions how "if (not) <array>" shall be interpreted.
Since it looks like we are checking whether vertices are None, I just rewrote it so the logic keeps the same.

Here the original error message:
```
2020-02-23 12:56:30,352 - CRITICAL - [MainThread] cura.CrashHandler.__init__ [67]:   File "/usr/lib/python3/dist-packages/UM/Mesh/MeshData.py", line 336, in getFaceNodes
2020-02-23 12:56:30,352 - CRITICAL - [MainThread] cura.CrashHandler.__init__ [67]:     if not self._indices or len(self._indices) == 0:
2020-02-23 12:56:30,353 - CRITICAL - [MainThread] cura.CrashHandler.__init__ [67]: ValueError: The truth value of an array with more than one element is ambiguous. Use a.any() or a.all()
```