### PR TITLE
Fix "TypeError: type str doesn't define __round__ method"

### DIFF
--- a/UM/Settings/SettingDefinition.py
+++ b/UM/Settings/SettingDefinition.py
@@ -748,7 +748,7 @@ class SettingDefinition:
         # An enumeration
         "enum": {"from": None, "to": None, "validator": None},
         # A floating point value
-        "float": {"from": lambda v: str(round(v, 4)) if v is not None else "", "to": _toFloatConversion, "validator": Validator},
+        "float": {"from": lambda v: str(round(float(v), 4)) if v is not None else "", "to": _toFloatConversion, "validator": Validator},
         # A list of 2D points
         "polygon": {"from": str, "to": ast.literal_eval, "validator": None},
         # A list of polygons

--- a/UM/Settings/SettingDefinition.py
+++ b/UM/Settings/SettingDefinition.py
@@ -613,7 +613,11 @@ class SettingDefinition:
 
         convert_function = cls.__type_definitions[type_name]["from"]
         if convert_function:
-            return convert_function(value)
+            try:
+                return convert_function(value)
+            except Exception as err:
+                Logger.log("e", "UM.Settings: Error converting from %s with value %s: %s", type_name, str(value), err)
+                raise
 
         return value
 

--- a/tests/Settings/TestSettingPropertyProvider.py
+++ b/tests/Settings/TestSettingPropertyProvider.py
@@ -73,7 +73,7 @@ def test_valueChanges(container_registry):
     setting_property_provider._update()
     assert setting_property_provider.watchedProperties == ["enabled", "value", "validationState"]
     assert setting_property_provider.properties.value("enabled") == "False"
-    assert setting_property_provider.properties.value("value") == "20"
+    assert setting_property_provider.properties.value("value") == "20.0"
 
     # Validator state is a special property that gets added based on the type and the value
     assert setting_property_provider.properties.value("validationState") == str(ValidatorState.Valid)


### PR DESCRIPTION
When handling a float setting with a calculation, I have been getting the following error in Cura.log:
```
20:33:42,995 - CRITICAL - [MainThread] cura.CrashHandler.__init__ [66]: An uncaught error has occurred!
20:33:42,999 - CRITICAL - [MainThread] cura.CrashHandler.__init__ [69]: Traceback (most recent call last):
20:33:43,004 - CRITICAL - [MainThread] cura.CrashHandler.__init__ [69]:   File "X:\4.8-exe\build\inst\lib\python3.5\site-packages\UM\Settings\Models\SettingPropertyProvider.py", line 373, in _update
20:33:43,007 - CRITICAL - [MainThread] cura.CrashHandler.__init__ [69]:   File "X:\4.8-exe\build\inst\lib\python3.5\site-packages\UM\Settings\Models\SettingPropertyProvider.py", line 430, in _getPropertyValue
20:33:43,011 - CRITICAL - [MainThread] cura.CrashHandler.__init__ [69]:   File "X:\4.8-exe\build\inst\lib\python3.5\site-packages\UM\Settings\SettingDefinition.py", line 616, in settingValueToString
20:33:43,014 - CRITICAL - [MainThread] cura.CrashHandler.__init__ [69]:   File "X:\4.8-exe\build\inst\lib\python3.5\site-packages\UM\Settings\SettingDefinition.py", line 751, in <lambda>
```

This proposed change should fix this error.