### PR TITLE
CURA-8164: Fix slice info being send multiple times

### DIFF
--- a/UM/OutputDevice/ProjectOutputDevice.py
+++ b/UM/OutputDevice/ProjectOutputDevice.py
@@ -7,11 +7,13 @@ from PyQt5.QtCore import pyqtSignal, QObject
 
 from UM.Application import Application
 from UM.OutputDevice.OutputDevice import OutputDevice
+from UM.Signal import signalemitter
 from UM.i18n import i18nCatalog
 
 catalog = i18nCatalog("uranium")
 
 
+@signalemitter
 class ProjectOutputDevice(QObject, OutputDevice):
     """
     Extends the OutputDevice class for OutputeDevices that support saving project files.


### PR DESCRIPTION
The OutputDevice class is decorated with the signalemitter decorator, which allows it to declare the instance signals outside the `__init__` function. However, the ProjectOutputDevice was not decorated similarly, which was causing it to have the writeSignals between ProjectOutputDevices being shared. Therefore, when we emitted the writeStarted signal (which triggers the sending of the SliceInfo) in the LocalFileOutputDevice, it was being triggered also for other ProjectOutputDevices. Pretty weird issue.

CURA-8164