### PR TITLE
Allow the scene to store metadata

### DIFF
--- a/UM/Qt/QtApplication.py
+++ b/UM/Qt/QtApplication.py
@@ -599,6 +599,7 @@ class QtApplication(QApplication, Application):
         self._workspace_metadata_storage.clear()
         self.deleteAll()
         self.workspaceLoaded.emit("")
+        self.getController().getScene().clearMetaData()
 
     def getMeshFileHandler(self) -> MeshFileHandler:
         """Get the MeshFileHandler of this application."""

--- a/UM/Scene/Scene.py
+++ b/UM/Scene/Scene.py
@@ -4,7 +4,7 @@
 import functools  # For partial to update files that were changed.
 import os.path  # To watch files for changes.
 import threading
-from typing import Callable, List, Optional, Set
+from typing import Callable, List, Optional, Set, Any
 
 from PyQt5.QtCore import QFileSystemWatcher  # To watch files for changes.
 
@@ -48,6 +48,17 @@ class Scene:
 
         self._reload_message = None  # type: Optional[Message]
         self._callbacks = set() # type: Set[Callable] # Need to keep these in memory. This is a memory leak every time you refresh, but a tiny one.
+
+        self._metadata = {}
+
+    def setMetaDataEntry(self, key: str, entry: Any) -> None:
+        self._metadata[key] = entry
+
+    def clearMetaData(self):
+        self._metadata = {}
+
+    def getMetaData(self):
+        return self._metadata.copy()
 
     def _connectSignalsRoot(self) -> None:
         self._root.transformationChanged.connect(self.sceneChanged)

--- a/UM/Scene/Scene.py
+++ b/UM/Scene/Scene.py
@@ -4,7 +4,7 @@
 import functools  # For partial to update files that were changed.
 import os.path  # To watch files for changes.
 import threading
-from typing import Callable, List, Optional, Set, Any
+from typing import Callable, List, Optional, Set, Any, Dict
 
 from PyQt5.QtCore import QFileSystemWatcher  # To watch files for changes.
 
@@ -49,7 +49,7 @@ class Scene:
         self._reload_message = None  # type: Optional[Message]
         self._callbacks = set() # type: Set[Callable] # Need to keep these in memory. This is a memory leak every time you refresh, but a tiny one.
 
-        self._metadata = {}
+        self._metadata = {}  # type: Dict[str, Any]
 
     def setMetaDataEntry(self, key: str, entry: Any) -> None:
         self._metadata[key] = entry

--- a/UM/Scene/SceneNode.py
+++ b/UM/Scene/SceneNode.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2019 Ultimaker B.V.
+# Copyright (c) 2021 Ultimaker B.V.
 # Uranium is released under the terms of the LGPLv3 or higher.
 
 from copy import deepcopy
@@ -47,6 +47,7 @@ class SceneNode:
 
         self._children = []     # type: List[SceneNode]
         self._mesh_data = None  # type: Optional[MeshData]
+        self.metadata = {}     # type: Dict[str, Any]
 
         # Local transformation (from parent to local)
         self._transformation = Matrix()  # type: Matrix


### PR DESCRIPTION
We need the scene to store metadata in order to retain metadata from scenes in 3MF documents.

Contributes to issue CURA-7615.