### PR TITLE
[CURA-7872] Always drop down in lay-flat operations.

### DIFF
--- a/UM/Operations/GravityOperation.py
+++ b/UM/Operations/GravityOperation.py
@@ -1,0 +1,63 @@
+# Copyright (c) 2020 Ultimaker B.V.
+# Uranium is released under the terms of the LGPLv3 or higher.
+
+from UM.Scene.SceneNode import SceneNode
+
+from . import Operation
+from UM.Math.Vector import Vector
+
+
+class GravityOperation(Operation.Operation):
+    """An operation that moves a scene node down to 0 on the y-axis.
+    """
+
+    def __init__(self, node):
+        """Initialises this GravityOperation.
+
+        :param node: The node to translate.
+        """
+
+        super().__init__()
+        self._node = node
+        self._old_transformation = node.getLocalTransformation() # To restore the transformation to in case of an undo.
+
+    def undo(self):
+        """Undoes the gravity operation, restoring the old transformation."""
+
+        self._node.setTransformation(self._old_transformation)
+
+    def redo(self):
+        """(Re-)Applies the gravity operation."""
+
+        # Drop to bottom of usable space (if not already there):
+        height_move = -self._node.getBoundingBox().bottom
+        if self._node.hasDecoration("getZOffset"):
+            height_move += self._node.callDecoration("getZOffset")
+        if abs(height_move) > 1e-5:
+            self._node.translate(Vector(0.0, height_move, 0.0), SceneNode.TransformSpace.World)
+
+    def mergeWith(self, other):
+        """Merges this operation with another gravity operation.
+
+        This prevents the user from having to undo multiple operations if they
+        were not his operations.
+
+        You should ONLY merge this operation with an older operation. It is NOT
+        symmetric.
+
+        :param other: The older gravity operation to merge this operation with.
+        """
+
+        if type(other) is not GravityOperation:
+            return False
+        if other._node != self._node: # Must be moving the same node.
+            return False
+        return other
+
+    def __repr__(self):
+        """Returns a programmer-readable representation of this operation.
+
+        :return: A programmer-readable representation of this operation.
+        """
+
+        return "GravityOp.(node={0})".format(self._node)

--- a/UM/Operations/LayFlatOperation.py
+++ b/UM/Operations/LayFlatOperation.py
@@ -1,8 +1,9 @@
-# Copyright (c) 2015 Ultimaker B.V.
+# Copyright (c) 2020 Ultimaker B.V.
 # Uranium is released under the terms of the LGPLv3 or higher.
 
 from . import Operation
 
+from UM.Operations.GravityOperation import GravityOperation
 from UM.Scene.SceneNode import SceneNode
 from UM.Math.Vector import Vector
 from UM.Math.Quaternion import Quaternion
@@ -142,7 +143,7 @@ class LayFlatOperation(Operation.Operation):
 
         if self._new_orientation: #Only if the orientation was finished calculating.
             self._node.setOrientation(self._new_orientation)
-            pass
+            GravityOperation(self._node).redo()
 
     def mergeWith(self, other):
         """Merge this lay flat operation with another lay flat operation.

--- a/plugins/Tools/RotateTool/RotateTool.py
+++ b/plugins/Tools/RotateTool/RotateTool.py
@@ -11,6 +11,7 @@ from UM.Math.Plane import Plane
 from UM.Math.Quaternion import Quaternion
 from UM.Math.Vector import Vector
 from UM.Message import Message
+from UM.Operations.GravityOperation import GravityOperation
 from UM.Operations.GroupedOperation import GroupedOperation
 from UM.Operations.LayFlatOperation import LayFlatOperation
 from UM.Operations.RotateOperation import RotateOperation
@@ -266,10 +267,12 @@ class RotateTool(Tool):
             return
 
         rotate_operation = RotateOperation(current_node, rotation_quaternion, rotation_point_vector)
+        gravity_operation = GravityOperation(current_node)
         operation.addOperation(rotate_operation)
+        operation.addOperation(gravity_operation)
         operation.push()
 
-        # NOTE: We might want to consider unchecking the select-face button afterthe operation is done.
+        # NOTE: We might want to consider unchecking the select-face button after the operation is done.
 
     def getToolHint(self):
         """Return a formatted angle of the current rotate operation


### PR DESCRIPTION
Drop down to buildplate after lay flat or align face to build-plate, even if always drop down is disabled.

Partially fixes Ultimaker/Cura#8746 as well.
