### PR TITLE
Fix crash when clicking right mousebutton over toolhandle extra widgets

### DIFF
--- a/UM/Scene/ToolHandle.py
+++ b/UM/Scene/ToolHandle.py
@@ -41,7 +41,9 @@ class ToolHandle(SceneNode.SceneNode):
     AllAxisSelectionColor = Color(1.0, 1.0, 1.0, 1.0)
 
     class ExtraWidgets(IntEnum):
-        # Toolhandle subclasses can optionally register additional widgets by overriding this enum
+        """Toolhandle subclasses can optionally register additional widgets by overriding this enum.
+        The ExtraWidgetsEnum should start with Toolhanlde.AllAxis + 1 in order not to overlap with the native axes.
+        """
         pass
 
     def __init__(self, parent = None):
@@ -177,8 +179,8 @@ class ToolHandle(SceneNode.SceneNode):
             self.AllAxis: self._all_axis_color
         }
 
-        for name, member in self.ExtraWidgets.__members__.items():
-            self._extra_widgets_color_map[name] = self._getUnusedColor()
+        for value in self.ExtraWidgets:
+            self._extra_widgets_color_map[value] = self._getUnusedColor()
 
         self.buildMesh()
 

--- a/plugins/Tools/RotateTool/RotateTool.py
+++ b/plugins/Tools/RotateTool/RotateTool.py
@@ -91,10 +91,10 @@ class RotateTool(Tool):
                 return False
 
             if id in self._handle.getExtraWidgetsColorMap():
-                self._active_widget = self._handle.ExtraWidgets[id]
+                self._active_widget = self._handle.ExtraWidgets(id)
                 self._widget_click_start = time.monotonic()
                 # Continue as if the picked widget is the appropriate axis
-                id = math.floor(self._active_widget.value / 2) + self._handle.XAxis
+                id = math.floor((self._active_widget.value - self._active_widget.XPositive90.value) / 2) + self._handle.XAxis
 
             if self._handle.isAxis(id):
                 self.setLockedAxis(id)
@@ -194,8 +194,9 @@ class RotateTool(Tool):
             if self._active_widget != None and time.monotonic() - self._widget_click_start < 0.2:
                 id = self._selection_pass.getIdAtPosition(event.x, event.y)
 
-                if id in self._handle.getExtraWidgetsColorMap() and self._active_widget == self._handle.ExtraWidgets[id]:
-                    axis = math.floor(self._active_widget.value / 2)
+                if id in self._handle.getExtraWidgetsColorMap() and self._active_widget == self._handle.ExtraWidgets(id):
+                    axis = math.floor((self._active_widget.value - self._active_widget.XPositive90.value) / 2)
+
                     angle = math.radians(-90 if self._active_widget.value - 2 * axis else 90)
                     axis +=  self._handle.XAxis
 

--- a/plugins/Tools/RotateTool/RotateToolHandle.py
+++ b/plugins/Tools/RotateTool/RotateToolHandle.py
@@ -13,12 +13,12 @@ class RotateToolHandle(ToolHandle):
     """Provides the circular toolhandles for each axis for the rotate tool"""
 
     class ExtraWidgets(IntEnum):
-        XPositive90 = 0
-        XNegative90 = 1
-        YPositive90 = 2
-        YNegative90 = 3
-        ZPositive90 = 4
-        ZNegative90 = 5
+        XPositive90 = ToolHandle.AllAxis + 1
+        XNegative90 = ToolHandle.AllAxis + 2
+        YPositive90 = ToolHandle.AllAxis + 3
+        YNegative90 = ToolHandle.AllAxis + 4
+        ZPositive90 = ToolHandle.AllAxis + 5
+        ZNegative90 = ToolHandle.AllAxis + 6
 
     def __init__(self, parent = None):
         super().__init__(parent)
@@ -161,7 +161,7 @@ class RotateToolHandle(ToolHandle):
             height = self._active_handle_height,
             depth = self._active_handle_width,
             center = Vector(0, self._handle_offset_a, self._handle_offset_b),
-            color = self._extra_widgets_color_map[self.ExtraWidgets.XPositive90.name],
+            color = self._extra_widgets_color_map[self.ExtraWidgets.XPositive90.value],
             axis = Vector.Unit_X,
             angle = -90 - self._angle_offset
         )
@@ -170,7 +170,7 @@ class RotateToolHandle(ToolHandle):
             height = self._active_handle_height,
             depth = self._active_handle_width,
             center = Vector(0, self._handle_offset_a, -self._handle_offset_b),
-            color = self._extra_widgets_color_map[self.ExtraWidgets.XNegative90.name],
+            color = self._extra_widgets_color_map[self.ExtraWidgets.XNegative90.value],
             axis = Vector.Unit_X,
             angle = 90 + self._angle_offset
         )
@@ -180,7 +180,7 @@ class RotateToolHandle(ToolHandle):
             height = self._active_handle_height,
             depth = self._active_handle_width,
             center = Vector(self._handle_offset_b, 0, self._handle_offset_a),
-            color = self._extra_widgets_color_map[self.ExtraWidgets.YPositive90.name],
+            color = self._extra_widgets_color_map[self.ExtraWidgets.YPositive90.value],
             axis = Vector.Unit_Z,
             angle = 90 - self._angle_offset
         )
@@ -189,7 +189,7 @@ class RotateToolHandle(ToolHandle):
             height = self._active_handle_height,
             depth = self._active_handle_width,
             center = Vector(-self._handle_offset_b, 0, self._handle_offset_a),
-            color = self._extra_widgets_color_map[self.ExtraWidgets.YNegative90.name],
+            color = self._extra_widgets_color_map[self.ExtraWidgets.YNegative90.value],
             axis = Vector.Unit_Z,
             angle = -90 + self._angle_offset
         )
@@ -199,7 +199,7 @@ class RotateToolHandle(ToolHandle):
             height = self._active_handle_height,
             depth = self._active_handle_width,
             center = Vector(self._handle_offset_a, self._handle_offset_b, 0),
-            color = self._extra_widgets_color_map[self.ExtraWidgets.ZPositive90.name],
+            color = self._extra_widgets_color_map[self.ExtraWidgets.ZPositive90.value],
             axis = Vector.Unit_Z,
             angle = - self._angle_offset
         )
@@ -208,7 +208,7 @@ class RotateToolHandle(ToolHandle):
             height = self._active_handle_height,
             depth = self._active_handle_width,
             center = Vector(self._handle_offset_a, -self._handle_offset_b, 0),
-            color = self._extra_widgets_color_map[self.ExtraWidgets.ZNegative90.name],
+            color = self._extra_widgets_color_map[self.ExtraWidgets.ZNegative90.value],
             axis = Vector.Unit_Z,
             angle = 180 + self._angle_offset
         )


### PR DESCRIPTION
This PR fixes a crash when right-clicking while hovering over toolhandle extra widgets such as the rotate-by-90-degrees arrows of the RotateTool that were added in https://github.com/Ultimaker/Uranium/pull/612. The original implementation used strings (enum name) as identifiers for the extra widgets. Instead, ExtraWidgets now identify as ints (enum value).

Fixes https://github.com/Ultimaker/Cura/issues/7867