### PR TITLE
Handle indexing on Python 3.8 AST string constants correctly

### DIFF
--- a/UM/Settings/SettingFunction.py
+++ b/UM/Settings/SettingFunction.py
@@ -245,7 +245,7 @@ class _SettingExpressionVisitor(ast.NodeVisitor):
     def visit_Subscript(self, node: ast.Index):
         if type(node.value) == ast.Str:
             raise IllegalMethodError("Indexing on strings is not allowed")
-        if type(node.value) == ast.Constant and isinstance(node.value.value, str):
+        if hasattr(ast, "Constant") and type(node.value) == ast.Constant and isinstance(node.value.value, str):
             raise IllegalMethodError("Indexing on strings is not allowed")
         for child_node in ast.iter_child_nodes(node):
             self.visit(child_node)

--- a/UM/Settings/SettingFunction.py
+++ b/UM/Settings/SettingFunction.py
@@ -245,6 +245,8 @@ class _SettingExpressionVisitor(ast.NodeVisitor):
     def visit_Subscript(self, node: ast.Index):
         if type(node.value) == ast.Str:
             raise IllegalMethodError("Indexing on strings is not allowed")
+        if type(node.value) == ast.Constant and isinstance(node.value.value, str):
+            raise IllegalMethodError("Indexing on strings is not allowed")
         for child_node in ast.iter_child_nodes(node):
             self.visit(child_node)
 


### PR DESCRIPTION
String constants are represented as ast.Constant objects starting with
Python 3.8.

Fixes #619.