### PR TITLE
Cura 7222 get coordinates in camera tool

### DIFF
--- a/UM/Controller.py
+++ b/UM/Controller.py
@@ -2,6 +2,7 @@
 # Uranium is released under the terms of the LGPLv3 or higher.
 from UM.Scene.Iterator.DepthFirstIterator import DepthFirstIterator
 from UM.Scene.Scene import Scene
+from Um.Scene.Scene.SceneNode import SceneNode
 from UM.Event import Event, KeyEvent, MouseEvent, ToolEvent, ViewEvent
 from UM.Scene.SceneNode import SceneNode
 from UM.Signal import Signal, signalemitter
@@ -14,6 +15,8 @@ from UM.Stage import Stage
 from UM.InputDevice import InputDevice
 from typing import cast, Optional, Dict, Union
 from UM.Math.Vector import Vector
+from UM.Math.Quaternion import Quaternion
+
 MYPY = False
 if MYPY:
     from UM.Application import Application
@@ -529,6 +532,28 @@ class Controller:
                 else:
                     camera.setPosition(Vector(0, 100, 700))
                     self._camera_tool.rotateCamera(0, angle)  # type: ignore
+
+    def getCameraOrientation(self) -> Optional[Quaternion]:
+        """Get the request camera position as a :py:class:`UM.Math.Quaternion.Quaternion`
+
+        :return: The camera position represented as an Quaternion
+        """
+        
+        camera = self._scene.getActiveCamera()
+        if not camera:
+            return
+        return camera.getOrientation()
+
+    def setCameraOrientation(self, orientation: Quaternion):
+        """Set the camera position with a :py:class:`UM.Math.Quaternion.Quaternion`
+        
+        :param orientation: The camera position represented as an Quaternion
+        """
+        
+        camera = self._scene.getActiveCamera()
+        if not camera:
+            return
+        camera.setOrientation(orientation, SceneNode.TransformSpace.Local)
 
     # Position camera view according to defined position
     def setCameraPosition(self, x_position: int = 0, y_position: int = 0, z_position: int = 0) -> None:

--- a/UM/Controller.py
+++ b/UM/Controller.py
@@ -541,7 +541,7 @@ class Controller:
         
         camera = self._scene.getActiveCamera()
         if not camera:
-            return
+            return None
         if axis is not None:
             return getattr(camera.getOrientation().toMatrix().getEuler(), axis)
         return camera.getOrientation()
@@ -579,7 +579,7 @@ class Controller:
 
         camera = self._scene.getActiveCamera()
         if not camera:
-            return
+            return None
         return camera.getPosition()
 
     # Indicate position where the camera should point at
@@ -626,5 +626,5 @@ class Controller:
         """
         camera = self._scene.getActiveCamera()
         if not camera:
-            return
+            return None
         return camera.isPerspective()

--- a/UM/Controller.py
+++ b/UM/Controller.py
@@ -537,6 +537,18 @@ class Controller:
             return
         camera.setPosition(Vector(x_position, y_position, z_position))
 
+    def getCameraPosition(self) -> Optional[Vector]:
+        r"""Get the camera coordinate as a :py:class:`UM.Math.Vector.Vector`
+
+        :return: A vector describing the active camera position or None if  there
+         isn't an active camera.
+        """
+
+        camera = self._scene.getActiveCamera()
+        if not camera:
+            return
+        return camera.getPosition()
+
     # Indicate position where the camera should point at
     def setLookAtPosition(self, x_look_at_position: int = 0, y_look_at_position: int = 0, z_look_at_position: int = 0) -> None:
         camera = self._scene.getActiveCamera()

--- a/UM/Controller.py
+++ b/UM/Controller.py
@@ -572,3 +572,14 @@ class Controller:
             "z": Vector(0, 100, 1)
         }
         camera.lookAt(coordinates[coordinate])
+
+    def isCameraPerspective(self) -> Optional[bool]:
+        r"""Is the camera in perspective or orthogonal mode
+
+        :return: True if camera is perspective, False if in orthogonal mode and
+        None if there isn't an instance of an active camera
+        """
+        camera = self._scene.getActiveCamera()
+        if not camera:
+            return
+        return camera.isPerspective()

--- a/UM/Controller.py
+++ b/UM/Controller.py
@@ -2,7 +2,6 @@
 # Uranium is released under the terms of the LGPLv3 or higher.
 from UM.Scene.Iterator.DepthFirstIterator import DepthFirstIterator
 from UM.Scene.Scene import Scene
-from Um.Scene.Scene.SceneNode import SceneNode
 from UM.Event import Event, KeyEvent, MouseEvent, ToolEvent, ViewEvent
 from UM.Scene.SceneNode import SceneNode
 from UM.Signal import Signal, signalemitter
@@ -553,7 +552,7 @@ class Controller:
         camera = self._scene.getActiveCamera()
         if not camera:
             return
-        camera.setOrientation(orientation, SceneNode.TransformSpace.Local)
+        camera.setOrientation(orientation, 3)
 
     # Position camera view according to defined position
     def setCameraPosition(self, x_position: int = 0, y_position: int = 0, z_position: int = 0) -> None:

--- a/UM/Controller.py
+++ b/UM/Controller.py
@@ -628,3 +628,13 @@ class Controller:
         if not camera:
             return None
         return camera.isPerspective()
+    
+    def setCameraPerspective(self, value: bool) -> None:
+        """Sets the camera perspective
+
+        :param value: True is perspective False is orthographic
+        """
+        camera = self._scene.getActiveCamera()
+        if not camera:
+            return None
+        camera.setPerspective(value)

--- a/UM/Qt/Bindings/ControllerProxy.py
+++ b/UM/Qt/Bindings/ControllerProxy.py
@@ -69,15 +69,27 @@ class ControllerProxy(QObject):
     @pyqtSlot(str, int)
     def setCameraRotation(self, coordinate: str, angle: int) -> None:
         self._controller.setCameraRotation(coordinate, angle)
-
-    @pyqtSlot(str, float)
-    def getCameraOrientation(self) -> Optional[Quaternion]:
-        """Get the request camera position as a :py:class:`UM.Math.Quaternion.Quaternion`
         
-        :return: The camera position represented as an Quaternion
+    @pyqtSlot(float, float, float)
+    def setCameraOrientation(self, x: float, y: float, z: float) -> None:
+        """Set the camera orientation according to the specified angle of rotation along each axis
+        
+        :param x: angle of rotation along the x axis given in radians
+        :param y: angle of rotation along the y axis given in radians
+        :param z: angle of rotation along the z axis given in radians
         """
+        self._controller.setCameraOrientation(ai=x, aj=y, ak=z)
+
+    @pyqtSlot(str, result = float)
+    def getCameraOrientation(self, axis: str = None) -> Optional[Union[Quaternion, float]]:
+        """Get the request camera position as a :py:class:`UM.Math.Quaternion.Quaternion` or single float
         
-        return self._controller.getCameraOrientation()
+        :param axis: When specified it wil return the requested x, y, z axis to return the rotation from, or when it 
+        is not specified it will return the vector (Optional) default is None 
+        
+        :return: The camera orientation along an axis or as a whole represented as an Quaternion
+        """
+        return self._controller.getCameraOrientation(axis)
 
     @pyqtSlot(int, int, int)
     def setCameraPosition(self, x_position: int = 0, y_position: int = 0, z_position: int = 0) -> None:

--- a/UM/Qt/Bindings/ControllerProxy.py
+++ b/UM/Qt/Bindings/ControllerProxy.py
@@ -96,7 +96,7 @@ class ControllerProxy(QObject):
         self._controller.setCameraPosition(x_position, y_position, z_position)
 
     @pyqtSlot(str, result = int)
-    def getCameraPosition(self, vector: str = None) -> Optional[Union[int, Vector]]:
+    def getCameraPosition(self, vector: str = '') -> Optional[Union[int, Vector]]:
         """Get the request camera position as a :py:class:`UM.Math.Vector.Vector`
         or it single requested component
 

--- a/UM/Qt/Bindings/ControllerProxy.py
+++ b/UM/Qt/Bindings/ControllerProxy.py
@@ -137,6 +137,14 @@ class ControllerProxy(QObject):
         None if there isn't an instance of an active camera
         """
         return self._controller.isCameraPerspective()
+    
+    @pyqtSlot(bool)
+    def setCameraPerspective(self, value: bool) -> None:
+        """Sets the camera perspective
+        
+        :param value: True is perspective False is orthographic
+        """
+        self._controller.setCameraPerspective(value)
 
     contextMenuRequested = pyqtSignal("quint64", arguments=["objectId"])
 

--- a/UM/Qt/Bindings/ControllerProxy.py
+++ b/UM/Qt/Bindings/ControllerProxy.py
@@ -5,6 +5,8 @@ from PyQt5.QtCore import QObject, pyqtSlot, pyqtSignal, pyqtProperty
 
 from typing import Optional, Union
 
+from UM.Math.Quaternion import Quaternion
+from UM.Math.Vector import Vector
 from UM.Application import Application
 from UM.Decorators import deprecated
 from UM.Scene.Selection import Selection
@@ -73,7 +75,7 @@ class ControllerProxy(QObject):
         self._controller.setCameraPosition(x_position, y_position, z_position)
 
     @pyqtSlot(str, result = int)
-    def getCameraPosition(self, vector: str = None) -> Optional[Union[int, 'UM.Math.Vector.Vector']]:
+    def getCameraPosition(self, vector: str = None) -> Optional[Union[int, Vector]]:
         """Get the request camera position as a :py:class:`UM.Math.Vector.Vector`
         or it single requested component
 
@@ -86,7 +88,7 @@ class ControllerProxy(QObject):
         if hasattr(self._controller.getCameraPosition(), vector):
             return getattr(self._controller.getCameraPosition(), vector)
         else:
-            return
+            return self._controller.getCameraPosition()
 
     @pyqtSlot(int, int, int)
     def setLookAtPosition(self, x_look_at_position: int = 0, y_look_at_position: int = 0, z_look_at_position: int = 0) -> None:

--- a/UM/Qt/Bindings/ControllerProxy.py
+++ b/UM/Qt/Bindings/ControllerProxy.py
@@ -3,7 +3,7 @@
 
 from PyQt5.QtCore import QObject, pyqtSlot, pyqtSignal, pyqtProperty
 
-from typing import Optional
+from typing import Optional, Union
 
 from UM.Application import Application
 from UM.Decorators import deprecated
@@ -71,6 +71,22 @@ class ControllerProxy(QObject):
     @pyqtSlot(int, int, int)
     def setCameraPosition(self, x_position: int = 0, y_position: int = 0, z_position: int = 0) -> None:
         self._controller.setCameraPosition(x_position, y_position, z_position)
+
+    @pyqtSlot(str, result = int)
+    def getCameraPosition(self, vector: str = None) -> Optional[Union[int, 'UM.Math.Vector.Vector']]:
+        """Get the request camera position as a :py:class:`UM.Math.Vector.Vector`
+        or it single requested component
+
+        :param vector: either specify the requested x, y, z component to return or
+         when it is not specified it will return the vector (Optional) default is None
+        :return: an integer for the specified component (x, y, z) or the whole
+         vector. If there isn't an active camera it will return None
+        """
+
+        if hasattr(self._controller.getCameraPosition(), vector):
+            return getattr(self._controller.getCameraPosition(), vector)
+        else:
+            return
 
     @pyqtSlot(int, int, int)
     def setLookAtPosition(self, x_look_at_position: int = 0, y_look_at_position: int = 0, z_look_at_position: int = 0) -> None:

--- a/UM/Qt/Bindings/ControllerProxy.py
+++ b/UM/Qt/Bindings/ControllerProxy.py
@@ -3,12 +3,13 @@
 
 from PyQt5.QtCore import QObject, pyqtSlot, pyqtSignal, pyqtProperty
 
+from typing import Optional
+
 from UM.Application import Application
 from UM.Decorators import deprecated
 from UM.Scene.Selection import Selection
 from UM.Operations.RemoveSceneNodeOperation import RemoveSceneNodeOperation
 from UM.Operations.GroupedOperation import GroupedOperation
-
 
 class ControllerProxy(QObject):
     def __init__(self, parent = None):
@@ -88,6 +89,15 @@ class ControllerProxy(QObject):
         """
 
         self._controller.setCameraOrigin(coordinate)
+
+    @pyqtSlot(result= bool)
+    def isCameraPerspective(self) -> Optional[bool]:
+        r"""Is the camera in perspective or orthogonal mode
+
+        :return: True if camera is perspective, False if in orthogonal mode and
+        None if there isn't an instance of an active camera
+        """
+        return self._controller.isCameraPerspective()
 
     contextMenuRequested = pyqtSignal("quint64", arguments=["objectId"])
 

--- a/UM/Qt/Bindings/ControllerProxy.py
+++ b/UM/Qt/Bindings/ControllerProxy.py
@@ -70,6 +70,15 @@ class ControllerProxy(QObject):
     def setCameraRotation(self, coordinate: str, angle: int) -> None:
         self._controller.setCameraRotation(coordinate, angle)
 
+    @pyqtSlot(str, float)
+    def getCameraOrientation(self) -> Optional[Quaternion]:
+        """Get the request camera position as a :py:class:`UM.Math.Quaternion.Quaternion`
+        
+        :return: The camera position represented as an Quaternion
+        """
+        
+        return self._controller.getCameraOrientation()
+
     @pyqtSlot(int, int, int)
     def setCameraPosition(self, x_position: int = 0, y_position: int = 0, z_position: int = 0) -> None:
         self._controller.setCameraPosition(x_position, y_position, z_position)


### PR DESCRIPTION
CURA-7222 describe that the camera-plugin should be able to read the state vector of the camera, manipulate, store and retrieve. The state vector of the camera in Euler space, consists of its position [x, y, z] and [roll, pitch, yaw], when the camera is in orthographic projection this is expanded with a zoom factor.
In order to accommodate the camera-plugin the following camera properties where exposed to the proxy:
- get/set Position
- get/set Orientation
- get/set Projection
- get/set Perspective