### PR TITLE
Cura 8010 icon size

### DIFF
--- a/UM/Qt/Bindings/Theme.py
+++ b/UM/Qt/Bindings/Theme.py
@@ -122,8 +122,8 @@ class Theme(QObject):
         if px in self._icons:
             if icon_name in self._icons[px]:
                 return self._icons[px][icon_name]
-            elif icon_name in self._icons["icons"]:  # Retrieve the "old" icon from the base icon folder
-                return self._icons["icons"][icon_name]
+        elif icon_name in self._icons["icons"]:  # Retrieve the "old" icon from the base icon folder
+            return self._icons["icons"][icon_name]
 
         # We don't log this anymore since we have new fallback behavior to load the icon from a plugin folder
         # Logger.log("w", "No icon %s defined in Theme", icon_name)

--- a/UM/Qt/Bindings/Theme.py
+++ b/UM/Qt/Bindings/Theme.py
@@ -118,10 +118,20 @@ class Theme(QObject):
 
     @pyqtSlot(str, str, result = "QUrl")
     @pyqtSlot(str, result = "QUrl")
-    def getIcon(self, icon_name: str, px: str = "default") -> QUrl:
-        if px in self._icons:
-            if icon_name in self._icons[px]:
-                return self._icons[px][icon_name]
+    def getIcon(self, icon_name: str, detail_level: str = "default") -> QUrl:
+        """
+        Finds and returns the url of the requested icon. The icons are organized in folders according to their detail
+        level and the same icon may exist with more details. If a detail level is not specified, the icon will be
+        retrieved from the "default" folder. Icons with a higher detail level are recommended to be used with a bigger
+        width/height.
+
+        :param icon_name: The name of the icon to be retrieved. The same icon may exist in multiple detail levels.
+        :param detail_level: The level of detail of the icon. Choice between "low, "default", "medium", "high".
+        :return: The file url of the requested icon, in the requested detail level.
+        """
+        if detail_level in self._icons:
+            if icon_name in self._icons[detail_level]:
+                return self._icons[detail_level][icon_name]
         elif icon_name in self._icons["icons"]:  # Retrieve the "old" icon from the base icon folder
             return self._icons["icons"][icon_name]
 

--- a/UM/Qt/Bindings/Theme.py
+++ b/UM/Qt/Bindings/Theme.py
@@ -118,7 +118,7 @@ class Theme(QObject):
 
     @pyqtSlot(str, str, result = "QUrl")
     @pyqtSlot(str, result = "QUrl")
-    def getIcon(self, icon_name: str, px: str = "24") -> QUrl:
+    def getIcon(self, icon_name: str, px: str = "default") -> QUrl:
         if px in self._icons:
             if icon_name in self._icons[px]:
                 return self._icons[px][icon_name]

--- a/UM/Qt/Bindings/Theme.py
+++ b/UM/Qt/Bindings/Theme.py
@@ -237,11 +237,11 @@ class Theme(QObject):
         iconsdir = os.path.join(path, "icons")
         if os.path.isdir(iconsdir):
             for base_path, _, icons in os.walk(iconsdir):
-                px = base_path.split(os.sep)[-1]
-                self._icons[px] = {}
+                detail_level = base_path.split(os.sep)[-1]
+                self._icons[detail_level] = {}
                 for icon in icons:
                     name = os.path.splitext(icon)[0]
-                    self._icons[px][name] = QUrl.fromLocalFile(os.path.join(base_path, icon))
+                    self._icons[detail_level][name] = QUrl.fromLocalFile(os.path.join(base_path, icon))
 
         imagesdir = os.path.join(path, "images")
         if os.path.isdir(imagesdir):

--- a/UM/Qt/qml/UM/MessageStack.qml
+++ b/UM/Qt/qml/UM/MessageStack.qml
@@ -108,7 +108,7 @@ ListView
                         width: UM.Theme.getSize("message_close").width
                         sourceSize.width: width
                         color: control.hovered ? UM.Theme.getColor("message_close_hover") : UM.Theme.getColor("message_close")
-                        source: UM.Theme.getIcon("cross1")
+                        source: UM.Theme.getIcon("Cancel")
                     }
 
                     label: Item {}

--- a/UM/Qt/qml/UM/Preferences/SettingVisibilityCategory.qml
+++ b/UM/Qt/qml/UM/Preferences/SettingVisibilityCategory.qml
@@ -24,7 +24,7 @@ Button {
                 anchors.verticalCenter: parent.verticalCenter
                 height: (label.height / 2) | 0
                 width: height
-                source: control.checked ? UM.Theme.getIcon("arrow_bottom") : UM.Theme.getIcon("arrow_right");
+                source: control.checked ? UM.Theme.getIcon("ChevronSingleDown") : UM.Theme.getIcon("ChevronSingleRight");
                 color: control.hovered ? palette.highlight : palette.buttonText
             }
             UM.RecolorImage

--- a/UM/Qt/qml/UM/Preferences/SettingVisibilityItem.qml
+++ b/UM/Qt/qml/UM/Preferences/SettingVisibilityItem.qml
@@ -58,7 +58,7 @@ Item {
             width: Math.round(check.height * 0.75) | 0
             height: width
 
-            source: UM.Theme.getIcon("notice")
+            source: UM.Theme.getIcon("Information")
 
             color: palette.buttonText
         }

--- a/UM/Qt/qml/UM/Wizard.qml
+++ b/UM/Qt/qml/UM/Wizard.qml
@@ -157,7 +157,7 @@ UM.Dialog
                             height: UM.Theme.getSize("standard_arrow").height
                             sourceSize.height: width
                             color: palette.mid
-                            source: UM.Theme.getIcon("arrow_bottom")
+                            source: UM.Theme.getIcon("ChevronSingleDown")
                         }
                     }
                 }

--- a/plugins/Tools/MirrorTool/__init__.py
+++ b/plugins/Tools/MirrorTool/__init__.py
@@ -11,7 +11,7 @@ def getMetaData():
         "tool": {
             "name": i18n_catalog.i18nc("@label", "Mirror"),
             "description": i18n_catalog.i18nc("@info:tooltip", "Mirror Model"),
-            "icon": "mirror",
+            "icon": "Mirror",
             "weight": 2
         },
     }

--- a/plugins/Tools/RotateTool/RotateTool.qml
+++ b/plugins/Tools/RotateTool/RotateTool.qml
@@ -19,7 +19,7 @@ Item
 
         //: Reset Rotation tool button
         text: catalog.i18nc("@action:button", "Reset")
-        iconSource: UM.Theme.getIcon("rotate_reset");
+        iconSource: UM.Theme.getIcon("ArrowReset");
         property bool needBorder: true
 
         style: UM.Theme.styles.tool_button;
@@ -37,7 +37,7 @@ Item
 
         //: Lay Flat tool button
         text: catalog.i18nc("@action:button", "Lay flat")
-        iconSource: UM.Theme.getIcon("rotate_layflat");
+        iconSource: UM.Theme.getIcon("LayFlat");
         property bool needBorder: true
 
         style: UM.Theme.styles.tool_button;
@@ -55,10 +55,10 @@ Item
 
         anchors.left: layFlatButton.visible ? layFlatButton.right : resetRotationButton.right;
         anchors.leftMargin: UM.Theme.getSize("default_margin").width;
-        width: visible ? UM.Theme.getIcon("rotate_face_layflat").width : 0;
+        width: visible ? UM.Theme.getIcon("LayFlatOnFace").width : 0;
 
         text: catalog.i18nc("@action:button", "Select face to align to the build plate")
-        iconSource: UM.Theme.getIcon("rotate_face_layflat")
+        iconSource: UM.Theme.getIcon("LayFlatOnFace")
         property bool needBorder: true
 
         style: UM.Theme.styles.tool_button;

--- a/plugins/Tools/RotateTool/__init__.py
+++ b/plugins/Tools/RotateTool/__init__.py
@@ -11,7 +11,7 @@ def getMetaData():
         "tool": {
             "name": i18n_catalog.i18nc("@label", "Rotate"),
             "description": i18n_catalog.i18nc("@info:tooltip", "Rotate Model"),
-            "icon": "rotate",
+            "icon": "Rotate",
             "tool_panel": "RotateTool.qml",
             "weight": 1
         }

--- a/plugins/Tools/ScaleTool/ScaleTool.qml
+++ b/plugins/Tools/ScaleTool/ScaleTool.qml
@@ -65,7 +65,7 @@ Item
 
         //: Reset scale tool button
         text: catalog.i18nc("@action:button","Reset")
-        iconSource: UM.Theme.getIcon("scale_reset");
+        iconSource: UM.Theme.getIcon("ArrowReset");
         property bool needBorder: true
 
         style: UM.Theme.styles.tool_button;

--- a/plugins/Tools/ScaleTool/__init__.py
+++ b/plugins/Tools/ScaleTool/__init__.py
@@ -11,7 +11,7 @@ def getMetaData():
         "tool": {
             "name": i18n_catalog.i18nc("@label", "Scale"),
             "description": i18n_catalog.i18nc("@info:tooltip", "Scale Model"),
-            "icon": "scale",
+            "icon": "Scale",
             "tool_panel": "ScaleTool.qml",
             "weight": 0
         }

--- a/plugins/Tools/TranslateTool/__init__.py
+++ b/plugins/Tools/TranslateTool/__init__.py
@@ -11,7 +11,7 @@ def getMetaData():
         "tool": {
             "name": i18n_catalog.i18nc("@action:button", "Move"),
             "description": i18n_catalog.i18nc("@info:tooltip", "Move Model"),
-            "icon": "translate",
+            "icon": "ArrowFourWay",
             "tool_panel": "TranslateTool.qml",
             "weight": -1
         }


### PR DESCRIPTION
This PR adds new logic to the getIcons function allowing an icon to be stored in a subfolder. For instance different sizes. Such as is the standard within the UX department.

Since the used icons are renamed according to the conversion table and practice of the UXers this is also updated in the code.

Also, check PR ultimaker/cura#9716 