### PR TITLE
Add option to load certain plug-ins before the rest

### DIFF
--- a/UM/PluginRegistry.py
+++ b/UM/PluginRegistry.py
@@ -52,6 +52,8 @@ class PluginRegistry(QObject):
         PluginRegistry.__instance = self
 
         super().__init__(parent)
+        self.preloaded_plugins = []  # List of plug-in names that must be loaded before the rest, if the plug-ins are available. They are loaded in this order too.
+
         self._application = application  # type: Application
         self._api_version = application.getAPIVersion()  # type: Version
 
@@ -404,9 +406,17 @@ class PluginRegistry(QObject):
         """
 
         start_time = time.time()
+
+        # First load all of the pre-loaded plug-ins.
+        for preloaded_plugin in self.preloaded_plugins:
+            self.loadPlugin(preloaded_plugin)
+
         # Get a list of all installed plugins:
         plugin_ids = self._findInstalledPlugins()
         for plugin_id in plugin_ids:
+            if plugin_id in self.preloaded_plugins:
+                continue  # Already loaded this before.
+
             # Get the plugin metadata:
             try:
                 plugin_metadata = self.getMetaData(plugin_id)

--- a/UM/PluginRegistry.py
+++ b/UM/PluginRegistry.py
@@ -52,7 +52,7 @@ class PluginRegistry(QObject):
         PluginRegistry.__instance = self
 
         super().__init__(parent)
-        self.preloaded_plugins = []  # List of plug-in names that must be loaded before the rest, if the plug-ins are available. They are loaded in this order too.
+        self.preloaded_plugins = []  # type: List[str]  # List of plug-in names that must be loaded before the rest, if the plug-ins are available. They are loaded in this order too.
 
         self._application = application  # type: Application
         self._api_version = application.getAPIVersion()  # type: Version


### PR DESCRIPTION
In particular an application might want to load the logging plug-ins first. Currently Cura manually calls the loadPlugin function for ConsoleLogger, and then ConsoleLogger is also loaded again later which is causing warnings. This prevents that because Uranium knows which plug-ins are pre-loaded and will not attempt to load those again.

This is a partial solution. A complete solution would be to allow plug-ins to depend on other plug-ins. All plug-ins that log things would then need to depend on the logger plug-ins. That system is more complex though so I'll not implement that until it's deemed necessary.

Contributes to issue CURA-7501.