### PR TITLE
CURA-8050: Remove project output devices from the list when they get disabled

### DIFF
--- a/UM/OutputDevice/OutputDeviceManager.py
+++ b/UM/OutputDevice/OutputDeviceManager.py
@@ -247,12 +247,10 @@ class OutputDeviceManager:
             self.resetActiveDevice()
         return True
 
-    def addProjectOutputDevice(self, device: "ProjectOutputDevice", add_to_output_devices: bool = False) -> None:
+    def addProjectOutputDevice(self, device: "ProjectOutputDevice") -> None:
         """Add and register a project output device.
 
         :param device: The output device to add.
-        :param add_to_output_devices: Boolean to determine whether the device should also be added to the _output_devices
-                                      list. If that happens, the device will appear as an option also in the OutputDevicesActionButton
 
         :note Does nothing if a device with the same ID as the passed device was already added.
         """
@@ -264,7 +262,7 @@ class OutputDeviceManager:
         self._project_output_devices[device.getId()] = device
         device.enabledChanged.connect(self.projectOutputDevicesChanged.emit)
 
-        if add_to_output_devices:
+        if device.add_to_output_devices and device.enabled:
             self.addOutputDevice(device)
         else:
             # Call the connectWriteSignalsToDevice(..) only if addOutputDevice(..) function hasn't been called already

--- a/plugins/LocalFileOutputDevice/LocalFileOutputDevice.py
+++ b/plugins/LocalFileOutputDevice/LocalFileOutputDevice.py
@@ -24,8 +24,8 @@ catalog = i18nCatalog("uranium")
 class LocalFileOutputDevice(ProjectOutputDevice):
     """Implements an OutputDevice that supports saving to arbitrary local files."""
 
-    def __init__(self, parent = None):
-        super().__init__(device_id = "local_file", parent = parent)
+    def __init__(self, add_to_output_devices: bool = True, parent = None):
+        super().__init__(device_id = "local_file", add_to_output_devices = add_to_output_devices, parent = parent)
 
         self.setName(catalog.i18nc("@item:inmenu", "Local File"))
         self.setShortDescription(catalog.i18nc("@action:button Preceded by 'Ready to'.", "Save to File"))

--- a/plugins/LocalFileOutputDevice/LocalFileOutputDevicePlugin.py
+++ b/plugins/LocalFileOutputDevice/LocalFileOutputDevicePlugin.py
@@ -19,7 +19,7 @@ class LocalFileOutputDevicePlugin(OutputDevicePlugin):
         Application.getInstance().getPreferences().addPreference("local_file/dialog_save_path", "")
 
     def start(self):
-        self.getOutputDeviceManager().addProjectOutputDevice(LocalFileOutputDevice(), add_to_output_devices = True)
+        self.getOutputDeviceManager().addProjectOutputDevice(LocalFileOutputDevice(add_to_output_devices = True))
 
     def stop(self):
         self.getOutputDeviceManager().removeProjectOutputDevice("local_file")


### PR DESCRIPTION
Previously, enabling/disabling a project output device would not reflect the change in the actual output devices list.

Now, if a project output device gets disabled, it will be automatically removed from the output_devices list if it was added there in the first place. When it gets enabled again, the device is readded to this list, making it available to be selected from the OutputDevicesActionButton in the bottom right.

CURA-7903