### PR TITLE
CURA-8291: Verbose plugin loading on startup

### DIFF
--- a/UM/CentralFileStorage.py
+++ b/UM/CentralFileStorage.py
@@ -6,6 +6,7 @@ import os  # To remove duplicate files.
 import os.path  # To re-format files with their proper file extension but with a version number in between.
 import shutil  # To move files in constant-time.
 from typing import List, Tuple, Dict
+from PyQt5.QtCore import QCoreApplication
 
 from UM.Logger import Logger
 from UM.Resources import Resources  # To get the central storage location.
@@ -148,6 +149,7 @@ class CentralFileStorage:
             while len(contents) > 0:
                 hasher.update(contents)
                 contents = f.read(block_size)
+        QCoreApplication.processEvents()  # Process events to allow the interface to update
         return hasher.hexdigest()
 
     @classmethod

--- a/UM/CentralFileStorage.py
+++ b/UM/CentralFileStorage.py
@@ -41,6 +41,8 @@ class CentralFileStorage:
     # In order to ensure that the same API can still be used, we store those situations.
     _unmoved_files = {}  # type: Dict[str, str]
 
+    _is_enterprise_version = False
+
     @classmethod
     def store(cls, path: str, path_id: str, version: Version = Version("1.0.0"), move_file: bool = True) -> None:
         """
@@ -110,9 +112,11 @@ class CentralFileStorage:
 
         if not os.path.exists(storage_path):
             raise FileNotFoundError(f"Central file storage doesn't have an item (file or directory) with ID {path_id} and version {str(version)}.")
-        stored_file_hash = cls._hashItem(storage_path)
-        if stored_file_hash != sha256_hash:
-            raise IOError(f"The centrally stored item (file or directory) with ID {path_id} and version {str(version)} does not match with the given hash.")
+
+        if cls._is_enterprise_version:
+            stored_file_hash = cls._hashItem(storage_path)
+            if stored_file_hash != sha256_hash:
+                raise IOError(f"The centrally stored item (file or directory) with ID {path_id} and version {str(version)} does not match with the given hash.")
 
         return storage_path
 
@@ -186,3 +190,7 @@ class CentralFileStorage:
         elif os.path.isfile(item_path):
             return cls._hashFile(item_path)
         raise FileNotFoundError(f"The specified item '{item_path}' was neither a file nor a directory.")
+
+    @classmethod
+    def setIsEnterprise(cls, is_enterprise: bool) -> None:
+        cls._is_enterprise_version = is_enterprise

--- a/UM/PackageManager.py
+++ b/UM/PackageManager.py
@@ -10,7 +10,7 @@ import zipfile
 from json import JSONDecodeError
 from typing import Any, Dict, List, Optional, Set, Tuple, cast, TYPE_CHECKING
 
-from PyQt5.QtCore import pyqtSlot, QObject, pyqtSignal, QUrl, pyqtProperty
+from PyQt5.QtCore import pyqtSlot, QObject, pyqtSignal, QUrl, pyqtProperty, QCoreApplication
 
 from UM import i18nCatalog
 from UM.Logger import Logger
@@ -294,6 +294,7 @@ class PackageManager(QObject):
     def _installAllScheduledPackages(self) -> None:
         while self._to_install_package_dict:
             package_id, package_info = list(self._to_install_package_dict.items())[0]
+            self._application.showSplashMessage(f"{catalog.i18nc('@info:progress', 'Unpacking plugin')} {package_id}...")
             self._installPackage(package_info)
             del self._to_install_package_dict[package_id]
             self._saveManagementData()
@@ -549,8 +550,11 @@ class PackageManager(QObject):
             return
         try:
             with zipfile.ZipFile(filename, "r") as archive:
+                name_list = archive.namelist()
                 temp_dir = tempfile.TemporaryDirectory()
-                archive.extractall(temp_dir.name)
+                for archive_filename in name_list:
+                    archive.extract(archive_filename, temp_dir.name)
+                    QCoreApplication.processEvents()
         except Exception:
             Logger.logException("e", "Failed to install package from file [%s]", filename)
             return

--- a/UM/PackageManager.py
+++ b/UM/PackageManager.py
@@ -294,7 +294,8 @@ class PackageManager(QObject):
     def _installAllScheduledPackages(self) -> None:
         while self._to_install_package_dict:
             package_id, package_info = list(self._to_install_package_dict.items())[0]
-            self._application.showSplashMessage(f"{catalog.i18nc('@info:progress', 'Unpacking plugin')} {package_id}...")
+            installing_plugin_msg = catalog.i18nc("@info:progress Don't translate {package_id}", "Installing plugin {package_id}...").format(package_id = package_id)
+            self._application.showSplashMessage(installing_plugin_msg)
             self._installPackage(package_info)
             del self._to_install_package_dict[package_id]
             self._saveManagementData()

--- a/UM/PluginRegistry.py
+++ b/UM/PluginRegistry.py
@@ -354,7 +354,7 @@ class PluginRegistry(QObject):
 
     # Indicates that a specific plugin is currently being loaded. If the plugin_id is empty, it means that no plugin
     # is currently being loaded.
-    pluginLoadingInProgress = pyqtSignal(str, arguments = ["plugin_id"])
+    pluginLoadStarted = pyqtSignal(str, arguments = ["plugin_id"])
 
     def loadPlugins(self, metadata: Optional[Dict[str, Any]] = None) -> None:
         """Load all plugins matching a certain set of metadata
@@ -375,7 +375,7 @@ class PluginRegistry(QObject):
             if plugin_id in self.preloaded_plugins:
                 continue  # Already loaded this before.
 
-            self.pluginLoadingInProgress.emit(plugin_id)
+            self.pluginLoadStarted.emit(plugin_id)
 
             # Get the plugin metadata:
             try:
@@ -400,7 +400,7 @@ class PluginRegistry(QObject):
                 except PluginNotFoundError:
                     pass
 
-        self.pluginLoadingInProgress.emit("")
+        self.pluginLoadStarted.emit("")
         Logger.log("d", "Loading all plugins took %s seconds", time.time() - start_time)
 
     # Checks if the given plugin API version is compatible with the current version.

--- a/UM/PluginRegistry.py
+++ b/UM/PluginRegistry.py
@@ -352,6 +352,10 @@ class PluginRegistry(QObject):
         self._bundled_plugin_cache[plugin_id] = is_bundled
         return is_bundled
 
+    # Indicates that a specific plugin is currently being loaded. If the plugin_id is empty, it means that no plugin
+    # is currently being loaded.
+    pluginLoadingInProgress = pyqtSignal(str, arguments = ["plugin_id"])
+
     def loadPlugins(self, metadata: Optional[Dict[str, Any]] = None) -> None:
         """Load all plugins matching a certain set of metadata
 
@@ -370,6 +374,8 @@ class PluginRegistry(QObject):
         for plugin_id in plugin_ids:
             if plugin_id in self.preloaded_plugins:
                 continue  # Already loaded this before.
+
+            self.pluginLoadingInProgress.emit(plugin_id)
 
             # Get the plugin metadata:
             try:
@@ -393,6 +399,8 @@ class PluginRegistry(QObject):
                     self._plugins_installed.append(plugin_id)
                 except PluginNotFoundError:
                     pass
+
+        self.pluginLoadingInProgress.emit("")
         Logger.log("d", "Loading all plugins took %s seconds", time.time() - start_time)
 
     # Checks if the given plugin API version is compatible with the current version.

--- a/UM/Qt/QtApplication.py
+++ b/UM/Qt/QtApplication.py
@@ -186,6 +186,12 @@ class QtApplication(QApplication, Application):
         Logger.log("i", "Initializing version upgrade manager ...")
         self._version_upgrade_manager = VersionUpgradeManager(self)
 
+    def _displayLoadingPluginSplashMessage(self, plugin_id: Optional[str]) -> None:
+        message = i18nCatalog("uranium").i18nc("@info:progress", "Loading plugins...")
+        if plugin_id:
+            message = f"{i18nCatalog('uranium').i18nc('@info:progress', 'Loading plugin')} {plugin_id}..."
+        self.showSplashMessage(message)
+
     def startSplashWindowPhase(self) -> None:
         super().startSplashWindowPhase()
         i18n_catalog = i18nCatalog("uranium")
@@ -205,7 +211,9 @@ class QtApplication(QApplication, Application):
         self.showSplashMessage(i18n_catalog.i18nc("@info:progress", "Loading plugins..."))
         # Remove and install the plugins that have been scheduled
         self._plugin_registry.initializeBeforePluginsAreLoaded()
+        self._plugin_registry.pluginLoadingInProgress.connect(self._displayLoadingPluginSplashMessage)
         self._loadPlugins()
+        self._plugin_registry.pluginLoadingInProgress.disconnect(self._displayLoadingPluginSplashMessage)
         self._plugin_registry.checkRequiredPlugins(self.getRequiredPlugins())
         self.pluginsLoaded.emit()
 

--- a/UM/Qt/QtApplication.py
+++ b/UM/Qt/QtApplication.py
@@ -189,7 +189,7 @@ class QtApplication(QApplication, Application):
     def _displayLoadingPluginSplashMessage(self, plugin_id: Optional[str]) -> None:
         message = i18nCatalog("uranium").i18nc("@info:progress", "Loading plugins...")
         if plugin_id:
-            message = f"{i18nCatalog('uranium').i18nc('@info:progress', 'Loading plugin')} {plugin_id}..."
+            message = i18nCatalog("uranium").i18nc("@info:progress", "Loading plugin {plugin_id}...").format(plugin_id = plugin_id)
         self.showSplashMessage(message)
 
     def startSplashWindowPhase(self) -> None:
@@ -211,9 +211,9 @@ class QtApplication(QApplication, Application):
         self.showSplashMessage(i18n_catalog.i18nc("@info:progress", "Loading plugins..."))
         # Remove and install the plugins that have been scheduled
         self._plugin_registry.initializeBeforePluginsAreLoaded()
-        self._plugin_registry.pluginLoadingInProgress.connect(self._displayLoadingPluginSplashMessage)
+        self._plugin_registry.pluginLoadStarted.connect(self._displayLoadingPluginSplashMessage)
         self._loadPlugins()
-        self._plugin_registry.pluginLoadingInProgress.disconnect(self._displayLoadingPluginSplashMessage)
+        self._plugin_registry.pluginLoadStarted.disconnect(self._displayLoadingPluginSplashMessage)
         self._plugin_registry.checkRequiredPlugins(self.getRequiredPlugins())
         self.pluginsLoaded.emit()
 

--- a/tests/TestCentralFileStorage.py
+++ b/tests/TestCentralFileStorage.py
@@ -91,10 +91,11 @@ def test_retrieveNonExistent():
     with unittest.mock.patch("UM.Resources.Resources.getDataStoragePath", lambda: "test_central_storage/4.9"):
         pytest.raises(FileNotFoundError, lambda: CentralFileStorage.retrieve("non_existent_file", "0123456789ABCDEF"))
 
-def test_retrieveWrongHash():
+def test_retrieveWrongHashOnEnterprise():
     """
     Tests retrieving a file that has a wrong hash.
     """
     with unittest.mock.patch("UM.Resources.Resources.getDataStoragePath", lambda: "test_central_storage/4.9"):
+        CentralFileStorage.setIsEnterprise(True)
         CentralFileStorage.store(TEST_FILE_PATH, "myfile")
         pytest.raises(IOError, lambda: CentralFileStorage.retrieve("myfile", TEST_FILE_HASH2))


### PR DESCRIPTION
This PR changes the following:

- To make sure that the splash screen's loading wheel is not stuck while plugins are being unpacked, the unzipping of a downloaded plugin by the PackageManager now happens file-by-file. After each extracted file, the package manager calls the `processEvents()` function, which ensures that the interface gets updated (and the loading wheel keeps turning instead of getting stuck).
- Same thing now happens while the CentralFileStorage is hashing files, because hashing can take a long time and give the idea that the splash screen is stuck.
- The splash screen now displays a message regarding which plugin is currently being unpacked and which plugin is being loaded. This way big plugins don't give the idea that the startup is stuck.

Requires https://github.com/Ultimaker/Cura/pull/9948.


CURA-8291