### PR TITLE
CURA-8164: Don't connect the signals if the device is disabled on startup

### DIFF
--- a/UM/OutputDevice/OutputDeviceManager.py
+++ b/UM/OutputDevice/OutputDeviceManager.py
@@ -262,12 +262,13 @@ class OutputDeviceManager:
         self._project_output_devices[device.getId()] = device
         device.enabledChanged.connect(self.projectOutputDevicesChanged.emit)
 
-        if device.add_to_output_devices and device.enabled:
-            self.addOutputDevice(device)
-        else:
-            # Call the connectWriteSignalsToDevice(..) only if addOutputDevice(..) function hasn't been called already
-            # to avoid connecting the signals twice
-            self.connectWriteSignalsToDevice(device)
+        if device.enabled:
+            if device.add_to_output_devices:
+                self.addOutputDevice(device)
+            else:
+                # Call the connectWriteSignalsToDevice(..) only if addOutputDevice(..) function hasn't been called already
+                # to avoid connecting the signals twice
+                self.connectWriteSignalsToDevice(device)
 
         self.projectOutputDevicesChanged.emit()
 


### PR DESCRIPTION
If the project output device was disabled at startup, the write signals were still connected. Then, when the device was getting enabled, its write signals were getting connected again, leading to issues like sending the slice info twice when the device was being used to write to a file.

This commit fixes that by making sure that the signals on startup are being connected ONLY if the device is enabled.

CURA-8164