### PR TITLE
[CURA-7996] Possible to distinguish between empty and corrupt files.

### DIFF
--- a/UM/FileHandler/FileReader.py
+++ b/UM/FileHandler/FileReader.py
@@ -52,3 +52,13 @@ class FileReader(PluginObject):
         """
 
         raise NotImplementedError("Reader plugin was not correctly implemented, no read was specified")
+
+    def emptyFileHintSet(self):
+        """ Some files can be perfectly valid, but empty. It's useful to separate these cases separately (in UX).
+        The default result of this is false, meaning that an empty file of a plugin that doesn't override this
+        will result in the user getting shown a less specific error.
+
+        :return: Might be true if the file is empty but otherwise valid, but can default to false in any case.
+        """
+
+        return False

--- a/UM/FileHandler/ReadFileJob.py
+++ b/UM/FileHandler/ReadFileJob.py
@@ -73,8 +73,10 @@ class ReadFileJob(Job):
         finally:
             end_time = time.time()
             Logger.log("d", "Loading file took %0.1f seconds", end_time - begin_time)
-            if not self._result:
-                self._loading_message.hide()
+            self._loading_message.hide()
+            if reader.emptyFileHintSet():
+                result_message = Message(i18n_catalog.i18nc("@info:status Don't translate the XML tag <filename>!", "There where no models in <filename>{0}</filename>.", self._filename), lifetime=0, title=i18n_catalog.i18nc("@info:title", "No Models in File"))
+                result_message.show()
+            elif not self._result:
                 result_message = Message(i18n_catalog.i18nc("@info:status Don't translate the XML tag <filename>!", "Failed to load <filename>{0}</filename>. The file could be corrupt, inaccessible or it did not contain any models.", self._filename), lifetime = 0, title = i18n_catalog.i18nc("@info:title", "Unable to Open File"))
                 result_message.show()
-            self._loading_message.hide()


### PR DESCRIPTION
Otherwise the user could infer valid, but empty file (workspace project for example) is corrupt.

