### PR TITLE
Remember the last used output device between sessions

### DIFF
--- a/UM/Application.py
+++ b/UM/Application.py
@@ -181,7 +181,7 @@ class Application:
         self._preferences.addPreference("general/disabled_plugins", "")
 
         self._controller = Controller(self)
-        self._output_device_manager = OutputDeviceManager(self)
+        self._output_device_manager = OutputDeviceManager()
 
         self._operation_stack = OperationStack(self._controller)
 

--- a/UM/Application.py
+++ b/UM/Application.py
@@ -181,7 +181,7 @@ class Application:
         self._preferences.addPreference("general/disabled_plugins", "")
 
         self._controller = Controller(self)
-        self._output_device_manager = OutputDeviceManager()
+        self._output_device_manager = OutputDeviceManager(self)
 
         self._operation_stack = OperationStack(self._controller)
 

--- a/UM/OutputDevice/OutputDeviceManager.py
+++ b/UM/OutputDevice/OutputDeviceManager.py
@@ -10,6 +10,7 @@ from UM.PluginRegistry import PluginRegistry
 if TYPE_CHECKING:
     from UM.OutputDevice.OutputDevice import OutputDevice
     from UM.OutputDevice.OutputDevicePlugin import OutputDevicePlugin
+    from UM.Application import Application
 
 # Used internally to determine plugins capable of 'manual' addition of devices, see also [add|remove]ManualDevice below.
 class ManualDeviceAdditionAttempt(Enum):
@@ -22,29 +23,29 @@ class ManualDeviceAdditionAttempt(Enum):
 @signalemitter
 class OutputDeviceManager:
     """Manages all available output devices and the plugin objects used to create them.
-    
+
     This class is intended as the main entry point for anything relating to file saving.
     For the most basic usage, call getActiveDevice() to get an output device, then
     call OutputDevice::requestWrite() on the returned object.
-    
+
     Active Device
     -------------
-    
+
     The active device by default is determined based on the priority of individual
     OutputDevice instances when there is more than one OutputDevice available. When
     adding a device, the active device will be updated with the highest priority device.
     Should there be two devices with the same priority the active device will be the first
     device encountered with that priority.
-    
+
     Calling setActiveDevice() will override this behaviour and instead force the active
     device to the specified device. This active device will not change when a new device
     is added or removed, but it will revert back to the default behaviour if the active
     device is removed. Call resetActiveDevice() to reset the active device to the default
     behaviour based on priority.
-    
+
     OutputDevicePlugin and OutputDevice creation/removal
     ----------------------------------------------------
-    
+
     Each instance of an OutputDevicePlugin is meant as an OutputDevice creation object.
     Subclasses of OutputDevicePlugin are meant to perform device lookup and listening
     for events like device hot-plugging. When a new device has been detected, the plugin
@@ -52,10 +53,10 @@ class OutputDeviceManager:
     manager class using addOutputDevice(). Similarly, if a device has been removed the
     OutputDevicePlugin is expected to call removeOutputDevice() to remove the proper
     device.
-    
+
     """
 
-    def __init__(self) -> None:
+    def __init__(self, application:"Application") -> None:
         super().__init__()
 
         self._output_devices = {}  # type: Dict[str, OutputDevice]
@@ -65,35 +66,45 @@ class OutputDeviceManager:
         self._write_in_progress = False
         PluginRegistry.addType("output_device", self.addOutputDevicePlugin)
 
+        self._application = application
+        self._application.getPreferences().addPreference("output_devices/last_used_device", "")
+        self._application.engineCreatedSignal.connect(self._onEngineCreated)
+
         self._is_running = False
+
+    def _onEngineCreated(self):
+        device_id = self._application.getPreferences().getValue("output_devices/last_used_device")
+        if device_id in self._output_devices:
+            self.setActiveDevice(device_id)
+
 
     writeStarted = Signal()
     """Emitted whenever a registered device emits writeStarted.
-    
+
     :sa OutputDevice::writeStarted
     """
 
     writeProgress = Signal()
     """Emitted whenever a registered device emits writeProgress.
-    
+
     :sa OutputDevice::writeProgress
     """
 
     writeFinished = Signal()
     """Emitted whenever a registered device emits writeFinished.
-    
+
     :sa OutputDevice::writeFinished
     """
 
     writeError = Signal()
     """Emitted whenever a registered device emits writeError.
-    
+
     :sa OutputDevice::writeError
     """
 
     writeSuccess = Signal()
     """Emitted whenever a registered device emits writeSuccess.
-    
+
     :sa OutputDevice::writeSuccess
     """
 
@@ -105,7 +116,7 @@ class OutputDeviceManager:
 
     def getOutputDevices(self):
         """Get a list of all registered output devices.
-        
+
         :return: :type{list} A list of all registered output devices.
         """
 
@@ -113,7 +124,7 @@ class OutputDeviceManager:
 
     def getOutputDeviceIds(self):
         """Get a list of all IDs of registered output devices.
-        
+
         :return: :type{list} A list of all registered output device ids.
         """
 
@@ -121,7 +132,7 @@ class OutputDeviceManager:
 
     def getOutputDevice(self, device_id: str) -> Optional["OutputDevice"]:
         """Get an output device by ID.
-        
+
         :param device_id: The ID of the device to retrieve.
         :return: :type{OutputDevice} The output device corresponding to the ID or None if not found.
         """
@@ -161,9 +172,9 @@ class OutputDeviceManager:
 
     def addOutputDevice(self, device: "OutputDevice") -> None:
         """Add and register an output device.
-        
+
         :param :type{OutputDevice} The output device to add.
-        
+
         :note Does nothing if a device with the same ID as the passed device was already added.
         """
 
@@ -185,9 +196,9 @@ class OutputDeviceManager:
 
     def removeOutputDevice(self, device_id: str) -> bool:
         """Remove a registered device by ID
-        
+
         :param device_id: The ID of the device to remove.
-        
+
         :note This does nothing if the device_id does not correspond to a registered device.
         :return: Whether the device was successfully removed or not.
         """
@@ -220,9 +231,9 @@ class OutputDeviceManager:
 
     def setActiveDevice(self, device_id: str) -> None:
         """Set the active device.
-        
+
         :param device_id: The ID of the device to set as active device.
-        
+
         :note This does nothing if the device_id does not correspond to a registered device.
         :note This will override the default active device selection behaviour.
         """
@@ -231,6 +242,7 @@ class OutputDeviceManager:
             return
 
         if not self._active_device or self._active_device.getId() != device_id:
+            self._application.getPreferences().setValue("output_devices/last_used_device", device_id)
             self._active_device = self.getOutputDevice(device_id)
             self._write_in_progress = False
             self._active_device_override = True
@@ -246,9 +258,9 @@ class OutputDeviceManager:
 
     def addOutputDevicePlugin(self, plugin: "OutputDevicePlugin") -> None:
         """Add an OutputDevicePlugin instance.
-        
+
         :param :type{OutputDevicePlugin} The plugin to add.
-        
+
         :note This does nothing if the plugin was already added.
         """
 
@@ -265,9 +277,9 @@ class OutputDeviceManager:
 
     def removeOutputDevicePlugin(self, plugin_id: str) -> None:
         """Remove an OutputDevicePlugin by ID.
-        
+
         :param plugin_id: The ID of the plugin to remove.
-        
+
         :note This does nothing if the specified plugin_id was not found.
         """
 
@@ -287,9 +299,9 @@ class OutputDeviceManager:
 
     def getOutputDevicePlugin(self, plugin_id: str) -> Optional["OutputDevicePlugin"]:
         """Get an OutputDevicePlugin by plugin ID
-        
+
         :param plugin_id: The ID of the plugin to retrieve
-        
+
         :return: The plugin corresponding to the specified ID or None if it was not found.
         """
 

--- a/UM/OutputDevice/OutputDeviceManager.py
+++ b/UM/OutputDevice/OutputDeviceManager.py
@@ -10,7 +10,6 @@ from UM.PluginRegistry import PluginRegistry
 if TYPE_CHECKING:
     from UM.OutputDevice.OutputDevice import OutputDevice
     from UM.OutputDevice.OutputDevicePlugin import OutputDevicePlugin
-    from UM.Application import Application
 
 # Used internally to determine plugins capable of 'manual' addition of devices, see also [add|remove]ManualDevice below.
 class ManualDeviceAdditionAttempt(Enum):
@@ -56,7 +55,7 @@ class OutputDeviceManager:
 
     """
 
-    def __init__(self, application:"Application") -> None:
+    def __init__(self) -> None:
         super().__init__()
 
         self._output_devices = {}  # type: Dict[str, OutputDevice]
@@ -66,17 +65,7 @@ class OutputDeviceManager:
         self._write_in_progress = False
         PluginRegistry.addType("output_device", self.addOutputDevicePlugin)
 
-        self._application = application
-        self._application.getPreferences().addPreference("output_devices/last_used_device", "")
-        self._application.engineCreatedSignal.connect(self._onEngineCreated)
-
         self._is_running = False
-
-    def _onEngineCreated(self):
-        device_id = self._application.getPreferences().getValue("output_devices/last_used_device")
-        if device_id in self._output_devices:
-            self.setActiveDevice(device_id)
-
 
     writeStarted = Signal()
     """Emitted whenever a registered device emits writeStarted.
@@ -242,7 +231,6 @@ class OutputDeviceManager:
             return
 
         if not self._active_device or self._active_device.getId() != device_id:
-            self._application.getPreferences().setValue("output_devices/last_used_device", device_id)
             self._active_device = self.getOutputDevice(device_id)
             self._write_in_progress = False
             self._active_device_override = True


### PR DESCRIPTION
This PR adds a preference to the OutputDeviceManager to remember which outputdevice is selected between sessions.

https://github.com/Ultimaker/Cura/issues/7168