### PR TITLE
Add widgets to Rotate by 90 degrees

### DIFF
--- a/UM/Scene/ToolHandle.py
+++ b/UM/Scene/ToolHandle.py
@@ -1,6 +1,8 @@
 # Copyright (c) 2019 Ultimaker B.V.
 # Uranium is released under the terms of the LGPLv3 or higher.
 from typing import Optional
+from enum import IntEnum
+import random
 
 from UM.Logger import Logger
 from UM.Mesh.MeshData import MeshData
@@ -38,6 +40,10 @@ class ToolHandle(SceneNode.SceneNode):
     ZAxisSelectionColor = Color(0.0, 1.0, 0.0, 1.0)
     AllAxisSelectionColor = Color(1.0, 1.0, 1.0, 1.0)
 
+    class ExtraWidgets(IntEnum):
+        # Toolhandle subclasses can optionally register additional widgets by overriding this enum
+        pass
+
     def __init__(self, parent = None):
         super().__init__(parent)
 
@@ -48,6 +54,7 @@ class ToolHandle(SceneNode.SceneNode):
         self._all_axis_color = None
 
         self._axis_color_map = {}
+        self._extra_widgets_color_map = {}
 
         self._scene = Application.getInstance().getController().getScene()
 
@@ -134,6 +141,9 @@ class ToolHandle(SceneNode.SceneNode):
     def isAxis(self, value):
         return value in self._axis_color_map
 
+    def getExtraWidgetsColorMap(self):
+        return self._extra_widgets_color_map
+
     def buildMesh(self) -> None:
         # This method should be overridden by toolhandle implementations
         pass
@@ -167,4 +177,20 @@ class ToolHandle(SceneNode.SceneNode):
             self.AllAxis: self._all_axis_color
         }
 
+        for name, member in self.ExtraWidgets.__members__.items():
+            self._extra_widgets_color_map[name] = self._getUnusedColor()
+
         self.buildMesh()
+
+    def _getUnusedColor(self):
+        while True:
+            r = random.randint(0, 255)
+            g = random.randint(0, 255)
+            b = random.randint(0, 255)
+            a = 255
+            color = Color(r, g, b, a)
+
+            if color not in self._axis_color_map.values() and color not in self._extra_widgets_color_map.values():
+                break
+
+        return color

--- a/UM/View/SelectionPass.py
+++ b/UM/View/SelectionPass.py
@@ -45,7 +45,7 @@ class SelectionPass(RenderPass):
         self._renderer = Application.getInstance().getRenderer()
 
         self._selection_map = {}
-        self._toolhandle_selection_map = {
+        self._default_toolhandle_selection_map = {
             self._dropAlpha(ToolHandle.DisabledSelectionColor): ToolHandle.NoAxis,
             self._dropAlpha(ToolHandle.XAxisSelectionColor): ToolHandle.XAxis,
             self._dropAlpha(ToolHandle.YAxisSelectionColor): ToolHandle.YAxis,
@@ -57,11 +57,25 @@ class SelectionPass(RenderPass):
             ToolHandle.ZAxisSelectionColor: ToolHandle.ZAxis,
             ToolHandle.AllAxisSelectionColor: ToolHandle.AllAxis
         }
+        self._toolhandle_selection_map = {}
+        Application.getInstance().getController().activeToolChanged.connect(self._onActiveToolChanged)
+        self._onActiveToolChanged()
 
         self._mode = SelectionPass.SelectionMode.OBJECTS
         Selection.selectedFaceChanged.connect(self._onSelectedFaceChanged)
 
         self._output = None
+
+    def _onActiveToolChanged(self):
+        self._toolhandle_selection_map = self._default_toolhandle_selection_map.copy()
+
+        active_tool = Application.getInstance().getController().getActiveTool()
+        if not active_tool:
+            return
+
+        tool_handle = active_tool.getHandle()
+        for name, color in tool_handle.getExtraWidgetsColorMap().items():
+            self._toolhandle_selection_map[color] = name
 
     def _onSelectedFaceChanged(self):
         self._mode = SelectionPass.SelectionMode.FACES if Selection.getFaceSelectMode() else SelectionPass.SelectionMode.OBJECTS

--- a/UM/View/SelectionPass.py
+++ b/UM/View/SelectionPass.py
@@ -76,6 +76,7 @@ class SelectionPass(RenderPass):
         tool_handle = active_tool.getHandle()
         for name, color in tool_handle.getExtraWidgetsColorMap().items():
             self._toolhandle_selection_map[color] = name
+            self._toolhandle_selection_map[self._dropAlpha(color)] = name
 
     def _onSelectedFaceChanged(self):
         self._mode = SelectionPass.SelectionMode.FACES if Selection.getFaceSelectMode() else SelectionPass.SelectionMode.OBJECTS

--- a/plugins/Tools/RotateTool/RotateToolHandle.py
+++ b/plugins/Tools/RotateTool/RotateToolHandle.py
@@ -2,6 +2,7 @@
 # Uranium is released under the terms of the LGPLv3 or higher.
 
 import math
+from enum import IntEnum
 
 from UM.Math.Vector import Vector
 from UM.Mesh.MeshBuilder import MeshBuilder
@@ -10,6 +11,14 @@ from UM.Scene.ToolHandle import ToolHandle
 
 class RotateToolHandle(ToolHandle):
     """Provides the circular toolhandles for each axis for the rotate tool"""
+
+    class ExtraWidgets(IntEnum):
+        XPositive90 = 0
+        XNegative90 = 1
+        YPositive90 = 2
+        YNegative90 = 3
+        ZPositive90 = 4
+        ZNegative90 = 5
 
     def __init__(self, parent = None):
         super().__init__(parent)
@@ -21,6 +30,15 @@ class RotateToolHandle(ToolHandle):
         self._active_inner_radius = 37
         self._active_outer_radius = 44
         self._active_line_width = 3
+
+        self._angle_offset = 3
+        self._handle_offset_a = self._inner_radius * math.cos(math.radians(self._angle_offset))
+        self._handle_offset_b = self._inner_radius * math.sin(math.radians(self._angle_offset))
+
+        self._handle_height = 7
+        self._handle_width = 3
+        self._active_handle_height = 9
+        self._active_handle_width = 7
 
     def buildMesh(self):
         #SOLIDMESH
@@ -50,6 +68,64 @@ class RotateToolHandle(ToolHandle):
             angle = math.pi / 2,
             color = self._x_axis_color
         )
+
+        mb.addPyramid(
+            width = self._handle_width,
+            height = self._handle_height,
+            depth = self._handle_width,
+            center = Vector(0, self._handle_offset_a, -self._handle_offset_b),
+            color = self._x_axis_color,
+            axis = Vector.Unit_X,
+            angle = 90 + self._angle_offset
+        )
+        mb.addPyramid(
+            width = self._handle_width,
+            height = self._handle_height,
+            depth = self._handle_width,
+            center = Vector(0, self._handle_offset_a, self._handle_offset_b),
+            color = self._x_axis_color,
+            axis = Vector.Unit_X,
+            angle = -90 - self._angle_offset
+        )
+
+        mb.addPyramid(
+            width = self._handle_width,
+            height = self._handle_height,
+            depth = self._handle_width,
+            center = Vector(self._handle_offset_b, 0, self._handle_offset_a),
+            color = self._y_axis_color,
+            axis = Vector.Unit_Z,
+            angle = 90 - self._angle_offset
+        )
+        mb.addPyramid(
+            width = self._handle_width,
+            height = self._handle_height,
+            depth = self._handle_width,
+            center = Vector(-self._handle_offset_b, 0, self._handle_offset_a),
+            color = self._y_axis_color,
+            axis = Vector.Unit_Z,
+            angle = -90 + self._angle_offset
+        )
+
+        mb.addPyramid(
+            width = self._handle_width,
+            height = self._handle_height,
+            depth = self._handle_width,
+            center = Vector(self._handle_offset_a, self._handle_offset_b, 0),
+            color = self._z_axis_color,
+            axis = Vector.Unit_Z,
+            angle = - self._angle_offset
+        )
+        mb.addPyramid(
+            width = self._handle_width,
+            height = self._handle_height,
+            depth = self._handle_width,
+            center = Vector(self._handle_offset_a, -self._handle_offset_b, 0),
+            color = self._z_axis_color,
+            axis = Vector.Unit_Z,
+            angle = 180 + self._angle_offset
+        )
+
         self.setSolidMesh(mb.build())
 
         #SELECTIONMESH
@@ -78,6 +154,63 @@ class RotateToolHandle(ToolHandle):
             axis = Vector.Unit_Y,
             angle = math.pi / 2,
             color = ToolHandle.XAxisSelectionColor
+        )
+
+        mb.addPyramid(
+            width = self._active_handle_width,
+            height = self._active_handle_height,
+            depth = self._active_handle_width,
+            center = Vector(0, self._handle_offset_a, self._handle_offset_b),
+            color = self._extra_widgets_color_map[self.ExtraWidgets.XPositive90.name],
+            axis = Vector.Unit_X,
+            angle = -90 - self._angle_offset
+        )
+        mb.addPyramid(
+            width = self._active_handle_width,
+            height = self._active_handle_height,
+            depth = self._active_handle_width,
+            center = Vector(0, self._handle_offset_a, -self._handle_offset_b),
+            color = self._extra_widgets_color_map[self.ExtraWidgets.XNegative90.name],
+            axis = Vector.Unit_X,
+            angle = 90 + self._angle_offset
+        )
+
+        mb.addPyramid(
+            width = self._active_handle_width,
+            height = self._active_handle_height,
+            depth = self._active_handle_width,
+            center = Vector(self._handle_offset_b, 0, self._handle_offset_a),
+            color = self._extra_widgets_color_map[self.ExtraWidgets.YPositive90.name],
+            axis = Vector.Unit_Z,
+            angle = 90 - self._angle_offset
+        )
+        mb.addPyramid(
+            width = self._active_handle_width,
+            height = self._active_handle_height,
+            depth = self._active_handle_width,
+            center = Vector(-self._handle_offset_b, 0, self._handle_offset_a),
+            color = self._extra_widgets_color_map[self.ExtraWidgets.YNegative90.name],
+            axis = Vector.Unit_Z,
+            angle = -90 + self._angle_offset
+        )
+
+        mb.addPyramid(
+            width = self._active_handle_width,
+            height = self._active_handle_height,
+            depth = self._active_handle_width,
+            center = Vector(self._handle_offset_a, self._handle_offset_b, 0),
+            color = self._extra_widgets_color_map[self.ExtraWidgets.ZPositive90.name],
+            axis = Vector.Unit_Z,
+            angle = - self._angle_offset
+        )
+        mb.addPyramid(
+            width = self._active_handle_width,
+            height = self._active_handle_height,
+            depth = self._active_handle_width,
+            center = Vector(self._handle_offset_a, -self._handle_offset_b, 0),
+            color = self._extra_widgets_color_map[self.ExtraWidgets.ZNegative90.name],
+            axis = Vector.Unit_Z,
+            angle = 180 + self._angle_offset
         )
 
         self.setSelectionMesh(mb.build())


### PR DESCRIPTION
This PR adds 3 pairs of arrow widgets to the Rotate ToolHandle, to rotate objects by exactly 90 degrees. To do so, it adds a way for ToolHandle instances to register additional widgets/controls. In this PR, the arrow widgets can still be dragged like the axes, but when clicked they rotate the model by +/- 90 degrees around the relevant axis.

![image](https://user-images.githubusercontent.com/143551/82809013-72affb80-9e8b-11ea-9edb-4302816d7394.png)


This feature covers a large chunk of the usecases for a panel with degree value boxes (https://github.com/Ultimaker/Cura/issues/2779) without the added can of worms that would open.