### PR TITLE
Fix calculating bounding box when group nodes are involved

### DIFF
--- a/UM/Math/Vector.py
+++ b/UM/Math/Vector.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2019 Ultimaker B.V.
+# Copyright (c) 2021 Ultimaker B.V.
 # Uranium is released under the terms of the LGPLv3 or higher.
 
 import numpy
@@ -220,10 +220,10 @@ class Vector:
         return Vector(data = -1 * self._data)
 
     def __repr__(self):
-        return "Vector({0:.3}, {1:.3}, {2:.3})".format(self._data[0], self._data[1], self._data[2])
+        return "Vector({0:.3f}, {1:.3f}, {2:.3f})".format(self._data[0], self._data[1], self._data[2])
 
     def __str__(self):
-        return "<{0:.3},{1:.3},{2:.3}>".format(self._data[0], self._data[1], self._data[2])
+        return "<{0:.3f},{1:.3f},{2:.3f}>".format(self._data[0], self._data[1], self._data[2])
 
     def __lt__(self, other):
         return self._data[0] < other._data[0] and self._data[1] < other._data[1] and self._data[2] < other._data[2]

--- a/UM/Scene/SceneNode.py
+++ b/UM/Scene/SceneNode.py
@@ -855,17 +855,23 @@ class SceneNode:
         self.boundingBoxChanged.emit()
 
     def _calculateAABB(self) -> None:
+        aabb = None
         if self._mesh_data:
             aabb = self._mesh_data.getExtents(self.getWorldTransformation(copy = False))
-        else:  # If there is no mesh_data, use a boundingbox that encompasses the local (0,0,0)
-            position = self.getWorldPosition()
-            aabb = AxisAlignedBox(minimum = position, maximum = position)
 
         for child in self._children:
+            if child.getBoundingBox().minimum == child.getBoundingBox().maximum:
+                # Child had a degenerate bounding box, such as an empty group. Don't count it along.
+                continue
             if aabb is None:
                 aabb = child.getBoundingBox()
             else:
                 aabb = aabb + child.getBoundingBox()
+
+        if aabb is None:  # There is no mesh data and no children with bounding box. Use the current position then, but it's a degenerate AABB.
+            position = self.getWorldPosition()
+            aabb = AxisAlignedBox(minimum = position, maximum = position)
+
         self._aabb = aabb
 
     def __str__(self) -> str:

--- a/UM/Scene/SceneNode.py
+++ b/UM/Scene/SceneNode.py
@@ -860,13 +860,14 @@ class SceneNode:
             aabb = self._mesh_data.getExtents(self.getWorldTransformation(copy = False))
 
         for child in self._children:
-            if child.getBoundingBox().minimum == child.getBoundingBox().maximum:
+            child_bb = child.getBoundingBox()
+            if child_bb is None or child_bb.minimum == child_bb.maximum:
                 # Child had a degenerate bounding box, such as an empty group. Don't count it along.
                 continue
             if aabb is None:
-                aabb = child.getBoundingBox()
+                aabb = child_bb
             else:
-                aabb = aabb + child.getBoundingBox()
+                aabb = aabb + child_bb
 
         if aabb is None:  # There is no mesh data and no children with bounding box. Use the current position then, but it's a degenerate AABB.
             position = self.getWorldPosition()


### PR DESCRIPTION
The position of the group node itself should in theory never be used. Only include the position of the group node itself if there is no mesh data and no children to have any redeemable AABB. Then also handle child nodes that have those degenerate empty group AABBs.

Contributes to issue CURA-7873.