### PR TITLE
Fix showing expanded/collapsed indicator arrow for setting categories

### DIFF
--- a/UM/Settings/Models/SettingDefinitionsModel.py
+++ b/UM/Settings/Models/SettingDefinitionsModel.py
@@ -77,6 +77,8 @@ class SettingDefinitionsModel(QAbstractListModel):
 
         self.destroyed.connect(self._onDestroyed)
 
+        self.expandedChanged.connect(self._onExpandedChanged)
+
     showAncestorsChanged = pyqtSignal()
     """Emitted whenever the showAncestors property changes."""
 
@@ -580,6 +582,11 @@ class SettingDefinitionsModel(QAbstractListModel):
         """Reimplemented from QAbstractListModel"""
 
         return self._role_names
+
+    def _onExpandedChanged(self) -> None:
+        # required to show settings/categories are expanded or collapsed
+        for row in range(len(self._row_index_list)):
+            self.dataChanged.emit(self.index(row, 0), self.index(row, 0), [self.ExpandedRole])
 
     def _onVisibilityChanged(self) -> None:
         if self._visibility_handler:


### PR DESCRIPTION
This PR fixes the expanded/collapsed indicator arrow for setting categories in setting views. It was broken in 905e8eb5b44fa6d16310aad80bec7ced32455b02. Reverting that change may have a performance hit, so some profiling may be in order.

Fixes https://github.com/Ultimaker/Cura/issues/8283, CURA-7692