### PR TITLE
Track MIME type of opened mesh files

### DIFF
--- a/UM/Mesh/MeshReader.py
+++ b/UM/Mesh/MeshReader.py
@@ -26,12 +26,17 @@ class MeshReader(FileReader):
 
         # The mesh reader may set a MIME type itself if it knows a more specific MIME type than just going by extension.
         # If not, automatically generate one from our MIME type database, going by the file extension.
-        if result.source_mime_type is None:
-            try:
-                result.source_mime_type = MimeTypeDatabase.getMimeTypeForFile(file_name)
-            except MimeTypeNotFoundError:
-                Logger.warning(f"Loaded file {file_name} has no associated MIME type.")
-                # Leave MIME type at None then.
+        if not isinstance(result, list):
+            meshes = [result]
+        else:
+            meshes = result
+        for mesh in meshes:
+            if mesh.source_mime_type is None:
+                try:
+                    mesh.source_mime_type = MimeTypeDatabase.getMimeTypeForFile(file_name)
+                except MimeTypeNotFoundError:
+                    Logger.warning(f"Loaded file {file_name} has no associated MIME type.")
+                    # Leave MIME type at None then.
 
         return result
 

--- a/UM/Scene/SceneNode.py
+++ b/UM/Scene/SceneNode.py
@@ -2,7 +2,7 @@
 # Uranium is released under the terms of the LGPLv3 or higher.
 
 from copy import deepcopy
-from typing import Any, Dict, List, Optional, cast
+from typing import Any, cast, Dict, List, Optional, TYPE_CHECKING
 
 import numpy
 
@@ -16,6 +16,8 @@ from UM.Mesh.MeshData import MeshData
 from UM.Scene.SceneNodeDecorator import SceneNodeDecorator
 from UM.Signal import Signal, signalemitter
 
+if TYPE_CHECKING:
+    from UM.MimeTypeDatabase import MimeType
 
 @signalemitter
 class SceneNode:
@@ -88,6 +90,7 @@ class SceneNode:
         self._name = name  # type: str
         self._id = node_id  # type: str
         self._decorators = []  # type: List[SceneNodeDecorator]
+        self.source_mime_type = None  # type: Optional[MimeType]  # MIME type of the source file this node was created from.
 
         # Store custom settings to be compatible with Savitar SceneNode
         self._settings = {}  # type: Dict[str, Any]


### PR DESCRIPTION
This keeps track of each mesh what MIME type the mesh was loaded from, for the purpose of being able to send that information as anonymous usage statistic to Ultimaker.
It is accepted that meshes generated in other ways (e.g. from the Support Blocker plug-in) don't get an assigned MIME type.

Contributes to issue CURA-8232.