### PR TITLE
CURA-7996: Fix trying to open deleted files from the recent files list

### DIFF
--- a/UM/FileHandler/FileHandler.py
+++ b/UM/FileHandler/FileHandler.py
@@ -84,9 +84,9 @@ class FileHandler(QObject):
             return
         if add_to_recent_files_hint:
             self._add_to_recent_files_hints.append(file)
-        self._readLocalFile(file)
+        self._readLocalFile(file, add_to_recent_files_hint)
 
-    def _readLocalFile(self, file: QUrl) -> None:
+    def _readLocalFile(self, file: QUrl, add_to_recent_files_hint: bool = True) -> None:
         raise NotImplementedError("_readLocalFile needs to be implemented by subclasses")
 
     def getSupportedFileTypesWrite(self) -> List[Dict[str, Union[str, int]]]:

--- a/UM/FileHandler/FileHandler.py
+++ b/UM/FileHandler/FileHandler.py
@@ -73,10 +73,6 @@ class FileHandler(QObject):
 
         return file_types
 
-    @pyqtSlot(QUrl, result = bool)
-    def getAddToRecentFilesHint(self, file: QUrl) -> bool:
-        return file in self._add_to_recent_files_hints
-
     @pyqtSlot(QUrl, bool)
     @pyqtSlot(QUrl)
     def readLocalFile(self, file: QUrl, add_to_recent_files_hint: bool = True) -> None:

--- a/UM/Mesh/MeshFileHandler.py
+++ b/UM/Mesh/MeshFileHandler.py
@@ -2,7 +2,7 @@
 # Uranium is released under the terms of the LGPLv3 or higher.
 
 import os
-from PyQt5.QtCore import QObject #For typing.
+from PyQt5.QtCore import QObject, QUrl  # For typing.
 
 from UM.Logger import Logger
 from UM.Math.Matrix import Matrix
@@ -62,11 +62,11 @@ class MeshFileHandler(FileHandler):
         Logger.log("w", "Unable to read file %s", file_name)
         return None  # unable to read
 
-    def _readLocalFile(self, file):
+    def _readLocalFile(self, file: QUrl, add_to_recent_files_hint: bool = True):
         # We need to prevent circular dependency, so do some just in time importing.
         from UM.Mesh.ReadMeshJob import ReadMeshJob
         filename = file.toLocalFile()
-        job = ReadMeshJob(filename, add_to_recent_files = self.getAddToRecentFilesHint(filename))
+        job = ReadMeshJob(filename, add_to_recent_files = add_to_recent_files_hint)
         job.finished.connect(self._readMeshFinished)
         job.start()
 

--- a/UM/Workspace/WorkspaceFileHandler.py
+++ b/UM/Workspace/WorkspaceFileHandler.py
@@ -32,10 +32,10 @@ class WorkspaceFileHandler(FileHandler):
 
         return results
 
-    def _readLocalFile(self, file: QUrl) -> None:
+    def _readLocalFile(self, file: QUrl, add_to_recent_files_hint: bool = True) -> None:
         from UM.FileHandler.ReadFileJob import ReadFileJob
         filename = file.toLocalFile()
-        job = ReadFileJob(filename, handler = self, add_to_recent_files = self.getAddToRecentFilesHint(file))
+        job = ReadFileJob(filename, handler = self, add_to_recent_files = add_to_recent_files_hint)
         job.finished.connect(self._readWorkspaceFinished)
         job.start()
 


### PR DESCRIPTION
The add_to_recent_files boolean will now be passed around as a variable to the FileHandlers. This makes it clearer whether the file should actually be added to the Recent Files list when it is being opened.

CURA-7996