### PR TITLE
Prevent code injection in setting functions

### DIFF
--- a/UM/Settings/SettingFunction.py
+++ b/UM/Settings/SettingFunction.py
@@ -230,6 +230,8 @@ class _SettingExpressionVisitor(ast.NodeVisitor):
         # extra sure that certain calls are *not* made!)
         if node.s in self._blacklist:
             raise IllegalMethodError(node.s)
+        if node.s.startswith("_"):
+            raise IllegalMethodError(node.s)
 
         if node.s not in self._knownNames and node.s not in dir(builtins):  # type: ignore #AST uses getattr stuff, so ignore type of node.s.
             self.keys.add(node.s)  # type: ignore
@@ -240,6 +242,8 @@ class _SettingExpressionVisitor(ast.NodeVisitor):
         # extra sure that certain calls are *not* made!)
         if node.value in self._blacklist:
             raise IllegalMethodError(node.value)
+        if node.s.startswith("_"):
+            raise IllegalMethodError(node.s)
         if isinstance(node.value, str) and node.value not in self._knownNames and node.value not in dir(builtins):  # type: ignore #AST uses getattr stuff, so ignore type of node.value.
             self.keys.add(node.value)  # type: ignore
 

--- a/UM/Settings/SettingFunction.py
+++ b/UM/Settings/SettingFunction.py
@@ -3,16 +3,12 @@
 
 import ast
 import builtins  # To check against functions that are built-in in Python.
-import math  # Imported here so it can be used easily by the setting functions.
-import uuid  # Imported here so it can be used easily by the setting functions.
-import base64  # Imported here so it can be used easily by the setting functions.
-import hashlib  # Imported here so it can be used easily by the setting functions.
 from types import CodeType
 from typing import Any, Callable, Dict, FrozenSet, NamedTuple, Optional, Set, TYPE_CHECKING
 
+from UM.Logger import Logger
 from UM.Settings.Interfaces import ContainerInterface
 from UM.Settings.PropertyEvaluationContext import PropertyEvaluationContext
-from UM.Logger import Logger
 
 if TYPE_CHECKING:
     from typing import FrozenSet
@@ -28,10 +24,10 @@ def _debug_value(value: Any) -> Any:
 
 
 class SettingFunction:
-    """
-    This class is used to evaluate Python codes (or you can call them formulas) for a setting's property. If a setting's
-    property is a static type, e.g., a string, an int, a float, etc., its value will just be interpreted as it is, but
-    when it's a Python code (formula), the value needs to be evaluated via this class.
+    """Evaluates Python formulas for a setting's property.
+
+    If a setting's property is a static type, e.g. a string, an int, a float, etc., its value will just be interpreted
+    as it is, but when it's a Python code (formula), the value needs to be evaluated via this class.
     """
     def __init__(self, expression: str) -> None:
         """Constructor.

--- a/UM/Settings/SettingFunction.py
+++ b/UM/Settings/SettingFunction.py
@@ -268,7 +268,8 @@ class _SettingExpressionVisitor(ast.NodeVisitor):
         "encode",
         "b64encode",
         "digest",
-        "md5"
+        "md5",
+        "radians"
     }  # type: Set[str]
 
     _blacklist = {

--- a/UM/Settings/SettingFunction.py
+++ b/UM/Settings/SettingFunction.py
@@ -316,3 +316,27 @@ class _SettingExpressionVisitor(ast.NodeVisitor):
         "__pycache__",
         "__file__"
     }  # type: Set[str]
+
+    _allowed_builtins = {
+        "bool",
+        "True",
+        "False",
+        "None",
+        "float",
+        "int",
+        "str",
+        "sum",
+        "pow",
+        "abs",
+        "all",
+        "any",
+        "round",
+        "divmod",
+        "hash",
+        "len",
+        "max",
+        "min"
+    }  # type: Set[str]
+
+    _disallowed_builtins = set(dir(builtins)) - _allowed_builtins
+    _blacklist |= _disallowed_builtins

--- a/UM/Settings/SettingFunction.py
+++ b/UM/Settings/SettingFunction.py
@@ -245,7 +245,13 @@ class _SettingExpressionVisitor(ast.NodeVisitor):
         "uuid",
         "hashlib",
         "base64",
-        "uuid3"
+        "uuid3",
+        "NAMESPACE_DNS",
+        "decode",
+        "encode",
+        "b64encode",
+        "digest",
+        "md5"
     }  # type: Set[str]
 
     _blacklist = {

--- a/UM/Settings/SettingFunction.py
+++ b/UM/Settings/SettingFunction.py
@@ -236,6 +236,12 @@ class _SettingExpressionVisitor(ast.NodeVisitor):
         if node.s not in self._knownNames and node.s not in dir(builtins):  # type: ignore #AST uses getattr stuff, so ignore type of node.s.
             self.keys.add(node.s)  # type: ignore
 
+    def visit_Subscript(self, node: ast.Index):
+        if type(node.value) == ast.Str:
+            raise IllegalMethodError("Indexing on strings is not allowed")
+        for child_node in ast.iter_child_nodes(node):
+            self.visit(child_node)
+
     def visit_Constant(self, node) -> None:
         """This one is used on Python 3.8+ to visit string types."""
         # The blacklisting is done just in case (All function calls should be whitelisted. The blacklist is to make

--- a/UM/Settings/SettingFunction.py
+++ b/UM/Settings/SettingFunction.py
@@ -221,7 +221,7 @@ class _SettingExpressionVisitor(ast.NodeVisitor):
         """
         raise IllegalMethodError("Slices are not allowed")
 
-    def visit_Str(self, node: ast.AST) -> None:
+    def visit_Str(self, node: ast.Str) -> None:
         """This one is used before Python 3.8 to visit string types.
         
         visit_Str will be marked as deprecated from Python 3.8 and onwards.
@@ -234,7 +234,7 @@ class _SettingExpressionVisitor(ast.NodeVisitor):
         if node.s not in self._knownNames and node.s not in dir(builtins):  # type: ignore #AST uses getattr stuff, so ignore type of node.s.
             self.keys.add(node.s)  # type: ignore
 
-    def visit_Constant(self, node: ast.AST) -> None:
+    def visit_Constant(self, node: ast.Constant) -> None:
         """This one is used on Python 3.8+ to visit string types."""
         # The blacklisting is done just in case (All function calls should be whitelisted. The blacklist is to make
         # extra sure that certain calls are *not* made!)

--- a/UM/Settings/SettingFunction.py
+++ b/UM/Settings/SettingFunction.py
@@ -267,6 +267,8 @@ class _SettingExpressionVisitor(ast.NodeVisitor):
         "__import__",
         "_",  # Because you can use this guy to create a number of the other blacklisted strings
         "__",
+        "."
+        "_._",   # Just in case (I also don't see a reason for someone to use a string named like that...)
         "__enter__",
         "__builtins__",
         "eval",
@@ -283,5 +285,15 @@ class _SettingExpressionVisitor(ast.NodeVisitor):
         "reload",
         "setattr",
         "vars",
-        "locals"
+        "locals",
+        "system",
+        "literal_eval",
+        "ast.literal_eval",
+        "ast",
+        "lambda",
+        "__getattribute__",
+        "__setattr__",
+        "find_module",
+        "__pycache__",
+        "__file__"
     }  # type: Set[str]

--- a/UM/Settings/SettingFunction.py
+++ b/UM/Settings/SettingFunction.py
@@ -2,9 +2,18 @@
 # Uranium is released under the terms of the LGPLv3 or higher.
 
 import ast
+# noinspection PyUnresolvedReferences
+import base64  # Imported here so it can be used easily by the setting functions.
 import builtins  # To check against functions that are built-in in Python.
+# noinspection PyUnresolvedReferences
+import hashlib  # Imported here so it can be used easily by the setting functions.
+# noinspection PyUnresolvedReferences
+import uuid  # Imported here so it can be used easily by the setting functions.
 from types import CodeType
 from typing import Any, Callable, Dict, FrozenSet, NamedTuple, Optional, Set, TYPE_CHECKING
+
+# noinspection PyUnresolvedReferences
+import math  # Imported here so it can be used easily by the setting functions.
 
 from UM.Logger import Logger
 from UM.Settings.Interfaces import ContainerInterface

--- a/UM/Settings/SettingFunction.py
+++ b/UM/Settings/SettingFunction.py
@@ -250,6 +250,12 @@ class _SettingExpressionVisitor(ast.NodeVisitor):
         "ceil",
         "min",
         "sqrt",
+        "log",
+        "tan",
+        "cos",
+        "sin",
+        "pi",
+        "floor"
         "debug",
         "sum",
         "len",

--- a/UM/Settings/SettingFunction.py
+++ b/UM/Settings/SettingFunction.py
@@ -234,7 +234,7 @@ class _SettingExpressionVisitor(ast.NodeVisitor):
         if node.s not in self._knownNames and node.s not in dir(builtins):  # type: ignore #AST uses getattr stuff, so ignore type of node.s.
             self.keys.add(node.s)  # type: ignore
 
-    def visit_Constant(self, node: ast.Constant) -> None:
+    def visit_Constant(self, node) -> None:
         """This one is used on Python 3.8+ to visit string types."""
         # The blacklisting is done just in case (All function calls should be whitelisted. The blacklist is to make
         # extra sure that certain calls are *not* made!)

--- a/UM/Settings/SettingFunction.py
+++ b/UM/Settings/SettingFunction.py
@@ -275,17 +275,18 @@ class _SettingExpressionVisitor(ast.NodeVisitor):
     _blacklist = {
         "sys",
         "os",
-        "delattr"
-        "getattr"
-        "dir"
+        "delattr",
+        "getattr",
+        "dir",
         "open",
         "write",
         "compile",
         "import",
         "__import__",
+        "__self__",
         "_",  # Because you can use this guy to create a number of the other blacklisted strings
         "__",
-        "."
+        ".",
         "_._",   # Just in case (I also don't see a reason for someone to use a string named like that...)
         "__enter__",
         "__builtins__",

--- a/UM/Settings/SettingFunction.py
+++ b/UM/Settings/SettingFunction.py
@@ -211,6 +211,16 @@ class _SettingExpressionVisitor(ast.NodeVisitor):
         for child_node in ast.iter_child_nodes(node):
             self.visit(child_node)
 
+    def visit_Slice(self, node):
+        """
+        Visitor function for slices.
+        We want to block all usage of slices, since it can be used to wiggle your way around the string filtering.
+        For example: "_0"[:1] + "_0"[:1] + "import__" will still result in the final string "__import__"
+        :param node:
+        :return:
+        """
+        raise IllegalMethodError("Slices are not allowed")
+
     def visit_Str(self, node: ast.AST) -> None:
         """This one is used before Python 3.8 to visit string types.
         

--- a/UM/Settings/SettingFunction.py
+++ b/UM/Settings/SettingFunction.py
@@ -249,6 +249,7 @@ class _SettingExpressionVisitor(ast.NodeVisitor):
         "max",
         "ceil",
         "min",
+        "sqrt",
         "debug",
         "sum",
         "len",

--- a/tests/Settings/TestSettingFunction.py
+++ b/tests/Settings/TestSettingFunction.py
@@ -40,6 +40,10 @@ setting_function_bad_data = [
     "(",                                                                # Syntax error.
     "[x for x in (1).__class__.__base__.__subclasses__() if x.__name__ == '_ImportLockContext'][0]().__enter__.__globals__['__builtins__']['__import__']('os').system(\"echo omgzomg\")",  # Obsfucated call to system
     "[x for x in (1).__class__.__base__.__subclasses__() if x.__name__ == '_ImportLockContext'][0]().__enter__.__globals__['__' + 'builtins__']['__import__']('os').system(\"echo omgzomg\")"   #Another obsfucated call to system
+    "'_'", # This string is not allowed
+    "import sys",  # We don't allow importing
+    "'a_a'[1]",  # Trying to circumvent the protection against underscores
+    "{x:x for x in [1,2,3,4]}"  # We don't allow dict comprehension
 ]
 
 

--- a/tests/Settings/TestSettingFunction.py
+++ b/tests/Settings/TestSettingFunction.py
@@ -1,9 +1,10 @@
-# Copyright (c) 2016 Ultimaker B.V.
+# Copyright (c) 2020 Ultimaker B.V.
 # Uranium is released under the terms of the LGPLv3 or higher.
 
 import pytest
 
 from UM.Settings.SettingFunction import SettingFunction
+
 
 ##  Individual test cases for the good setting functions.
 #
@@ -18,6 +19,7 @@ setting_function_good_data = [
     "foo * zoo"     # Two variables.
 ]
 
+
 ##  Fixture to create a setting function.
 #
 #   These setting functions are all built with good functions. Id est no errors
@@ -25,6 +27,7 @@ setting_function_good_data = [
 @pytest.fixture(params = setting_function_good_data)
 def setting_function_good(request):
     return SettingFunction(request.param)
+
 
 ##  Individual test cases for the bad setting functions.
 #
@@ -37,6 +40,7 @@ setting_function_bad_data = [
     "("                                                                 # Syntax error.
 ]
 
+
 ##  Fixture to create a setting function.
 #
 #   These setting functions are all built with bad functions. Id est they should
@@ -45,6 +49,7 @@ setting_function_bad_data = [
 def setting_function_bad(request):
     return SettingFunction(request.param)
 
+
 ##  Tests the initialisation of setting functions with good functions.
 #
 #   Each of these should create a good function.
@@ -52,12 +57,14 @@ def test_init_good(setting_function_good):
     assert setting_function_good is not None
     assert setting_function_good.isValid()
 
+
 ##  Tests the initialisation of setting functions with bad functions.
 #
 #   Each of these should create a bad function.
 def test_init_bad(setting_function_bad):
     assert setting_function_bad is not None
     assert not setting_function_bad.isValid()
+
 
 class MockValueProvider:
     ##  Creates a mock value provider.
@@ -77,6 +84,7 @@ class MockValueProvider:
             return None
         return self._values[key]
 
+
 test_call_data = [
     { "code": "0",            "result": 0 },
     { "code": "\"x\"",        "result": "x" },
@@ -90,6 +98,7 @@ test_call_data = [
     { "code": "boo",          "result": 0 } # Variable doesn't exist.
 ]
 
+
 ##  Tests the calling of a valid setting function.
 #
 #   \param setting_function_good A valid setting function from a fixture.
@@ -99,21 +108,23 @@ def test_call(data):
     function = SettingFunction(data["code"])
     assert function(value_provider) == data["result"]
 
+
 ##  Tests the equality operator on setting functions.
 def test_eq():
     setting_function = SettingFunction("3 * 3")
-    assert not (setting_function == "some string") # Equality against something of a different type.
+    assert not (setting_function == "some string")  # Equality against something of a different type.
     assert setting_function != "some string"
     assert setting_function == setting_function # Equality against itself.
     assert not (setting_function != setting_function)
 
-    duplicate = SettingFunction("3 * 3") # Different instance with the same code. Should be equal!
+    duplicate = SettingFunction("3 * 3")  # Different instance with the same code. Should be equal!
     assert setting_function == duplicate
     assert not (setting_function != duplicate)
 
-    same_answer = SettingFunction("9") # Different code but the result is the same. Should NOT be equal!
+    same_answer = SettingFunction("9")  # Different code but the result is the same. Should NOT be equal!
     assert not (setting_function == same_answer)
     assert setting_function != same_answer
+
 
 ##  The individual test cases for test_getUsedSettings.
 #
@@ -125,11 +136,12 @@ test_getUsedSettings_data = [
     { "code": "\"x\"",   "variables": ["x"] },
     { "code": "x",       "variables": ["x"] },
     { "code": "x * y",   "variables": ["x", "y"] },
-    { "code": "sqrt(4)", "variables": ["sqrt"] },
-    { "code": "sqrt(x)", "variables": ["sqrt", "x"] },
-    { "code": "x * x",   "variables": ["x"] }, # Use the same variable twice.
-    { "code": "sqrt('x')" , "variables": [ "sqrt", "x" ] }, # Calling functions with string parameters will mark the string parameter as a "used setting".
+    { "code": "sqrt(4)", "variables": [] },
+    { "code": "sqrt(x)", "variables": ["x"] },
+    { "code": "x * x",   "variables": ["x"] },  # Use the same variable twice.
+    { "code": "sqrt('x')" , "variables": ["x"] }, # Calling functions with string parameters will mark the string parameter as a "used setting".
 ]
+
 
 ##  Tests if the function finds correctly which settings are used.
 #
@@ -139,13 +151,14 @@ def test_getUsedSettings(data):
     function = SettingFunction(data["code"])
     answer = function.getUsedSettingKeys()
     assert len(answer) == len(data["variables"])
-    for variable in data["variables"]: # Check for set equality regardless of the order.
+    for variable in data["variables"]:  # Check for set equality regardless of the order.
         assert variable in answer
+
 
 ##  Tests the conversion of a setting function to string.
 def test_str():
     # Due to the simplicity of the function, it's not really necessary to make a full-blown parametrised test for this. Just two simple tests:
-    function = SettingFunction("3.14156") # Simple test case.
+    function = SettingFunction("3.14156")  # Simple test case.
     assert str(function) == "=3.14156"
-    function = SettingFunction("") # Also the edge case.
+    function = SettingFunction("")  # Also the edge case.
     assert str(function) == "="

--- a/tests/Settings/TestSettingFunction.py
+++ b/tests/Settings/TestSettingFunction.py
@@ -37,7 +37,9 @@ setting_function_bad_data = [
     "",                                                                 # Empty string.
     "os.read(os.open(\"/etc/passwd\", os.O_RDONLY), 10)",               # Function that reads your passwords from your system.
     "exec(\"os.read(os.open(\\\"/etc/passwd\\\", os.O_RDONLY), 10)\")", # Obfuscated function that reads your passwords from your system.
-    "("                                                                 # Syntax error.
+    "(",                                                                # Syntax error.
+    "[x for x in (1).__class__.__base__.__subclasses__() if x.__name__ == '_ImportLockContext'][0]().__enter__.__globals__['__builtins__']['__import__']('os').system(\"echo omgzomg\")",  # Obsfucated call to system
+    "[x for x in (1).__class__.__base__.__subclasses__() if x.__name__ == '_ImportLockContext'][0]().__enter__.__globals__['__' + 'builtins__']['__import__']('os').system(\"echo omgzomg\")"   #Another obsfucated call to system
 ]
 
 


### PR DESCRIPTION
This makes the setting function a whole lot more paranoid! It contains both a white and a black list. All setting calls must be on the white list and a number of strings are blacklisted. 

CURA-7169