### PR TITLE
Prevent seemingly multiple selected tabs in prefs-screen.

### DIFF
--- a/UM/Qt/qml/UM/Preferences/PreferencesDialog.qml
+++ b/UM/Qt/qml/UM/Preferences/PreferencesDialog.qml
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 Ultimaker B.V.
+// Copyright (c) 2021 Ultimaker B.V.
 // Uranium is released under the terms of the LGPLv3 or higher.
 
 import QtQuick 2.1
@@ -24,6 +24,7 @@ Dialog
     property int currentPage: 0;
     onCurrentPageChanged:
     {
+        pagesList.selection.clear();
         pagesList.selection.select(currentPage);
     }
 


### PR DESCRIPTION
Since single selection is already default, you wouldn't expect this to be necesary, but single selection is appearantly only for mouse clicks, not for the inactive selection? Must be a bug I guess. Anyway it works now.

fixed as part of CURA-8127