### PR TITLE
Fix Cura error with URANIUM_TRACE_SETTINGINSTANCE

### DIFF
--- a/UM/Settings/SettingInstance.py
+++ b/UM/Settings/SettingInstance.py
@@ -19,8 +19,8 @@ from . import SettingFunction
 from .SettingDefinition import SettingDefinition
 
 # Helper functions for SettingInstance tracing
-def _traceSetProperty(instance: "SettingInstance", property_name: str, property_value: Any, container: ContainerInterface) -> None:
-    Logger.log("d", "Set property '{0}' of '{1}' to '{2}', updating using values from {3}".format(property_name, instance, property_value, container))
+def _traceSetProperty(instance: "SettingInstance", property_name: str, property_value: Any, container: ContainerInterface, emit_signals: bool) -> None:
+    Logger.log("d", "Set property '{0}' of '{1}' to '{2}', updating using values from {3}, emit signals {4}".format(property_name, instance, property_value, container, emit_signals))
 
 def _traceUpdateProperty(instance: "SettingInstance", property_name: str, container: ContainerInterface) -> None:
     Logger.log("d", "Updating property '{0}' of '{1}' using container {2}".format(property_name, instance, container))


### PR DESCRIPTION
When you set environment variable URANIUM_TRACE_SETTINGINSTANCE and run Cura you get fatal error:
```
2020-11-25 09:44:09,862 - CRITICAL - [MainThread] cura.CrashHandler.__init__ [66]: An uncaught error has occurred!
2020-11-25 09:44:09,867 - CRITICAL - [MainThread] cura.CrashHandler.__init__ [69]: Traceback (most recent call last):
2020-11-25 09:44:09,871 - CRITICAL - [MainThread] cura.CrashHandler.__init__ [69]:   File "X:\4.8-exe\build\inst\lib\python3.5\site-packages\cura\CuraApplication.py", line 1063, in event
2020-11-25 09:44:09,875 - CRITICAL - [MainThread] cura.CrashHandler.__init__ [69]:   File "X:\4.8-exe\build\inst\lib\python3.5\site-packages\UM\Qt\QtApplication.py", line 464, in event
2020-11-25 09:44:09,880 - CRITICAL - [MainThread] cura.CrashHandler.__init__ [69]:   File "X:\4.8-exe\build\inst\lib\python3.5\site-packages\UM\Event.py", line 218, in call
2020-11-25 09:44:09,884 - CRITICAL - [MainThread] cura.CrashHandler.__init__ [69]:   File "X:\4.8-exe\build\inst\lib\python3.5\site-packages\cura\Settings\MachineManager.py", line 179, in setInitialActiveMachine
2020-11-25 09:44:09,887 - CRITICAL - [MainThread] cura.CrashHandler.__init__ [69]:   File "X:\4.8-exe\build\inst\lib\python3.5\site-packages\cura\Settings\MachineManager.py", line 333, in setActiveMachine
2020-11-25 09:44:09,891 - CRITICAL - [MainThread] cura.CrashHandler.__init__ [69]:   File "X:\4.8-exe\build\inst\lib\python3.5\site-packages\cura\Settings\ExtruderManager.py", line 373, in fixSingleExtrusionMachineExtruderDefinition
2020-11-25 09:44:09,894 - CRITICAL - [MainThread] cura.CrashHandler.__init__ [69]:   File "X:\4.8-exe\build\inst\lib\python3.5\site-packages\cura\Settings\GlobalStack.py", line 78, in extruderList
2020-11-25 09:44:09,897 - CRITICAL - [MainThread] cura.CrashHandler.__init__ [69]:   File "X:\4.8-exe\build\inst\lib\python3.5\site-packages\cura\Settings\GlobalStack.py", line 246, in getProperty
2020-11-25 09:44:09,900 - CRITICAL - [MainThread] cura.CrashHandler.__init__ [69]:   File "X:\4.8-exe\build\inst\lib\python3.5\site-packages\cura\Settings\CuraContainerStack.py", line 402, in getProperty
2020-11-25 09:44:09,903 - CRITICAL - [MainThread] cura.CrashHandler.__init__ [69]:   File "X:\4.8-exe\build\inst\lib\python3.5\site-packages\UM\Settings\ContainerStack.py", line 232, in getProperty
2020-11-25 09:44:09,906 - CRITICAL - [MainThread] cura.CrashHandler.__init__ [69]:   File "X:\4.8-exe\build\inst\lib\python3.5\site-packages\UM\Settings\ContainerStack.py", line 281, in getRawProperty
2020-11-25 09:44:09,909 - CRITICAL - [MainThread] cura.CrashHandler.__init__ [69]:   File "X:\4.8-exe\build\inst\lib\python3.5\site-packages\UM\Settings\InstanceContainer.py", line 290, in getProperty
2020-11-25 09:44:09,913 - CRITICAL - [MainThread] cura.CrashHandler.__init__ [69]:   File "X:\4.8-exe\build\inst\lib\python3.5\site-packages\UM\Settings\InstanceContainer.py", line 639, in _instantiateCachedValues
2020-11-25 09:44:09,916 - CRITICAL - [MainThread] cura.CrashHandler.__init__ [69]:   File "X:\4.8-exe\build\inst\lib\python3.5\site-packages\UM\Settings\InstanceContainer.py", line 384, in setProperty
2020-11-25 09:44:09,921 - CRITICAL - [MainThread] cura.CrashHandler.__init__ [69]:   File "X:\4.8-exe\build\inst\lib\python3.5\site-packages\UM\Decorators.py", line 58, in call_function
2020-11-25 09:44:09,924 - CRITICAL - [MainThread] cura.CrashHandler.__init__ [69]: TypeError: _traceSetProperty() got an unexpected keyword argument 'emit_signals'
```