### PR TITLE
Cura 7333 fix reloading 3mf files with many objects

### DIFF
--- a/UM/Mesh/ReadMeshJob.py
+++ b/UM/Mesh/ReadMeshJob.py
@@ -22,6 +22,7 @@ class ReadMeshJob(ReadFileJob):
     def __init__(self, filename: str) -> None:
         super().__init__(filename)
         from UM.Qt.QtApplication import QtApplication
+        self.object_to_be_reloaded = 0  # used when reloading a 3mf file with multiple objects
         self._application = QtApplication.getInstance()
         self._handler = QtApplication.getInstance().getMeshFileHandler()
 

--- a/UM/Mesh/ReadMeshJob.py
+++ b/UM/Mesh/ReadMeshJob.py
@@ -22,7 +22,6 @@ class ReadMeshJob(ReadFileJob):
     def __init__(self, filename: str) -> None:
         super().__init__(filename)
         from UM.Qt.QtApplication import QtApplication
-        self.object_to_be_reloaded = 0  # used when reloading a 3mf file with multiple objects
         self._application = QtApplication.getInstance()
         self._handler = QtApplication.getInstance().getMeshFileHandler()
 

--- a/UM/Scene/SceneNode.py
+++ b/UM/Scene/SceneNode.py
@@ -34,7 +34,7 @@ class SceneNode:
         Parent = 2 #type: int
         World = 3 #type: int
 
-    def __init__(self, parent: Optional["SceneNode"] = None, visible: bool = True, name: str = "", node_id: int = -1) -> None:
+    def __init__(self, parent: Optional["SceneNode"] = None, visible: bool = True, name: str = "", node_id: str = "") -> None:
         """Construct a scene node.
 
         :param parent: The parent of this node (if any). Only a root node should have None as a parent.
@@ -81,7 +81,7 @@ class SceneNode:
 
         self._visible = visible  # type: bool
         self._name = name  # type: str
-        self._id = node_id  # type: int
+        self._id = node_id  # type: str
         self._decorators = []  # type: List[SceneNodeDecorator]
 
         # Store custom settings to be compatible with Savitar SceneNode

--- a/UM/Scene/SceneNode.py
+++ b/UM/Scene/SceneNode.py
@@ -34,7 +34,7 @@ class SceneNode:
         Parent = 2 #type: int
         World = 3 #type: int
 
-    def __init__(self, parent: Optional["SceneNode"] = None, visible: bool = True, name: str = "") -> None:
+    def __init__(self, parent: Optional["SceneNode"] = None, visible: bool = True, name: str = "", node_id: int = -1) -> None:
         """Construct a scene node.
 
         :param parent: The parent of this node (if any). Only a root node should have None as a parent.
@@ -81,6 +81,7 @@ class SceneNode:
 
         self._visible = visible  # type: bool
         self._name = name  # type: str
+        self._id = node_id  # type: int
         self._decorators = []  # type: List[SceneNodeDecorator]
 
         # Store custom settings to be compatible with Savitar SceneNode
@@ -304,6 +305,12 @@ class SceneNode:
 
     def setName(self, name: str) -> None:
         self._name = name
+
+    def getId(self) -> str:
+        return self._id
+
+    def setId(self, node_id: str) -> None:
+        self._id = node_id
 
     def getDepth(self) -> int:
         """How many nodes is this node removed from the root?


### PR DESCRIPTION
Add the node id that represents the objectId from inside the 3mf file. This can now be used as an identifier of the node when refreshing the object, to refresh the correct object from the 3mf file.

Requires https://github.com/Ultimaker/libSavitar/pull/24
Merge this along with https://github.com/Ultimaker/Cura/pull/7384