### PR TITLE
CURA-8261: Allow central storage to store folders

### DIFF
--- a/UM/CentralFileStorage.py
+++ b/UM/CentralFileStorage.py
@@ -62,9 +62,9 @@ class CentralFileStorage:
         if os.path.exists(storage_path):  # File already exists. Check if it's the same.
             if os.path.getsize(path) != os.path.getsize(storage_path):  # As quick check if files are the same, check their file sizes.
                 raise FileExistsError(f"Central file storage already has an item (file or directory) with ID {path_id} and version {str(version)}, but it's different.")
-            new_file_hash = cls._hashItem(path)
-            stored_file_hash = cls._hashItem(storage_path)
-            if new_file_hash != stored_file_hash:
+            new_item_hash = cls._hashItem(path)
+            stored_item_hash = cls._hashItem(storage_path)
+            if new_item_hash != stored_item_hash:
                 raise FileExistsError(f"Central file storage already has an item (file or directory) with ID {path_id} and version {str(version)}, but it's different.")
             if os.path.isfile(path):
                 os.remove(path)

--- a/UM/CentralFileStorage.py
+++ b/UM/CentralFileStorage.py
@@ -13,57 +13,59 @@ from UM.Version import Version  # To track version numbers of these files.
 
 class CentralFileStorage:
     """
-    This class stores and retrieves files stored in a location central to all versions of the application. Its purpose
-    is to provide a way for plug-ins to store big files without having those big files copied to the new resource
-    directory at every version upgrade.
+    This class stores and retrieves items (files or directories) stored in a location central to all versions of the
+    application. Its purpose is to provide a way for plug-ins to store big items (files or directories) without having
+    those big items copied to the new resource directory at every version upgrade.
 
-    Each file gets a file ID and a version number by which to identify the individual file. The file ID and version
-    number combination needs to be unique for a file and together refer to a specific file's contents. When retrieving
-    the file, the retriever needs to specify the hash of the file that it expects to find, and this hash is checked
-    before giving up the location of the file. This hash will guard against unauthorised changes to the file. The
-    plug-in, if properly signed, will then not be surprised by malicious content in that file.
+    Each items gets a path ID and a version number by which to identify the individual items. The path ID and version
+    number combination needs to be unique for an item and together refer to a specific item's contents. When retrieving
+    the item, the retriever needs to specify the hash of the item that it expects to find, and this hash is checked
+    before giving up the location of the item. This hash will guard against unauthorised changes to the item. The
+    plug-in, if properly signed, will then not be surprised by malicious content in that file or directory.
 
-    If multiple files need to be moved, it's also possible to add a file called "central_storage.json" to the root
+    If multiple items need to be moved, it's also possible to add a file called "central_storage.json" to the root
     directory of the plugin. This json needs to contain a list, of which each element is a list of 4 elements.
-    The first element holds the relative path to the file, the second is the ID, the third is the ID of the file and the
-    last item is the hash.
+    The first element holds the relative path to the item (file or directory), the second is the ID, the third is the
+    ID of the item and the last item is the hash.
 
     A brief example of such a file:
     [
-        ["files/VeryLargeFileToStore.big", "very_large_file", "1.0.1", "abcdefghijklmnop"]
+        ["files/VeryLargeFileToStore.big", "very_large_file", "1.0.1", "abcdefghijklmnop"],
+        ["relative/path/to/dir", "relative/path/to/dir/in/storage", "1.0.1, "124986978cb21e"]
     ]
     """
 
     @classmethod
     def store(cls, path: str, path_id: str, version: Version = Version("1.0.0")) -> None:
         """
-        Store a new file into the central file storage. This file will get moved to a storage location that is not
-        specific to this version of the application.
+        Store a new item (file or directory) into the central file storage. This item will get moved to a storage
+        location that is not specific to this version of the application.
 
-        If the file already exists, this will check if it's the same file. If the file is not the same, it raises a
-        `FileExistsError`. If the file is the same, no error is raised and the file to store is simply deleted. It is a
-        duplicate of the file already stored.
-        :param path: The path to the file to store in the central file storage.
-        :param path_id: A name for the file to store.
-        :param version: A version number for the file.
-        :raises FileExistsError: There is already a centrally stored file with that name and version, but it's
-        different.
+        If the item already exists, this will check if it's the same item. If the item is not the same, it raises a
+        `FileExistsError`. If the item is the same, no error is raised and the item to store is simply deleted. It is a
+        duplicate of the item already stored.
+
+        :param path: The path to the item (file or directory) to store in the central file storage.
+        :param path_id: A name for the item (file or directory) to store.
+        :param version: A version number for the item (file or directory).
+        :raises FileExistsError: There is already a centrally stored item (file or directory) with that name and
+        version, but it's different.
         """
         if not os.path.exists(cls._centralStorageLocation()):
             os.makedirs(cls._centralStorageLocation())
         if not os.path.exists(path):
-            Logger.debug(f"{path_id} {str(version)} was already stored centrally or the provided file_path is not correct")
+            Logger.debug(f"{path_id} {str(version)} was already stored centrally or the provided path is not correct")
             return
 
-        storage_path = cls._getFilePath(path_id, version)
+        storage_path = cls._getItemPath(path_id, version)
 
         if os.path.exists(storage_path):  # File already exists. Check if it's the same.
             if os.path.getsize(path) != os.path.getsize(storage_path):  # As quick check if files are the same, check their file sizes.
-                raise FileExistsError(f"Central file storage already has a file with ID {path_id} and version {str(version)}, but it's different.")
-            new_file_hash = cls._hashPath(path)
-            stored_file_hash = cls._hashPath(storage_path)
+                raise FileExistsError(f"Central file storage already has an item (file or directory) with ID {path_id} and version {str(version)}, but it's different.")
+            new_file_hash = cls._hashItem(path)
+            stored_file_hash = cls._hashItem(storage_path)
             if new_file_hash != stored_file_hash:
-                raise FileExistsError(f"Central file storage already has a file with ID {path_id} and version {str(version)}, but it's different.")
+                raise FileExistsError(f"Central file storage already has an item (file or directory) with ID {path_id} and version {str(version)}, but it's different.")
             if os.path.isfile(path):
                 os.remove(path)
             elif os.path.isdir(path):
@@ -71,39 +73,40 @@ class CentralFileStorage:
             Logger.info(f"{path_id} {str(version)} was already stored centrally. Removing duplicate.")
         else:
             shutil.move(path, storage_path)
-            Logger.info(f"Storing new file {path_id} {str(version)}.")
+            Logger.info(f"Storing new item {path_id}.{str(version)}.")
 
     @classmethod
     def retrieve(cls, path_id: str, sha256_hash: str, version: Version = Version("1.0.0")) -> str:
         """
-        Retrieve the file path of a previously stored file.
-        :param path_id: The name of the file or folder to retrieve.
-        :param sha256_hash: A SHA-256 hash of the file or folder you expect to receive from the central storage.
-        :param version: The version number of the file or folder to retrieve.
-        :return: A path to the location of the centrally stored file or folder.
-        :raises FileNotFoundError: There is no file stored with that name and version.
-        :raises IOError: The hash of the file is incorrect. Opening this file could be a security risk.
+        Retrieve the path of a previously stored item (file or directory).
+        :param path_id: The name of the item (file or directory) to retrieve.
+        :param sha256_hash: A SHA-256 hash of the item (file or directory) you expect to receive from the central storage.
+        :param version: The version number of the item (file or directory) to retrieve.
+        :return: A path to the location of the centrally stored item (file or directory).
+        :raises FileNotFoundError: There is no item (file or directory) stored with that name and version.
+        :raises IOError: The hash of the item (file or directory) is incorrect. Opening this item could be a security
+        risk.
         """
-        storage_path = cls._getFilePath(path_id, version)
+        storage_path = cls._getItemPath(path_id, version)
 
         if not os.path.exists(storage_path):
-            raise FileNotFoundError(f"Central file storage doesn't have a file with ID {path_id} and version {str(version)}.")
-        stored_file_hash = cls._hashPath(storage_path)
+            raise FileNotFoundError(f"Central file storage doesn't have an item (file or directory) with ID {path_id} and version {str(version)}.")
+        stored_file_hash = cls._hashItem(storage_path)
         if stored_file_hash != sha256_hash:
-            raise IOError(f"The centrally stored file with ID {path_id} and version {str(version)} does not match with the given file hash.")
+            raise IOError(f"The centrally stored item (file or directory) with ID {path_id} and version {str(version)} does not match with the given hash.")
 
         return storage_path
 
     @classmethod
-    def _getFilePath(cls, file_id: str, version: Version) -> str:
+    def _getItemPath(cls, item_id: str, version: Version) -> str:
         """
-        Get a canonical file path for a hypothetical file with a specified ID and version.
-        :param file_id: The name of the file to get a name for.
-        :param version: The version number of the file to get a name for.
-        :return: A path to store such a file.
+        Get a canonical path for a hypothetical item (file or folder) with a specified ID and version.
+        :param item_id: The name of the item (file or directory) to get a name for.
+        :param version: The version number of the item (file or directory) to get a name for.
+        :return: A path to store such an item.
         """
-        file_name = file_id + "." + str(version)
-        return os.path.join(cls._centralStorageLocation(), file_name)
+        item_name = item_id + "." + str(version)
+        return os.path.join(cls._centralStorageLocation(), item_name)
 
     @classmethod
     def _centralStorageLocation(cls) -> str:
@@ -152,14 +155,14 @@ class CentralFileStorage:
         return hasher.hexdigest()
 
     @classmethod
-    def _hashPath(cls, path: str) -> str:
+    def _hashItem(cls, item_path: str) -> str:
         """
         Calls the hash function according to the type of the path (directory or file).
         :param path: The path that needs to be hashed.
         :return: A cryptographic hash of the specified path.
         """
-        if os.path.isdir(path):
-            return cls._hashDirectory(path)
-        elif os.path.isfile(path):
-            return cls._hashFile(path)
-        raise FileNotFoundError(f"The specified path '{path}' was neither a file nor a directory.")
+        if os.path.isdir(item_path):
+            return cls._hashDirectory(item_path)
+        elif os.path.isfile(item_path):
+            return cls._hashFile(item_path)
+        raise FileNotFoundError(f"The specified item '{item_path}' was neither a file nor a directory.")

--- a/UM/CentralFileStorage.py
+++ b/UM/CentralFileStorage.py
@@ -5,6 +5,7 @@ import hashlib  # To generate cryptographic hashes of files.
 import os  # To remove duplicate files.
 import os.path  # To re-format files with their proper file extension but with a version number in between.
 import shutil  # To move files in constant-time.
+from typing import List, Tuple
 
 from UM.Logger import Logger
 from UM.Resources import Resources  # To get the central storage location.
@@ -34,7 +35,7 @@ class CentralFileStorage:
     """
 
     @classmethod
-    def store(cls, file_path: str, file_id: str, version: Version = Version("1.0.0")) -> None:
+    def store(cls, path: str, path_id: str, version: Version = Version("1.0.0")) -> None:
         """
         Store a new file into the central file storage. This file will get moved to a storage location that is not
         specific to this version of the application.
@@ -42,51 +43,54 @@ class CentralFileStorage:
         If the file already exists, this will check if it's the same file. If the file is not the same, it raises a
         `FileExistsError`. If the file is the same, no error is raised and the file to store is simply deleted. It is a
         duplicate of the file already stored.
-        :param file_path: The path to the file to store in the central file storage.
-        :param file_id: A name for the file to store.
+        :param path: The path to the file to store in the central file storage.
+        :param path_id: A name for the file to store.
         :param version: A version number for the file.
         :raises FileExistsError: There is already a centrally stored file with that name and version, but it's
         different.
         """
         if not os.path.exists(cls._centralStorageLocation()):
             os.makedirs(cls._centralStorageLocation())
-        if not os.path.exists(file_path):
-            Logger.debug(f"{file_id} {str(version)} was already stored centrally or the provided file_path is not correct")
+        if not os.path.exists(path):
+            Logger.debug(f"{path_id} {str(version)} was already stored centrally or the provided file_path is not correct")
             return
 
-        storage_path = cls._getFilePath(file_id, version)
+        storage_path = cls._getFilePath(path_id, version)
 
         if os.path.exists(storage_path):  # File already exists. Check if it's the same.
-            if os.path.getsize(file_path) != os.path.getsize(storage_path):  # As quick check if files are the same, check their file sizes.
-                raise FileExistsError(f"Central file storage already has a file with ID {file_id} and version {str(version)}, but it's different.")
-            new_file_hash = cls._hashFile(file_path)
-            stored_file_hash = cls._hashFile(storage_path)
+            if os.path.getsize(path) != os.path.getsize(storage_path):  # As quick check if files are the same, check their file sizes.
+                raise FileExistsError(f"Central file storage already has a file with ID {path_id} and version {str(version)}, but it's different.")
+            new_file_hash = cls._hashPath(path)
+            stored_file_hash = cls._hashPath(storage_path)
             if new_file_hash != stored_file_hash:
-                raise FileExistsError(f"Central file storage already has a file with ID {file_id} and version {str(version)}, but it's different.")
-            os.remove(file_path)
-            Logger.info(f"{file_id} {str(version)} was already stored centrally. Removing duplicate.")
+                raise FileExistsError(f"Central file storage already has a file with ID {path_id} and version {str(version)}, but it's different.")
+            if os.path.isfile(path):
+                os.remove(path)
+            elif os.path.isdir(path):
+                shutil.rmtree(path)
+            Logger.info(f"{path_id} {str(version)} was already stored centrally. Removing duplicate.")
         else:
-            shutil.move(file_path, storage_path)
-            Logger.info(f"Storing new file {file_id} {str(version)}.")
+            shutil.move(path, storage_path)
+            Logger.info(f"Storing new file {path_id} {str(version)}.")
 
     @classmethod
-    def retrieve(cls, file_id: str, sha256_hash: str, version: Version = Version("1.0.0")) -> str:
+    def retrieve(cls, path_id: str, sha256_hash: str, version: Version = Version("1.0.0")) -> str:
         """
         Retrieve the file path of a previously stored file.
-        :param file_id: The name of the file to retrieve.
-        :param sha256_hash: A SHA-256 hash of the file you expect to receive from the central storage.
-        :param version: The version number of the file to retrieve.
-        :return: A path to the location of the centrally stored file.
+        :param path_id: The name of the file or folder to retrieve.
+        :param sha256_hash: A SHA-256 hash of the file or folder you expect to receive from the central storage.
+        :param version: The version number of the file or folder to retrieve.
+        :return: A path to the location of the centrally stored file or folder.
         :raises FileNotFoundError: There is no file stored with that name and version.
         :raises IOError: The hash of the file is incorrect. Opening this file could be a security risk.
         """
-        storage_path = cls._getFilePath(file_id, version)
+        storage_path = cls._getFilePath(path_id, version)
 
         if not os.path.exists(storage_path):
-            raise FileNotFoundError(f"Central file storage doesn't have a file with ID {file_id} and version {str(version)}.")
-        stored_file_hash = cls._hashFile(storage_path)
+            raise FileNotFoundError(f"Central file storage doesn't have a file with ID {path_id} and version {str(version)}.")
+        stored_file_hash = cls._hashPath(storage_path)
         if stored_file_hash != sha256_hash:
-            raise IOError(f"The centrally stored file with ID {file_id} and version {str(version)} does not match with the given file hash.")
+            raise IOError(f"The centrally stored file with ID {path_id} and version {str(version)} does not match with the given file hash.")
 
         return storage_path
 
@@ -124,3 +128,38 @@ class CentralFileStorage:
                 hasher.update(contents)
                 contents = f.read(block_size)
         return hasher.hexdigest()
+
+    @classmethod
+    def _hashDirectory(cls, directory: str) -> str:
+        """
+        Returns a SHA-256 hash of the specified directory.
+        :param directory: The path to a directory to get the hash of.
+        :return: A cryptographic hash of the specified directory.
+        """
+        hash_list: List[Tuple[str, str]] = []  # Contains a list of (relative_file_path, hash) tuples
+        for root, _, filenames in os.walk(directory):
+            for filename in filenames:
+                rel_dir_path = os.path.relpath(root, directory)
+                rel_path = os.path.join(rel_dir_path, filename)
+                abs_path = os.path.join(root, filename)
+                hash_list.append((rel_path, cls._hashFile(abs_path)))
+
+        ordered_list = sorted(hash_list, key = lambda x: x[0])
+
+        hasher = hashlib.sha256()
+        for i in ordered_list:
+            hasher.update("".join(i).encode('utf-8'))
+        return hasher.hexdigest()
+
+    @classmethod
+    def _hashPath(cls, path: str) -> str:
+        """
+        Calls the hash function according to the type of the path (directory or file).
+        :param path: The path that needs to be hashed.
+        :return: A cryptographic hash of the specified path.
+        """
+        if os.path.isdir(path):
+            return cls._hashDirectory(path)
+        elif os.path.isfile(path):
+            return cls._hashFile(path)
+        raise FileNotFoundError(f"The specified path '{path}' was neither a file nor a directory.")

--- a/UM/Trust.py
+++ b/UM/Trust.py
@@ -453,14 +453,16 @@ class Trust:
                     for entry in storage_json:
                         try:
                             # If this doesn't raise an exception, it's correct.
-                            CentralFileStorage.retrieve(entry[1], entry[3], Version(entry[2]))
+                            central_storage_path = CentralFileStorage.retrieve(entry[1], entry[3], Version(entry[2]))
+
+                            # If a directory was moved, add all the files in that directory to the file_count. For
+                            # individual files mentioned in the central_storage.json increment the file_count by 1.
+                            if os.path.isdir(central_storage_path):
+                                file_count += sum([len(files) for _, _, files in os.walk(central_storage_path)])
+                            elif os.path.isfile(central_storage_path):
+                                file_count += 1
                         except (EnvironmentError, IOError):
                             self._violation_handler(f"Centrally stored file '{entry[1]}' didn't match with checksum or it could not be found")
-
-                # A number of files have been moved to the storage.
-                # This is allowed, so we should accept that.
-                if storage_json:
-                    file_count += len(storage_json)
 
                 # The number of correctly signed files should be the same as the number of signatures:
                 if len(signatures_json.keys()) != file_count:


### PR DESCRIPTION
Plugins that make use of the central storage can now move an entire folder without having to mention each and every file in their `central_storage.json`. So now, when an entire folder is move, the `central_storage.json` can look like this:

```json
[
    [
        "my_folder",
        "my_folder",
        "1.0.0",
        "aa9125bc0121eaaa09125989832532c9c718a9b9e9ddd123"
    ]
]
```

CURA-8261