### PR TITLE
Speed up getting the cfg version by using regex instead of configparser

### DIFF
--- a/UM/VersionUpgrade.py
+++ b/UM/VersionUpgrade.py
@@ -1,6 +1,6 @@
-# Copyright (c) 2016 Ultimaker B.V.
+# Copyright (c) 2020 Ultimaker B.V.
 # Cura is released under the terms of the LGPLv3 or higher.
-
+import re
 from UM.PluginObject import PluginObject
 
 
@@ -19,6 +19,23 @@ class VersionUpgrade(PluginObject):
         """Initialises a version upgrade plugin instance."""
 
         super().__init__()
+        self._version_regex = re.compile("\nversion ?= ?(\d+)")
+        self._setting_version_regex = re.compile("\nsetting_version ?= ?(\d+)")
+
+    def getCfgVersion(self, serialised: str) -> int:
+        """
+        Gets the version number from a config file.
+
+        In all config files that concern this version upgrade, the version number is stored in general/version, so get
+        the data from that key.
+
+        :param serialised: The contents of a config file.
+        :return: The version number of that config file.
+        """
+
+        format_version = int(self._version_regex.search(serialised).groups()[-1])
+        setting_version = int(self._setting_version_regex.search(serialised).groups()[-1])
+        return format_version * 1000000 + setting_version
 
 
 class FormatException(Exception):


### PR DESCRIPTION
This drastically speeds up the upgrader. On a regular boot, it took ~1.8
sec when upgrading, vs ~0.05s when upgrading with this fix (do note that
it's running with a profiler, so reality is about ~4x as fast on both sides)

See also: https://github.com/Ultimaker/Cura/pull/7559