### PR TITLE
Create an UnclickableItem component that consumes clicks

### DIFF
--- a/UM/Qt/qml/UM/UnclickableItem.qml
+++ b/UM/Qt/qml/UM/UnclickableItem.qml
@@ -1,0 +1,16 @@
+// Copyright (c) 2020 Ultimaker B.V.
+// Cura is released under the terms of the LGPLv3 or higher.
+
+import QtQuick 2.7
+
+// Item with a MouseArea to consume unwanted clicks and scroll wheels.
+Item
+{
+    MouseArea
+    {
+       acceptedButtons: Qt.AllButtons
+       onClicked: parent.onClicked ? parent.onClicked() : {}
+       onWheel: parent.onWheel ? parent.onWheel() : {}
+       anchors.fill: parent
+    }
+}

--- a/UM/Qt/qml/UM/qmldir
+++ b/UM/Qt/qml/UM/qmldir
@@ -25,3 +25,5 @@ ProgressBar 1.3 ProgressBar.qml
 SimpleButton 1.1 SimpleButton.qml
 TabRow 1.3 TabRow.qml
 TabRowButton 1.3 TabRowButton.qml
+
+UnclickableItem 1.4 UnclickableItem.qml


### PR DESCRIPTION
The UnclickableItem component has a MouseArea in order
to consume unwanted clicks inside the item. This is primarily
used in order to avoid accidentally zooming or twisting the scene
while hovering over components that reside above the scene, such as
the MainWindowHeader in Cura.

Created during Turbo Testing and Tooling.