### PR TITLE
Cura 6253 fix remove container that requires to load a container first

### DIFF
--- a/UM/Settings/ContainerRegistry.py
+++ b/UM/Settings/ContainerRegistry.py
@@ -16,6 +16,7 @@ from UM.Logger import Logger
 from UM.MimeTypeDatabase import MimeType, MimeTypeDatabase
 from UM.PluginRegistry import PluginRegistry #To register the container type plug-ins and container provider plug-ins.
 from UM.Resources import Resources
+from UM.Settings.EmptyInstanceContainer import EmptyInstanceContainer
 from UM.Settings.ContainerFormatError import ContainerFormatError
 from UM.Settings.ContainerProvider import ContainerProvider
 from UM.Settings.constant_instance_containers import empty_container
@@ -441,12 +442,10 @@ class ContainerRegistry(ContainerRegistryInterface):
         if container_id in self.metadata:
             if container is None:
                 # We're in a bit of a weird state now. We want to notify the rest of the code that the container
-                # has been deleted, but due to lazy loading, it hasnt even been loaded yet. The issues is that in order
-                # to notify the rest of the code, we need to actually *have* the container. So we need to load it
-                # in order to remove it...
-                provider = self.source_provider.get(container_id)
-                if provider:
-                    container = provider.loadContainer(container_id)
+                # has been deleted, but due to lazy loading, it hasn't been loaded yet. The issues is that in order
+                # to notify the rest of the code, we need to actually *have* the container. So an empty instance 
+                # container is created, which is emitted with the containerRemoved signal and contains the metadata
+                container = EmptyInstanceContainer(container_id)
             del self.metadata[container_id]
         if container_id in self.source_provider:
             if self.source_provider[container_id] is not None:

--- a/UM/Settings/ContainerRegistry.py
+++ b/UM/Settings/ContainerRegistry.py
@@ -446,6 +446,7 @@ class ContainerRegistry(ContainerRegistryInterface):
                 # to notify the rest of the code, we need to actually *have* the container. So an empty instance 
                 # container is created, which is emitted with the containerRemoved signal and contains the metadata
                 container = EmptyInstanceContainer(container_id)
+                container.metaData = self.metadata[container_id]
             del self.metadata[container_id]
         if container_id in self.source_provider:
             if self.source_provider[container_id] is not None:

--- a/tests/Settings/TestContainerRegistry.py
+++ b/tests/Settings/TestContainerRegistry.py
@@ -112,6 +112,22 @@ def test_removeContainer(container_registry):
     assert not container_registry.isLoaded("omgzomg")
 
 
+def test_removeNotLoadedContainer(container_registry):
+    # Removing a partial (only metadata) loaded container should not break
+    test_container = InstanceContainer("omgzomg")
+    container_registry.addContainer(test_container)
+    container_registry._containers["omgzomg"] = None  # Emulates as partial loaded container
+    assert container_registry.isLoaded("omgzomg")
+
+    def _onContainerRemoved(container: "ContainerInterface") -> None:
+        assert isinstance(container, InstanceContainer)
+        assert container.getName() == "omgzomg"
+
+    container_registry.containerRemoved.connect(_onContainerRemoved)
+    container_registry.removeContainer("omgzomg")
+    assert not container_registry.isLoaded("omgzomg")
+    
+    
 def test_renameContainer(container_registry):
     # Ensure that renaming an unknown container doesn't break
     container_registry.renameContainer("ContainerThatDoesntExist", "whatever")


### PR DESCRIPTION
If a container is partial (only metadata) loaded it shouldn't have to
load the container before removal. The emitted RemovedContainer signal
expects a container to be passed along with it. This will be an
EmptyInstanceContainer containing the metadata of the container.