### PR TITLE
CURA 7333 Add internal variable to keep track of object idx

### DIFF
--- a/UM/Mesh/ReadMeshJob.py
+++ b/UM/Mesh/ReadMeshJob.py
@@ -22,6 +22,7 @@ class ReadMeshJob(ReadFileJob):
     def __init__(self, filename: str) -> None:
         super().__init__(filename)
         from UM.Qt.QtApplication import QtApplication
+        self.object_to_be_reloaded = 0  # used when reloading a 3mf file with multiple objects
         self._application = QtApplication.getInstance()
         self._handler = QtApplication.getInstance().getMeshFileHandler()
 


### PR DESCRIPTION
The ReadMeshJob is called for each object in the 3mf file individually.
Therefore, when reloading a 3mf file, the ReadMeshJob has to be aware
of which object it is reloading. To do that, it keeps a track of it
through the new internal variable object_to_be_reloaded.

This variable is read back in cura in order to request the object at
that specific index.

CURA-7333