### PR TITLE
Replace non-existant property visible with isVisible.

### DIFF
--- a/UM/Qt/QtApplication.py
+++ b/UM/Qt/QtApplication.py
@@ -446,7 +446,7 @@ class QtApplication(QApplication, Application):
     @property
     def isVisible(self) -> bool:
         if self._main_window is not None:
-            return self._main_window.visible #type: ignore #MyPy doesn't realise that self._main_window cannot be None here.
+            return self._main_window.isVisible()  #type: ignore #MyPy doesn't realise that self._main_window cannot be None here.
         return False
 
     def getTheme(self) -> Optional[Theme]:


### PR DESCRIPTION
Turns out isVisible (the QtApplication function) was never called, so _main_window.visible was never called, so no-one realized that this latter one didn't exist. But _main_window _also_ has a isVisible (function not property) so now that is called by the QtApplication isVisible (property) instead.