### PR TITLE
CURA-7211_pos_infill_defaults_0

### DIFF
--- a/UM/Settings/Models/SettingVisibilityHandler.py
+++ b/UM/Settings/Models/SettingVisibilityHandler.py
@@ -20,3 +20,7 @@ class SettingVisibilityHandler(QObject):
     def getVisible(self) -> Set[str]:
         return self._visible.copy()
 
+    def forceVisibilityChanged(self) -> None:
+        self.visibilityChanged.emit()
+
+


### PR DESCRIPTION
The problem: When infill mesh is set, wall_thickness and top_bottom_thickness are added to the settings.
Then these settings are set to visible on the visibility_handler.
It appears however, that the visibility_handler considers all added settings to be visible. It thus concludes that no UI update is necessary because the settings are already added.