### PR TITLE
CURA-7016 Fix Trust and tests thereof.

### DIFF
--- a/UM/PluginRegistry.py
+++ b/UM/PluginRegistry.py
@@ -84,13 +84,6 @@ class PluginRegistry(QObject):
 
     def setCheckIfTrusted(self, check_if_trusted: bool) -> None:
         self._check_if_trusted = check_if_trusted
-
-        # As part of CURA-7016, for now, we skip checking altogether if the public key is missing. That might not be as
-        #   bad as it sounds, as non-admin enterprise users shouldn't have access to that file's location anyway.
-        # TODO: DON'T FORGET TO REMOVE THESE (COMMENTS AND) NEXT 2 LINES WHEN WE _CAN_ START SIGNING THE PLUGINS.
-        if not os.path.exists(Trust.getPublicRootKeyPath()):
-            self._check_if_trusted = False
-
         if self._check_if_trusted:
             self._trust_checker = Trust.getInstance()
             # 'Trust.getInstance()' will raise an exception if anything goes wrong (e.g.: 'unable to read public key').

--- a/tests/TestTrust.py
+++ b/tests/TestTrust.py
@@ -56,25 +56,30 @@ class TestTrust:
         assert signFile(private_path, filepath_signed, _passphrase)
 
         assert trust_instance.signedFileCheck(filepath_signed)
+        assert violation_callback.call_count == 0  # No violation
+
         assert not trust_instance.signedFileCheck(filepath_unsigned)
+        assert violation_callback.call_count == 1
+
         assert not trust_instance.signedFileCheck("file-not-found-check")
+        assert violation_callback.call_count == 2
 
         public_key = copy.copy(trust_instance._public_key)
         trust_instance._public_key = None
         assert not trust_instance.signedFileCheck(filepath_signed)
-        assert violation_callback.call_count > 0
+        assert violation_callback.call_count == 3
         violation_callback.reset_mock()
         trust_instance._public_key = public_key
 
         with open(filepath_signed, "w") as file:
             file.write("\nPay 10 Golden Talents To Get Your Data Back Or Else\n")
         assert not trust_instance.signedFolderCheck(filepath_signed)
-        assert violation_callback.call_count > 0
+        assert violation_callback.call_count == 1
         violation_callback.reset_mock()
 
         os.remove(filepath_signed)
         assert not trust_instance.signedFolderCheck(filepath_signed)
-        assert violation_callback.call_count > 0
+        assert violation_callback.call_count == 1
         violation_callback.reset_mock()
 
     def test_signFolderAndVerify(self, init_trust):

--- a/tests/TestTrust.py
+++ b/tests/TestTrust.py
@@ -42,7 +42,8 @@ class TestTrust:
 
         # instantiate a trust object with the public key that was just generated:
         violation_callback = MagicMock()
-        trust = Trust(public_path, lambda msg: violation_callback())  # No '.getInstance', since key & handler provided.
+        trust = Trust(public_path)  # No '.getInstance', since key & handler provided.
+        trust._violation_handler = violation_callback
         yield temp_path, private_path, trust, violation_callback
 
         temp_dir.cleanup()

--- a/tests/TestTrust.py
+++ b/tests/TestTrust.py
@@ -22,7 +22,7 @@ class TestTrust:
 
     @pytest.fixture()
     def init_trust(self):
-        # create a temporary directory and save a test key-pair to it:
+        # Create a temporary directory and save a test key-pair to it:
         temp_dir = tempfile.TemporaryDirectory()
         temp_path = temp_dir.name
         private_key, public_key = TrustBasics.generateNewKeyPair()
@@ -30,7 +30,7 @@ class TestTrust:
         public_path = os.path.join(temp_path, "test_public_key.pem")
         TrustBasics.saveKeyPair(private_key, private_path, public_path, _passphrase)
 
-        # create random files:
+        # Create random files:
         all_paths = [os.path.abspath(os.path.join(temp_path, x, y, z))
                      for x in _folder_names for y in _subfolder_names for z in _file_names]
         for path in all_paths:
@@ -40,7 +40,7 @@ class TestTrust:
             with open(path, "w") as file:
                 file.write("".join(random.choice(['a', 'b', 'c', '0', '1', '2', '\n']) for _ in range(1024)))
 
-        # instantiate a trust object with the public key that was just generated:
+        # Instantiate a trust object with the public key that was just generated:
         violation_callback = MagicMock()
         trust = Trust(public_path)  # No '.getInstance', since key & handler provided.
         trust._violation_handler = violation_callback
@@ -53,17 +53,22 @@ class TestTrust:
         filepath_signed = os.path.join(temp_dir, _folder_names[0], _subfolder_names[0], _file_names[0])
         filepath_unsigned = os.path.join(temp_dir, _folder_names[1], _subfolder_names[0], _file_names[2])
 
+        # Attempt to sign a file.
         assert signFile(private_path, filepath_signed, _passphrase)
 
+        # Check if we're able to verify the file we just signed.
         assert trust_instance.signedFileCheck(filepath_signed)
         assert violation_callback.call_count == 0  # No violation
 
+        # Check if the file we didn't sign notifies us about this.
         assert not trust_instance.signedFileCheck(filepath_unsigned)
         assert violation_callback.call_count == 1
 
+        # An unknown file is also seen as an invalid one.
         assert not trust_instance.signedFileCheck("file-not-found-check")
         assert violation_callback.call_count == 2
 
+        # The signing should fail if we disable the key (since we can't confirm anything)
         public_key = copy.copy(trust_instance._public_key)
         trust_instance._public_key = None
         assert not trust_instance.signedFileCheck(filepath_signed)
@@ -71,12 +76,14 @@ class TestTrust:
         violation_callback.reset_mock()
         trust_instance._public_key = public_key
 
+        # Oh noes! Someone changed the file!
         with open(filepath_signed, "w") as file:
             file.write("\nPay 10 Golden Talents To Get Your Data Back Or Else\n")
         assert not trust_instance.signedFolderCheck(filepath_signed)
         assert violation_callback.call_count == 1
         violation_callback.reset_mock()
 
+        # If one file is missing, the entire folder isn't considered to be signed.
         os.remove(filepath_signed)
         assert not trust_instance.signedFolderCheck(filepath_signed)
         assert violation_callback.call_count == 1
@@ -87,23 +94,29 @@ class TestTrust:
         folderpath_signed = os.path.join(temp_dir, _folder_names[0])
         folderpath_unsigned = os.path.join(temp_dir, _folder_names[1])
 
+        # Attempt to sign a folder & validate it's signatures.
         assert signFolder(private_path, folderpath_signed, [], _passphrase)
-
         assert trust_instance.signedFolderCheck(folderpath_signed)
+
+        # A folder that is not signed should be seen as such
         assert not trust_instance.signedFolderCheck(folderpath_unsigned)
-        assert violation_callback.call_count > 0
-        violation_callback.reset_mock()
-        assert not trust_instance.signedFileCheck("folder-not-found-check")
-        assert violation_callback.call_count > 0
+        assert violation_callback.call_count == 1
         violation_callback.reset_mock()
 
+        # Unknown folders should also be seen as unsigned
+        assert not trust_instance.signedFileCheck("folder-not-found-check")
+        assert violation_callback.call_count == 1
+        violation_callback.reset_mock()
+
+        # After removing the key, the folder that was signed should be seen as unsigned.
         public_key = copy.copy(trust_instance._public_key)
         trust_instance._public_key = None
         assert not trust_instance.signedFolderCheck(folderpath_signed)
-        assert violation_callback.call_count > 0
+        assert violation_callback.call_count == 1
         violation_callback.reset_mock()
         trust_instance._public_key = public_key
 
+        # Any modification will should also invalidate it.
         filepath = os.path.join(folderpath_signed, _subfolder_names[0], _file_names[1])
         with open(filepath, "w") as file:
             file.write("\nAlice and Bob will never notice this! Hehehehe.\n")
@@ -113,7 +126,7 @@ class TestTrust:
 
         os.remove(filepath)
         assert not trust_instance.signedFolderCheck(folderpath_signed)
-        assert violation_callback.call_count > 0
+        assert violation_callback.call_count == 1
         violation_callback.reset_mock()
 
     def test_initTrustFail(self):


### PR DESCRIPTION
Adding a public key to Cura revealed that fail fast crashes weren't happening when an untrusted plugin was about to be loaded. This fixes that. (Here of course since plugins are in Uranium as swell.)

(See also https://github.com/Ultimaker/Cura/pull/7182 )