### PR TITLE
Fix QML warnings produced due to signal calls in Connections

### DIFF
--- a/UM/Qt/qml/UM/MessageStack.qml
+++ b/UM/Qt/qml/UM/MessageStack.qml
@@ -348,7 +348,7 @@ ListView
                     Connections
                     {
                         target: actionButton.item
-                        onClicked: base.model.actionTriggered(message.model_id, modelData.action_id)
+                        function onClicked() { base.model.actionTriggered(message.model_id, modelData.action_id) }
                     }
                 }
             }
@@ -417,7 +417,7 @@ ListView
                     Connections
                     {
                         target: actionButton.item
-                        onClicked: base.model.actionTriggered(message.model_id, modelData.action_id)
+                        function onClicked() { base.model.actionTriggered(message.model_id, modelData.action_id) }
                     }
                 }
             }

--- a/UM/Qt/qml/UM/Preferences/ManagementPage.qml
+++ b/UM/Qt/qml/UM/Preferences/ManagementPage.qml
@@ -178,7 +178,7 @@ PreferencesPage
         {
             target: objectList.model
 
-            onItemsChanged:
+            function onItemsChanged()
             {
                 var itemIndex = -1;
                 if (base.currentItem === null)


### PR DESCRIPTION
In Qt5.15 the Connections items should not be using the "on < signal >" format since it is depricated.
They should have the format function "on< signal >(arguments)" instead.