### PR TITLE
Fix for loading OBJ files without normals, and speed optimisations

### DIFF
--- a/plugins/FileHandlers/OBJReader/OBJReader.py
+++ b/plugins/FileHandlers/OBJReader/OBJReader.py
@@ -40,13 +40,7 @@ class OBJReader(MeshReader):
                     del parts[-1]
                     previous_line_parts = parts
                     continue
-                if parts[0] == "v":
-                    vertex_list.append([float(parts[1]), float(parts[3]), -float(parts[2])])
-                elif parts[0] == "vn":
-                    normal_list.append([float(parts[1]), float(parts[3]), -float(parts[2])])
-                elif parts[0] == "vt":
-                    uv_list.append([float(parts[1]), float(parts[2])])
-                elif parts[0] == "f":
+                if parts[0] == "f":
                     parts = [i for i in map(lambda p: p.split("/"), parts)]
                     for idx in range(1, len(parts) - 2):
                         data = [int(parts[1][0]), int(parts[idx + 1][0]), int(parts[idx + 2][0])]
@@ -57,6 +51,12 @@ class OBJReader(MeshReader):
                             if len(parts[1]) > 2:
                                 data += [int(parts[1][2]), int(parts[idx + 1][2]), int(parts[idx + 2][2])]
                         face_list.append(data)
+                elif parts[0] == "v":
+                    vertex_list.append([float(parts[1]), float(parts[3]), -float(parts[2])])
+                elif parts[0] == "vn":
+                    normal_list.append([float(parts[1]), float(parts[3]), -float(parts[2])])
+                elif parts[0] == "vt":
+                    uv_list.append([float(parts[1]), float(parts[2])])
                 Job.yieldThread()
             f.close()
 

--- a/plugins/FileHandlers/OBJReader/OBJReader.py
+++ b/plugins/FileHandlers/OBJReader/OBJReader.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2018 Ultimaker B.V.
+# Copyright (c) 2020 Ultimaker B.V.
 # Copyright (c) 2013 David Braam
 # Uranium is released under the terms of the LGPLv3 or higher.
 
@@ -42,13 +42,13 @@ class OBJReader(MeshReader):
                     continue
                 if parts[0] == "v":
                     vertex_list.append([float(parts[1]), float(parts[3]), -float(parts[2])])
-                if parts[0] == "vn":
+                elif parts[0] == "vn":
                     normal_list.append([float(parts[1]), float(parts[3]), -float(parts[2])])
-                if parts[0] == "vt":
+                elif parts[0] == "vt":
                     uv_list.append([float(parts[1]), float(parts[2])])
-                if parts[0] == "f":
+                elif parts[0] == "f":
                     parts = [i for i in map(lambda p: p.split("/"), parts)]
-                    for idx in range(1, len(parts)-2):
+                    for idx in range(1, len(parts) - 2):
                         data = [int(parts[1][0]), int(parts[idx + 1][0]), int(parts[idx + 2][0])]
                         if len(parts[1]) > 1:
                             if parts[1][1] and parts[idx + 1][1] and parts[idx + 2][1]:

--- a/plugins/FileHandlers/OBJReader/OBJReader.py
+++ b/plugins/FileHandlers/OBJReader/OBJReader.py
@@ -49,12 +49,13 @@ class OBJReader(MeshReader):
                 if parts[0] == "f":
                     parts = [i for i in map(lambda p: p.split("/"), parts)]
                     for idx in range(1, len(parts)-2):
-                        data = [int(parts[1][0]), int(parts[idx+1][0]), int(parts[idx+2][0])]
-                        if len(parts[1]) > 2:
-                            data += [int(parts[1][2]), int(parts[idx+1][2]), int(parts[idx+2][2])]
+                        data = [int(parts[1][0]), int(parts[idx + 1][0]), int(parts[idx + 2][0])]
+                        if len(parts[1]) > 1:
+                            if parts[1][1] and parts[idx + 1][1] and parts[idx + 2][1]:
+                                data += [int(parts[1][1]), int(parts[idx + 1][1]), int(parts[idx + 2][1])]
 
-                            if parts[1][1] and parts[idx+1][1] and parts[idx+2][1]:
-                                data += [int(parts[1][1]), int(parts[idx+1][1]), int(parts[idx+2][1])]
+                            if len(parts[1]) > 2:
+                                data += [int(parts[1][2]), int(parts[idx + 1][2]), int(parts[idx + 2][2])]
                         face_list.append(data)
                 Job.yieldThread()
             f.close()
@@ -69,22 +70,22 @@ class OBJReader(MeshReader):
                 k = face[2] - 1
 
                 if len(face) > 3:
-                    ni = face[3] - 1
-                    nj = face[4] - 1
-                    nk = face[5] - 1
-                else:
-                    ni = -1
-                    nj = -1
-                    nk = -1
-
-                if len(face) > 6:
-                    ui = face[6] - 1
-                    uj = face[7] - 1
-                    uk = face[8] - 1
+                    ui = face[3] - 1
+                    uj = face[4] - 1
+                    uk = face[5] - 1
                 else:
                     ui = -1
                     uj = -1
                     uk = -1
+
+                if len(face) > 6:
+                    ni = face[6] - 1
+                    nj = face[7] - 1
+                    nk = face[8] - 1
+                else:
+                    ni = -1
+                    nj = -1
+                    nk = -1
 
                 #TODO: improve this handling, this can cause weird errors (negative indexes are relative indexes, and are not properly handled)
                 if i < 0 or i >= num_vertices:


### PR DESCRIPTION
I've made a fix here that fixes loading meshes that contain vertex coordinates, but not normal vectors. Previously this would crash with an IndexError.

The format for a face is as follows:

    f v1/t1/n1 v2/t2/n2 v3/t3/n3

The part after a slash is optional. You could also have faces like this, without the normals:

    f v1/t1 v2/t2 v3/t3

Or even a face like this, with just the vertices and no textures:

    f v1 v2 v3

However it's not possible to have a face with vertices and normals but no textures:

    f v1/n1 v2/n2 v3/n3

This gets interpreted as a face with vertices and textures.

When given a face with just vertices and textures, our old code would give an IndexError saying that the normal vectors are out of range. That would be correct since it only stored -1 there. This fixes that by turning the texture and normal data around in our internal representation so that it has the same representation as the actual OBJ file. The same order. And so the len() checks if they are present will have the same effect as a len() check on the number of slashes in the original file.

Additionally I made some minor theoretical performance improvements. I don't know how effective those really are.