### PR TITLE
CURA-7735: Make symlink following optional when checking the plugin signatures

### DIFF
--- a/UM/PluginRegistry.py
+++ b/UM/PluginRegistry.py
@@ -80,16 +80,18 @@ class PluginRegistry(QObject):
         self._supported_file_types = {"umplugin": "Uranium Plugin"} # type: Dict[str, str]
 
         self._check_if_trusted = False  # type: bool
+        self._debug_mode = False  # type: bool
         self._checked_plugin_ids = []     # type: List[str]
         self._distrusted_plugin_ids = []  # type: List[str]
         self._trust_checker = None  # type: Optional[Trust]
 
-    def setCheckIfTrusted(self, check_if_trusted: bool) -> None:
+    def setCheckIfTrusted(self, check_if_trusted: bool, debug_mode: bool = False) -> None:
         self._check_if_trusted = check_if_trusted
         if self._check_if_trusted:
             self._trust_checker = Trust.getInstance()
             # 'Trust.getInstance()' will raise an exception if anything goes wrong (e.g.: 'unable to read public key').
             # Any such exception is explicitly _not_ caught here, as the application should quit with a crash.
+            self._trust_checker.setFollowSymlinks(debug_mode)
 
     def getCheckIfTrusted(self) -> bool:
         return self._check_if_trusted

--- a/UM/PluginRegistry.py
+++ b/UM/PluginRegistry.py
@@ -91,7 +91,8 @@ class PluginRegistry(QObject):
             self._trust_checker = Trust.getInstance()
             # 'Trust.getInstance()' will raise an exception if anything goes wrong (e.g.: 'unable to read public key').
             # Any such exception is explicitly _not_ caught here, as the application should quit with a crash.
-            self._trust_checker.setFollowSymlinks(debug_mode)
+            if self._trust_checker:
+                self._trust_checker.setFollowSymlinks(debug_mode)
 
     def getCheckIfTrusted(self) -> bool:
         return self._check_if_trusted

--- a/UM/Trust.py
+++ b/UM/Trust.py
@@ -346,6 +346,10 @@ class Trust:
                         if not self._verifyFile(name_on_disk, signature):
                             self._violation_handler("File '{0}' didn't match with checksum.".format(name_on_disk))
                             return False
+                    for dirname in dirnames:
+                        dir_full_path = os.path.join(path, dirname)
+                        if os.path.islink(dir_full_path) and not self._follow_symlinks:
+                            Logger.log("w", "Directory '{0}' is a symbolic link and will not be followed.".format(dir_full_path))
 
                 # The number of correctly signed files should be the same as the number of signatures:
                 if len(signatures_json.keys()) != file_count:

--- a/UM/Trust.py
+++ b/UM/Trust.py
@@ -272,6 +272,8 @@ class Trust:
         """
 
         self._public_key = None  # type: Optional[RSAPublicKey]
+        self._follow_symlinks = False  # type: bool
+
         try:
             with open(public_key_filename, "rb") as file:
                 self._public_key = load_pem_public_key(file.read(), backend = default_backend())
@@ -327,7 +329,7 @@ class Trust:
 
                 # Loop over all files within the folder (excluding the signature file):
                 file_count = 0
-                for root, dirnames, filenames in os.walk(path, followlinks = True):
+                for root, dirnames, filenames in os.walk(path, followlinks = self._follow_symlinks):
                     for filename in filenames:
                         if filename == TrustBasics.getSignaturesLocalFilename() and root == path:
                             continue
@@ -394,6 +396,9 @@ class Trust:
         """
 
         return os.path.exists(TrustBasics.getSignaturePathForFile(filename))
+
+    def setFollowSymlinks(self, follow_symlinks: bool) -> None:
+        self._follow_symlinks = follow_symlinks
 
 
 class TrustException(Exception):


### PR DESCRIPTION
Unless explicitly requested (e.g. in DEBUG mode), Trust should not follow symlinks when checking the plugin signatures.
The enterprise plugins should not contain any symlinks anyway.

Merge along with https://github.com/Ultimaker/Cura/pull/8499.

CURA-7735