### PR TITLE
Central File Storage

### DIFF
--- a/UM/CentralFileStorage.py
+++ b/UM/CentralFileStorage.py
@@ -6,6 +6,7 @@ import os  # To remove duplicate files.
 import os.path  # To re-format files with their proper file extension but with a version number in between.
 import shutil  # To move files in constant-time.
 
+from UM.Logger import Logger
 from UM.Resources import Resources  # To get the central storage location.
 from UM.Version import Version  # To track version numbers of these files.
 
@@ -36,6 +37,7 @@ class CentralFileStorage:
         :param version: A version number for the file.
         """
         if not os.path.exists(file_path):
+            Logger.debug(f"{file_id} {str(version)} was already stored centrally.")
             return
         storage_path = cls._getFilePath(file_id, version)
 
@@ -45,8 +47,10 @@ class CentralFileStorage:
             if new_file_hash != stored_file_hash:
                 raise FileExistsError(f"Central file storage already has a file with ID {file_id} and version {str(version)}, but it's different.")
             os.remove(file_path)
+            Logger.info(f"{file_id} {str(version)} was already stored centrally. Removing duplicate.")
         else:
             shutil.move(file_path, storage_path)
+            Logger.info(f"Storing new file {file_id} {str(version)}.")
 
     @classmethod
     def retrieve(cls, file_id: str, sha256_hash: str, version: Version = Version("1.0.0")) -> str:

--- a/UM/CentralFileStorage.py
+++ b/UM/CentralFileStorage.py
@@ -37,11 +37,11 @@ class CentralFileStorage:
         """
         if not os.path.exists(file_path):
             return
-        storage_path = cls._get_file_path(file_id, version)
+        storage_path = cls._getFilePath(file_id, version)
 
         if os.path.exists(storage_path):  # File already exists. Check if it's the same.
-            new_file_hash = cls._hash_file(file_path)
-            stored_file_hash = cls._hash_file(storage_path)
+            new_file_hash = cls._hashFile(file_path)
+            stored_file_hash = cls._hashFile(storage_path)
             if new_file_hash != stored_file_hash:
                 raise FileExistsError(f"Central file storage already has a file with ID {file_id} and version {str(version)}, but it's different.")
             os.remove(file_path)
@@ -57,18 +57,18 @@ class CentralFileStorage:
         :param version: The version number of the file to retrieve.
         :return: A path to the location of the centrally stored file.
         """
-        storage_path = cls._get_file_path(file_id, version)
+        storage_path = cls._getFilePath(file_id, version)
 
         if not os.path.exists(storage_path):
             raise FileNotFoundError(f"Central file storage doesn't have a file with ID {file_id} and version {str(version)}.")
-        stored_file_hash = cls._hash_file(storage_path)
+        stored_file_hash = cls._hashFile(storage_path)
         if stored_file_hash != sha256_hash:
             raise IOError(f"The centrally stored file with ID {file_id} and version {str(version)} does not match with the given file hash.")
 
         return storage_path
 
     @classmethod
-    def _get_file_path(cls, file_id: str, version: Version) -> str:
+    def _getFilePath(cls, file_id: str, version: Version) -> str:
         """
         Get a canonical file path for a hypothetical file with a specified ID and version.
         :param file_id: The name of the file to get a name for.
@@ -79,7 +79,7 @@ class CentralFileStorage:
         return os.path.join(Resources._getDataStorageRootPath(), "storage", file_name)
 
     @classmethod
-    def _hash_file(cls, file_path: str) -> str:
+    def _hashFile(cls, file_path: str) -> str:
         """
         Returns a SHA-256 hash of the specified file.
         :param file_path: The path to a file to get the hash of.

--- a/UM/CentralFileStorage.py
+++ b/UM/CentralFileStorage.py
@@ -35,6 +35,8 @@ class CentralFileStorage:
         :param file_path: The path to the file to store in the central file storage.
         :param file_id: A name for the file to store.
         :param version: A version number for the file.
+        :raises FileExistsError: There is already a centrally stored file with that name and version, but it's
+        different.
         """
         if not os.path.exists(file_path):
             Logger.debug(f"{file_id} {str(version)} was already stored centrally.")
@@ -60,6 +62,8 @@ class CentralFileStorage:
         :param sha256_hash: A SHA-256 hash of the file you expect to receive from the central storage.
         :param version: The version number of the file to retrieve.
         :return: A path to the location of the centrally stored file.
+        :raises FileNotFoundError: There is no file stored with that name and version.
+        :raises IOError: The hash of the file is incorrect. Opening this file could be a security risk.
         """
         storage_path = cls._getFilePath(file_id, version)
 

--- a/UM/CentralFileStorage.py
+++ b/UM/CentralFileStorage.py
@@ -55,7 +55,15 @@ class CentralFileStorage:
         :param version: The version number of the file to retrieve.
         :return: A path to the location of the centrally stored file.
         """
-        pass  # TODO.
+        storage_path = cls._get_file_path(file_id, version)
+
+        if not os.path.exists(storage_path):
+            raise FileNotFoundError(f"Central file storage doesn't have a file with ID {file_id} and version {str(version)}.")
+        stored_file_hash = cls._hash_file(storage_path)
+        if stored_file_hash != sha256_hash:
+            raise IOError(f"The centrally stored file with ID {file_id} and version {str(version)} does not match with the given file hash.")
+
+        return storage_path
 
     @classmethod
     def _get_file_path(cls, file_id: str, version: Version) -> str:

--- a/UM/CentralFileStorage.py
+++ b/UM/CentralFileStorage.py
@@ -47,6 +47,8 @@ class CentralFileStorage:
         storage_path = cls._getFilePath(file_id, version)
 
         if os.path.exists(storage_path):  # File already exists. Check if it's the same.
+            if os.path.getsize(file_path) != os.path.getsize(storage_path):  # As quick check if files are the same, check their file sizes.
+                raise FileExistsError(f"Central file storage already has a file with ID {file_id} and version {str(version)}, but it's different.")
             new_file_hash = cls._hashFile(file_path)
             stored_file_hash = cls._hashFile(storage_path)
             if new_file_hash != stored_file_hash:

--- a/UM/CentralFileStorage.py
+++ b/UM/CentralFileStorage.py
@@ -38,9 +38,12 @@ class CentralFileStorage:
         :raises FileExistsError: There is already a centrally stored file with that name and version, but it's
         different.
         """
+        if not os.path.exists(cls._centralStorageLocation()):
+            os.makedirs(cls._centralStorageLocation())
         if not os.path.exists(file_path):
             Logger.debug(f"{file_id} {str(version)} was already stored centrally.")
             return
+
         storage_path = cls._getFilePath(file_id, version)
 
         if os.path.exists(storage_path):  # File already exists. Check if it's the same.
@@ -84,7 +87,15 @@ class CentralFileStorage:
         :return: A path to store such a file.
         """
         file_name = file_id + "." + str(version)
-        return os.path.join(Resources.getDataStoragePath(), "..", "storage", file_name)
+        return os.path.join(cls._centralStorageLocation(), file_name)
+
+    @classmethod
+    def _centralStorageLocation(cls) -> str:
+        """
+        Gets a directory to store things in a version-neutral location.
+        :return: A directory to store things centrally.
+        """
+        return os.path.join(Resources.getDataStoragePath(), "..", "storage")
 
     @classmethod
     def _hashFile(cls, file_path: str) -> str:

--- a/UM/CentralFileStorage.py
+++ b/UM/CentralFileStorage.py
@@ -76,7 +76,7 @@ class CentralFileStorage:
         :return: A path to store such a file.
         """
         file_name = file_id + "." + str(version)
-        return os.path.join(Resources._getDataStorageRootPath(), "storage", file_name)
+        return os.path.join(Resources.getDataStoragePath(), "..", "storage", file_name)
 
     @classmethod
     def _hashFile(cls, file_path: str) -> str:

--- a/UM/CentralFileStorage.py
+++ b/UM/CentralFileStorage.py
@@ -35,6 +35,8 @@ class CentralFileStorage:
         :param file_id: A name for the file to store.
         :param version: A version number for the file.
         """
+        if not os.path.exists(file_path):
+            return
         storage_path = cls._get_file_path(file_id, version)
 
         if os.path.exists(storage_path):  # File already exists. Check if it's the same.
@@ -68,7 +70,7 @@ class CentralFileStorage:
     @classmethod
     def _get_file_path(cls, file_id: str, version: Version) -> str:
         """
-        Get a canonical file path for a hypothetical fil with a specified ID and version.
+        Get a canonical file path for a hypothetical file with a specified ID and version.
         :param file_id: The name of the file to get a name for.
         :param version: The version number of the file to get a name for.
         :return: A path to store such a file.

--- a/UM/CentralFileStorage.py
+++ b/UM/CentralFileStorage.py
@@ -1,0 +1,43 @@
+# Copyright (c) 2021 Ultimaker B.V.
+# Uranium is released under the terms of the LGPLv3 or higher.
+
+from UM.Version import Version
+
+class CentralFileStorage:
+    """
+    This class stores and retrieves files stored in a location central to all versions of the application. Its purpose
+    is to provide a way for plug-ins to store big files without having those big files copied to the new resource
+    directory at every version upgrade.
+
+    Each file gets a file ID and a version number by which to identify the individual file. The file ID and version
+    number combination needs to be unique for a file and together refer to a specific file's contents. When retrieving
+    the file, the retriever needs to specify the hash of the file that it expects to find, and this hash is checked
+    before giving up the location of the file. This hash will guard against unauthorised changes to the file. The
+    plug-in, if properly signed, will then not be surprised by malicious content in that file.
+    """
+
+    @classmethod
+    def store(cls, file_path: str, file_id: str, version: Version = Version("1.0.0")) -> None:
+        """
+        Store a new file into the central file storage. This file will get moved to a storage location that is not
+        specific to this version of the application.
+
+        If the file already exists, this will check if it's the same file. If the file is not the same, it raises a
+        `FileExistsError`. If the file is the same, no error is raised and the file to store is simply deleted. It is a
+        duplicate of the file already stored.
+        :param file_path: The path to the file to store in the central file storage.
+        :param file_id: A name for the file to store.
+        :param version: A version number for the file.
+        """
+        pass  # TODO.
+
+    @classmethod
+    def retrieve(cls, file_id: str, sha256_hash: str, version: Version = Version("1.0.0")) -> str:
+        """
+        Retrieve the file path of a previously stored file.
+        :param file_id: The name of the file to retrieve.
+        :param sha256_hash: A SHA-256 hash of the file you expect to receive from the central storage.
+        :param version: The version number of the file to retrieve.
+        :return: A path to the location of the centrally stored file.
+        """
+        pass  # TODO.

--- a/tests/TestCentralFileStorage.py
+++ b/tests/TestCentralFileStorage.py
@@ -83,3 +83,10 @@ def test_storeVersions():
     assert stored_path1 != stored_path2
     assert open(stored_path1, "rb").read() == TEST_FILE_CONTENTS
     assert open(stored_path2, "rb").read() == TEST_FILE_CONTENTS2
+
+def test_retrieveNonExistent():
+    """
+    Tests retrieving a file that is not stored in the central location.
+    """
+    with unittest.mock.patch("UM.Resources.Resources.getDataStoragePath", lambda: "test_central_storage/4.9"):
+        pytest.raises(FileNotFoundError, lambda: CentralFileStorage.retrieve("non_existent_file", "0123456789ABCDEF"))

--- a/tests/TestCentralFileStorage.py
+++ b/tests/TestCentralFileStorage.py
@@ -90,3 +90,11 @@ def test_retrieveNonExistent():
     """
     with unittest.mock.patch("UM.Resources.Resources.getDataStoragePath", lambda: "test_central_storage/4.9"):
         pytest.raises(FileNotFoundError, lambda: CentralFileStorage.retrieve("non_existent_file", "0123456789ABCDEF"))
+
+def test_retrieveWrongHash():
+    """
+    Tests retrieving a file that has a wrong hash.
+    """
+    with unittest.mock.patch("UM.Resources.Resources.getDataStoragePath", lambda: "test_central_storage/4.9"):
+        CentralFileStorage.store(TEST_FILE_PATH, "myfile")
+        pytest.raises(IOError, lambda: CentralFileStorage.retrieve("myfile", TEST_FILE_HASH2))

--- a/tests/TestCentralFileStorage.py
+++ b/tests/TestCentralFileStorage.py
@@ -18,10 +18,13 @@ def setup_function():
         f.write(TEST_FILE_CONTENTS)
 
 def teardown_function():
-    if os.path.exists(TEST_FILE_PATH):
-        os.remove(TEST_FILE_PATH)
-    if os.path.exists("test_central_storage"):
-        shutil.rmtree("test_central_storage")
+    try:
+        if os.path.exists(TEST_FILE_PATH):
+            os.remove(TEST_FILE_PATH)
+        if os.path.exists("test_central_storage"):
+            shutil.rmtree("test_central_storage")
+    except EnvironmentError:
+        pass
 
 def test_storeRetrieve():
     """

--- a/tests/TestCentralFileStorage.py
+++ b/tests/TestCentralFileStorage.py
@@ -32,4 +32,6 @@ def test_storeRetrieve():
     """
     with unittest.mock.patch("UM.Resources.Resources.getDataStoragePath", lambda: "test_central_storage/4.9"):
         CentralFileStorage.store(TEST_FILE_PATH, "myfile")
-        CentralFileStorage.retrieve("myfile", TEST_FILE_HASH)
+        stored_path = CentralFileStorage.retrieve("myfile", TEST_FILE_HASH)
+    assert os.path.exists(stored_path)
+    assert open(stored_path, "rb").read() == TEST_FILE_CONTENTS

--- a/tests/TestCentralFileStorage.py
+++ b/tests/TestCentralFileStorage.py
@@ -66,6 +66,14 @@ def test_storeDuplicate():
         CentralFileStorage.store(TEST_FILE_PATH + ".copy.txt", "myfile")  # Shouldn't raise error. File contents are identical.
         assert not os.path.exists(TEST_FILE_PATH + ".copy.txt")  # Duplicate must be removed.
 
+def test_storeConflict():
+    """
+    Tests storing two different files under the same ID/version.
+    """
+    with unittest.mock.patch("UM.Resources.Resources.getDataStoragePath", lambda: "test_central_storage/4.9"):
+        CentralFileStorage.store(TEST_FILE_PATH, "myfile")
+        pytest.raises(FileExistsError, lambda: CentralFileStorage.store(TEST_FILE_PATH2, "myfile"))
+
 def test_storeVersions():
     with unittest.mock.patch("UM.Resources.Resources.getDataStoragePath", lambda: "test_central_storage/4.9"):
         CentralFileStorage.store(TEST_FILE_PATH, "myfile", Version("1.0.0"))

--- a/tests/TestCentralFileStorage.py
+++ b/tests/TestCentralFileStorage.py
@@ -41,6 +41,7 @@ def test_storeRetrieve():
     with unittest.mock.patch("UM.Resources.Resources.getDataStoragePath", lambda: "test_central_storage/4.9"):
         CentralFileStorage.store(TEST_FILE_PATH, "myfile")
         stored_path = CentralFileStorage.retrieve("myfile", TEST_FILE_HASH)
+    assert not os.path.exists(TEST_FILE_PATH)
     assert os.path.exists(stored_path)
     assert open(stored_path, "rb").read() == TEST_FILE_CONTENTS
 

--- a/tests/TestCentralFileStorage.py
+++ b/tests/TestCentralFileStorage.py
@@ -8,10 +8,14 @@ import shutil  # To clean up after the test.
 import unittest.mock  # To mock the Resources class.
 
 from UM.CentralFileStorage import CentralFileStorage  # The class under test.
+from UM.Version import Version  # Storing files of different versions.
 
 TEST_FILE_PATH = "test_file.txt"
 TEST_FILE_CONTENTS = b"May thy PLA floweth into all the right spots, and none other."
 TEST_FILE_HASH = hashlib.sha256(TEST_FILE_CONTENTS).hexdigest()
+TEST_FILE_PATH2 = "test_file2.txt"
+TEST_FILE_CONTENTS2 = b"May all PVA dissolveth to the snotty goo from wence it came, for it be its natural state of being."
+TEST_FILE_HASH2 = hashlib.sha256(TEST_FILE_CONTENTS2).hexdigest()
 
 def setup_function():
     with open(TEST_FILE_PATH, "wb") as f:
@@ -35,3 +39,12 @@ def test_storeRetrieve():
         stored_path = CentralFileStorage.retrieve("myfile", TEST_FILE_HASH)
     assert os.path.exists(stored_path)
     assert open(stored_path, "rb").read() == TEST_FILE_CONTENTS
+
+def test_storeNonExistent():
+    """
+    Tests storing a file that doesn't exist.
+
+    The storage is expected to fail silently, leaving just a debug statement that it was already stored.
+    """
+    with unittest.mock.patch("UM.Resources.Resources.getDataStoragePath", lambda: "test_central_storage/4.9"):
+        CentralFileStorage.store("non_existent_file.txt", "my_non_existent_file")  # Shouldn't raise error.

--- a/tests/TestCentralFileStorage.py
+++ b/tests/TestCentralFileStorage.py
@@ -1,0 +1,32 @@
+# Copyright (c) 2021 Ultimaker B.V.
+# Uranium is released under the terms of the LGPLv3 or higher.
+
+import hashlib  # To give a hash to the central file storage.
+import os  # To deal with test files.
+import pytest  # The test runner.
+import shutil  # To clean up after the test.
+import unittest.mock  # To mock the Resources class.
+
+from UM.CentralFileStorage import CentralFileStorage  # The class under test.
+
+TEST_FILE_PATH = "test_file.txt"
+TEST_FILE_CONTENTS = b"May thy PLA floweth into all the right spots, and none other."
+TEST_FILE_HASH = hashlib.sha256(TEST_FILE_CONTENTS).hexdigest()
+
+def setup_function():
+    with open(TEST_FILE_PATH, "wb") as f:
+        f.write(TEST_FILE_CONTENTS)
+
+def teardown_function():
+    if os.path.exists(TEST_FILE_PATH):
+        os.remove(TEST_FILE_PATH)
+    if os.path.exists("test_central_storage"):
+        shutil.rmtree("test_central_storage")
+
+def test_storeRetrieve():
+    """
+    Basic store-retrieve loop test.
+    """
+    with unittest.mock.patch("UM.Resources.Resources.getDataStoragePath", lambda: "test_central_storage/4.9"):
+        CentralFileStorage.store(TEST_FILE_PATH, "myfile")
+        CentralFileStorage.retrieve("myfile", TEST_FILE_HASH)

--- a/tests/TestCentralFileStorage.py
+++ b/tests/TestCentralFileStorage.py
@@ -53,6 +53,18 @@ def test_storeNonExistent():
     with unittest.mock.patch("UM.Resources.Resources.getDataStoragePath", lambda: "test_central_storage/4.9"):
         CentralFileStorage.store("non_existent_file.txt", "my_non_existent_file")  # Shouldn't raise error.
 
+def test_storeDuplicate():
+    """
+    Tests storing a file twice.
+
+    The storage should make the files unique, i.e. remove the duplicate.
+    """
+    with unittest.mock.patch("UM.Resources.Resources.getDataStoragePath", lambda: "test_central_storage/4.9"):
+        shutil.copy(TEST_FILE_PATH, TEST_FILE_PATH + ".copy.txt")
+        CentralFileStorage.store(TEST_FILE_PATH, "myfile")
+        CentralFileStorage.store(TEST_FILE_PATH + ".copy.txt", "myfile")  # Shouldn't raise error. File contents are identical.
+        assert not os.path.exists(TEST_FILE_PATH + ".copy.txt")  # Duplicate must be removed.
+
 def test_storeVersions():
     with unittest.mock.patch("UM.Resources.Resources.getDataStoragePath", lambda: "test_central_storage/4.9"):
         CentralFileStorage.store(TEST_FILE_PATH, "myfile", Version("1.0.0"))

--- a/tests/TestCentralFileStorage.py
+++ b/tests/TestCentralFileStorage.py
@@ -20,11 +20,15 @@ TEST_FILE_HASH2 = hashlib.sha256(TEST_FILE_CONTENTS2).hexdigest()
 def setup_function():
     with open(TEST_FILE_PATH, "wb") as f:
         f.write(TEST_FILE_CONTENTS)
+    with open(TEST_FILE_PATH2, "wb") as f:
+        f.write(TEST_FILE_CONTENTS2)
 
 def teardown_function():
     try:
         if os.path.exists(TEST_FILE_PATH):
             os.remove(TEST_FILE_PATH)
+        if os.path.exists(TEST_FILE_PATH2):
+            os.remove(TEST_FILE_PATH2)
         if os.path.exists("test_central_storage"):
             shutil.rmtree("test_central_storage")
     except EnvironmentError:
@@ -48,3 +52,13 @@ def test_storeNonExistent():
     """
     with unittest.mock.patch("UM.Resources.Resources.getDataStoragePath", lambda: "test_central_storage/4.9"):
         CentralFileStorage.store("non_existent_file.txt", "my_non_existent_file")  # Shouldn't raise error.
+
+def test_storeVersions():
+    with unittest.mock.patch("UM.Resources.Resources.getDataStoragePath", lambda: "test_central_storage/4.9"):
+        CentralFileStorage.store(TEST_FILE_PATH, "myfile", Version("1.0.0"))
+        CentralFileStorage.store(TEST_FILE_PATH2, "myfile", Version("1.1.0"))
+        stored_path1 = CentralFileStorage.retrieve("myfile", TEST_FILE_HASH, Version("1.0.0"))
+        stored_path2 = CentralFileStorage.retrieve("myfile", TEST_FILE_HASH2, Version("1.1.0"))
+    assert stored_path1 != stored_path2
+    assert open(stored_path1, "rb").read() == TEST_FILE_CONTENTS
+    assert open(stored_path2, "rb").read() == TEST_FILE_CONTENTS2


### PR DESCRIPTION
This is a pull request that adds new functionality to Uranium: Central File Storage. This functionality allows the programmer to store a file in a central location that is not dependent on the version number of the application he's running. It is a requirement for using plug-ins with large files, as the version upgrade system would copy those plug-ins each time the user upgrades the application. Using this central file storage, the programmer can move a big file out of the plug-in directory, reducing the file size of the plug-in directory.

There is a new class `CentralFileStorage` which collects two methods: `store` and `retrieve`. The `store` function stores a file in the central location, physically moving it away from the directories that get copied for each version. The `retrieve` function checks the file against a hash and then gives the path where the file is stored if that hash check is successful.

Requirements (from the ticket):
* There is a new function in Uranium to store big files in a shared location. This function takes a file path, a file version and an ID to reference the file by.
* If the file doesn't exist, the function exits cleanly without error. This way the plug-in can call the storing function simply at start-up without needing to check if this is the first time it was ran.
* The storage function needs to move the file to a central location which is not copied when the version upgrade runs. This central location needs to be part of the "data" storage location (not "config"). So in Windows it needs to be in %APPDATA%\Roaming\cura; in Linux it needs to be in ~/.local/share/cura; in MacOS it needs to be in ~/Library/Application Support/cura. This will be a sub-folder next to all of the folders for each Cura version.
* The storage function needs to rename the file to something which includes the file ID as well as the version number.
* The storage function needs to check if there is already a file with that file ID and version number in the central location. If there is and the files are the same, it simply deletes the new file and retains the old one. If there is and the files are NOT the same, it needs to raise an error.
* There needs to be a retrieval function which returns the file path of a file with a certain file ID and version number.
* This retrieval function needs to accept a file hash as well. Before returning the file path, it needs to check the file against that hash and if they don't match raise an error.

Implements CURA-8162.