### PR TITLE
CURA-7278: Differentiate warning messages in cura

### DIFF
--- a/UM/Message.py
+++ b/UM/Message.py
@@ -22,9 +22,15 @@ class Message(QObject):
         ALIGN_LEFT = 2
         ALIGN_RIGHT = 3
 
+    class MessageType:
+        CONFIRMATION = 0
+        INFORMATION = 1
+        WARNING = 2
+        FAILURE = 3
+
     def __init__(self, text: str = "", lifetime: int = 30, dismissable: bool = True, progress: float = None,
                  title: Optional[str] = None, parent=None, use_inactivity_timer: bool = True, image_source: str = "",
-                 image_caption: str = "", option_text: str = "", option_state: bool = True) -> None:
+                 image_caption: str = "", option_text: str = "", option_state: bool = True, message_type: int = MessageType.INFORMATION) -> None:
 
         """Class for displaying messages to the user.
         Even though the lifetime can be set, in certain cases it can still have a lifetime if nothing happens with the
@@ -75,6 +81,8 @@ class Message(QObject):
 
         self._actions = []  # type: List[Dict[str, Union[str, int]]]
         self._title = title
+
+        self._message_type = message_type
 
         self.actionTriggered.connect(self._onActionTriggered)
 
@@ -195,6 +203,14 @@ class Message(QObject):
 
     def getImageCaption(self) -> str:
         return self._image_caption
+
+    def getMessageType(self) -> int:
+        """
+        Gets the type of the message.
+        The message gets a different icon according to its type.
+        :return: The type of the message (CONFIRMATION, INFORMATION, WARNING, FAILURE)
+        """
+        return self._message_type
 
     def setText(self, text: str) -> None:
         """Changes the text on the message.

--- a/UM/Message.py
+++ b/UM/Message.py
@@ -12,7 +12,6 @@ from UM.Signal import Signal, signalemitter
 class Message(QObject):
     """Class for displaying messages to the user."""
 
-
     class ActionButtonStyle:
         DEFAULT = 0
         LINK = 1
@@ -23,14 +22,14 @@ class Message(QObject):
         ALIGN_RIGHT = 3
 
     class MessageType:
-        CONFIRMATION = 0
-        INFORMATION = 1
+        POSITIVE = 0
+        NEUTRAL = 1
         WARNING = 2
-        FAILURE = 3
+        ERROR = 3
 
     def __init__(self, text: str = "", lifetime: int = 30, dismissable: bool = True, progress: float = None,
                  title: Optional[str] = None, parent=None, use_inactivity_timer: bool = True, image_source: str = "",
-                 image_caption: str = "", option_text: str = "", option_state: bool = True, message_type: int = MessageType.INFORMATION) -> None:
+                 image_caption: str = "", option_text: str = "", option_state: bool = True, message_type: int = MessageType.NEUTRAL) -> None:
 
         """Class for displaying messages to the user.
         Even though the lifetime can be set, in certain cases it can still have a lifetime if nothing happens with the
@@ -208,7 +207,7 @@ class Message(QObject):
         """
         Gets the type of the message.
         The message gets a different icon according to its type.
-        :return: The type of the message (CONFIRMATION, INFORMATION, WARNING, FAILURE)
+        :return: The type of the message (POSITIVE, NEUTRAL, WARNING, ERROR)
         """
         return self._message_type
 

--- a/UM/Message.py
+++ b/UM/Message.py
@@ -51,9 +51,9 @@ class Message(QObject):
         really, it's up to the QML to handle that).
         :param progress: Is there any progress to be displayed? if -1, it's seen
         as indeterminate.
-        :param message_type: Defines the type of message (POSITIVE, NEUTRAL, WARNING, ERROR, default: NEUTRAL).
-                            According to the type, an icon appears next to the message title. The NEUTRAL messages
-                            contain no icon.
+        :param message_type: Defines the type of message according to the MessageType enum (POSITIVE, NEUTRAL, WARNING,
+        ERROR, default: NEUTRAL). Depending on the type, an icon appears next to the message title. The NEUTRAL messages
+        contain no icon.
         """
 
         super().__init__(parent)

--- a/UM/Message.py
+++ b/UM/Message.py
@@ -43,7 +43,7 @@ class Message(QObject):
         :param text: Text that needs to be displayed in the message
         :param lifetime: How long should the message be displayed (in seconds).
             if lifetime is 0, it will never automatically be destroyed.
-        :param dismissible: Can the user dismiss the message?
+        :param dismissable: Can the user dismiss the message?
         :param title: Phrase that will be shown above the message.
         :param image_source: an absolute path where an image can be found to be
         displayed (QUrl.toLocalFile()) can be used for that.
@@ -51,6 +51,9 @@ class Message(QObject):
         really, it's up to the QML to handle that).
         :param progress: Is there any progress to be displayed? if -1, it's seen
         as indeterminate.
+        :param message_type: Defines the type of message (POSITIVE, NEUTRAL, WARNING, ERROR, default: NEUTRAL).
+                            According to the type, an icon appears next to the message title. The NEUTRAL messages
+                            contain no icon.
         """
 
         super().__init__(parent)

--- a/UM/Qt/Bindings/VisibleMessagesModel.py
+++ b/UM/Qt/Bindings/VisibleMessagesModel.py
@@ -23,6 +23,7 @@ class VisibleMessagesModel(ListModel):
     ImageCaptionRole = Qt.UserRole + 12
     OptionTextRole = Qt.UserRole + 13
     OptionStateRole = Qt.UserRole + 14
+    MessageTypeRole = Qt.UserRole + 15
 
     def __init__(self, parent=None):
         super().__init__(parent)
@@ -39,6 +40,7 @@ class VisibleMessagesModel(ListModel):
         self.addRoleName(self.ImageCaptionRole, "image_caption")
         self.addRoleName(self.OptionTextRole, "option_text")
         self.addRoleName(self.OptionStateRole, "option_state")
+        self.addRoleName(self.MessageTypeRole, "message_type")
         self._populateMessageList()
 
     def _populateMessageList(self):
@@ -57,7 +59,8 @@ class VisibleMessagesModel(ListModel):
             "image_source": message.getImageSource(),
             "image_caption": message.getImageCaption(),
             "option_text": message.getOptionText(),
-            "option_state": message.getOptionState()
+            "option_state": message.getOptionState(),
+            "message_type": message.getMessageType()
         })
         message.titleChanged.connect(self._onMessageTitleChanged)
         message.textChanged.connect(self._onMessageTextChanged)

--- a/UM/Qt/qml/UM/MessageStack.qml
+++ b/UM/Qt/qml/UM/MessageStack.qml
@@ -79,7 +79,7 @@ ListView
         border.color: UM.Theme.getColor("message_border")
         radius: UM.Theme.getSize("message_radius").width
 
-        Item
+        Row
         {
             id: titleBar
 
@@ -91,7 +91,117 @@ ListView
                 margins: UM.Theme.getSize("default_margin").width
             }
 
-            height: childrenRect.height
+            height: messageTypeIcon.height
+            Item
+            {
+                id: messageTypeIcon
+                visible: model.progress == null
+                height: UM.Theme.getSize("small_button_icon").height
+                width: visible ? UM.Theme.getSize("small_button_icon").height : 0
+                Rectangle
+                {
+                    id: messageIconBackground
+                    height: parent.height
+                    width: parent.width
+                    radius: Math.round(width / 2)
+                }
+                UM.RecolorImage
+                {
+                    id: messageIcon
+                    height: parent.height
+                    width: parent.width
+                    sourceSize.width: width
+                    sourceSize.height: height
+                }
+
+                states:
+                        [
+                            State
+                            {
+                                name: "positive"
+                                when: model.message_type == 0
+                                PropertyChanges
+                                {
+                                    target: messageIcon
+                                    source: UM.Theme.getIcon("Check", "low")
+                                    color: UM.Theme.getColor("message_success_icon")
+                                }
+                                PropertyChanges
+                                {
+                                    target: messageIconBackground
+                                    color: UM.Theme.getColor("message_success_background")
+                                }
+                            },
+                            State
+                            {
+                                name: "neutral"
+                                when: model.message_type == 1
+                                PropertyChanges
+                                {
+                                    target: messageIcon
+                                    source: ""
+                                }
+                                PropertyChanges
+                                {
+                                    target: messageIconBackground
+                                    color: "transparent"
+                                }
+                                PropertyChanges
+                                {
+                                    target: messageTypeIcon
+                                    visible: false
+                                }
+                            },
+                            State
+                            {
+                                name: "warning"
+                                when: model.message_type == 2
+                                PropertyChanges
+                                {
+                                    target: messageIcon
+                                    source: UM.Theme.getIcon("Warning", "low")
+                                    color: UM.Theme.getColor("message_warning_icon")
+                                }
+                                PropertyChanges
+                                {
+                                    target: messageIconBackground
+                                    color: UM.Theme.getColor("message_warning_background")
+                                }
+                            },
+                            State
+                            {
+                                name: "error"
+                                when: model.message_type == 3
+                                PropertyChanges
+                                {
+                                    target: messageIcon
+                                    source: UM.Theme.getIcon("Cancel", "low")
+                                    color: UM.Theme.getColor("message_error_icon")
+                                }
+                                PropertyChanges
+                                {
+                                    target: messageIconBackground
+                                    color: UM.Theme.getColor("message_error_background")
+                                }
+                            }
+                        ]
+            }
+
+
+            Label
+            {
+                id: messageTitle
+                width: parent.width - x
+                anchors.verticalCenter: parent.verticalCenter
+
+                text: model.title == undefined ? "" : model.title
+                color: UM.Theme.getColor("text")
+                font: UM.Theme.getFont("default_bold")
+                wrapMode: Text.WordWrap
+                elide: Text.ElideRight
+                maximumLineCount: 2
+                renderType: Text.NativeRendering
+            }
 
             Button
             {
@@ -99,7 +209,7 @@ ListView
                 width: UM.Theme.getSize("message_close").width
                 height: UM.Theme.getSize("message_close").height
 
-                anchors.right: parent.right
+                anchors.verticalCenter: parent.verticalCenter
 
                 style: ButtonStyle
                 {
@@ -117,118 +227,6 @@ ListView
                 onClicked: base.model.hideMessage(model.id)
                 visible: model.dismissable
                 enabled: model.dismissable
-            }
-            Row
-            {
-            
-            }
-            Rectangle
-            {
-                id: messageIconBackground
-                anchors.verticalCenter: messageTitle.verticalCenter
-                anchors.left: parent.left
-                visible: model.progress == null
-                height: visible ? UM.Theme.getSize("small_button_icon").height : 0
-                width: height
-                radius: Math.round(width / 2)
-            }
-            UM.RecolorImage
-            {
-                id: messageTypeIcon
-                visible: messageIconBackground.visible
-                anchors.centerIn: messageIconBackground
-                height: messageIconBackground.height
-                width: height
-                sourceSize.width: width
-                sourceSize.height: height
-            }
-
-            states:
-                    [
-                        State
-                        {
-                            name: "positive"
-                            when: model.message_type == 0
-                            PropertyChanges
-                            {
-                                target: messageTypeIcon
-                                source: UM.Theme.getIcon("Check", "low")
-                                color: UM.Theme.getColor("message_success_icon")
-                            }
-                            PropertyChanges
-                            {
-                                target: messageIconBackground
-                                color: UM.Theme.getColor("message_success_background")
-                            }
-                        },
-                        State
-                        {
-                            name: "neutral"
-                            when: model.message_type == 1
-                            PropertyChanges
-                            {
-                                target: messageTypeIcon
-                                source: ""
-                            }
-                            PropertyChanges
-                            {
-                                target: messageIconBackground
-                                color: "transparent"
-                                visible: false
-                            }
-                        },
-                        State
-                        {
-                            name: "warning"
-                            when: model.message_type == 2
-                            PropertyChanges
-                            {
-                                target: messageTypeIcon
-                                source: UM.Theme.getIcon("Warning", "low")
-                                color: UM.Theme.getColor("message_warning_icon")
-                            }
-                            PropertyChanges
-                            {
-                                target: messageIconBackground
-                                color: UM.Theme.getColor("message_warning_background")
-                            }
-                        },
-                        State
-                        {
-                            name: "error"
-                            when: model.message_type == 3
-                            PropertyChanges
-                            {
-                                target: messageTypeIcon
-                                source: UM.Theme.getIcon("Cancel", "low")
-                                color: UM.Theme.getColor("message_error_icon")
-                            }
-                            PropertyChanges
-                            {
-                                target: messageIconBackground
-                                color: UM.Theme.getColor("message_error_background")
-                            }
-                        }
-                    ]
-
-            Label
-            {
-                id: messageTitle
-
-                anchors
-                {
-                    left: messageTypeIcon.right
-                    right: closeButton.left
-                    rightMargin: UM.Theme.getSize("default_margin").width
-                }
-
-                text: model.title == undefined ? "" : model.title
-                color: UM.Theme.getColor("text")
-                font: UM.Theme.getFont("default_bold")
-                wrapMode: Text.WordWrap
-                elide: Text.ElideRight
-                maximumLineCount: 2
-                renderType: Text.NativeRendering
             }
         }
         Item

--- a/UM/Qt/qml/UM/MessageStack.qml
+++ b/UM/Qt/qml/UM/MessageStack.qml
@@ -117,76 +117,76 @@ ListView
                 }
 
                 states:
-                        [
-                            State
-                            {
-                                name: "positive"
-                                when: model.message_type == 0
-                                PropertyChanges
-                                {
-                                    target: messageIcon
-                                    source: UM.Theme.getIcon("Check", "low")
-                                    color: UM.Theme.getColor("message_success_icon")
-                                }
-                                PropertyChanges
-                                {
-                                    target: messageIconBackground
-                                    color: UM.Theme.getColor("message_success_background")
-                                }
-                            },
-                            State
-                            {
-                                name: "neutral"
-                                when: model.message_type == 1
-                                PropertyChanges
-                                {
-                                    target: messageIcon
-                                    source: ""
-                                }
-                                PropertyChanges
-                                {
-                                    target: messageIconBackground
-                                    color: "transparent"
-                                }
-                                PropertyChanges
-                                {
-                                    target: messageTypeIcon
-                                    visible: false
-                                }
-                            },
-                            State
-                            {
-                                name: "warning"
-                                when: model.message_type == 2
-                                PropertyChanges
-                                {
-                                    target: messageIcon
-                                    source: UM.Theme.getIcon("Warning", "low")
-                                    color: UM.Theme.getColor("message_warning_icon")
-                                }
-                                PropertyChanges
-                                {
-                                    target: messageIconBackground
-                                    color: UM.Theme.getColor("message_warning_background")
-                                }
-                            },
-                            State
-                            {
-                                name: "error"
-                                when: model.message_type == 3
-                                PropertyChanges
-                                {
-                                    target: messageIcon
-                                    source: UM.Theme.getIcon("Cancel", "low")
-                                    color: UM.Theme.getColor("message_error_icon")
-                                }
-                                PropertyChanges
-                                {
-                                    target: messageIconBackground
-                                    color: UM.Theme.getColor("message_error_background")
-                                }
-                            }
-                        ]
+                [
+                    State
+                    {
+                        name: "positive"
+                        when: model.message_type == 0
+                        PropertyChanges
+                        {
+                            target: messageIcon
+                            source: UM.Theme.getIcon("Check", "low")
+                            color: UM.Theme.getColor("message_success_icon")
+                        }
+                        PropertyChanges
+                        {
+                            target: messageIconBackground
+                            color: UM.Theme.getColor("message_success_background")
+                        }
+                    },
+                    State
+                    {
+                        name: "neutral"
+                        when: model.message_type == 1
+                        PropertyChanges
+                        {
+                            target: messageIcon
+                            source: ""
+                        }
+                        PropertyChanges
+                        {
+                            target: messageIconBackground
+                            color: "transparent"
+                        }
+                        PropertyChanges
+                        {
+                            target: messageTypeIcon
+                            visible: false
+                        }
+                    },
+                    State
+                    {
+                        name: "warning"
+                        when: model.message_type == 2
+                        PropertyChanges
+                        {
+                            target: messageIcon
+                            source: UM.Theme.getIcon("Warning", "low")
+                            color: UM.Theme.getColor("message_warning_icon")
+                        }
+                        PropertyChanges
+                        {
+                            target: messageIconBackground
+                            color: UM.Theme.getColor("message_warning_background")
+                        }
+                    },
+                    State
+                    {
+                        name: "error"
+                        when: model.message_type == 3
+                        PropertyChanges
+                        {
+                            target: messageIcon
+                            source: UM.Theme.getIcon("Cancel", "low")
+                            color: UM.Theme.getColor("message_error_icon")
+                        }
+                        PropertyChanges
+                        {
+                            target: messageIconBackground
+                            color: UM.Theme.getColor("message_error_background")
+                        }
+                    }
+                ]
             }
 
 

--- a/UM/Qt/qml/UM/MessageStack.qml
+++ b/UM/Qt/qml/UM/MessageStack.qml
@@ -97,15 +97,16 @@ ListView
             {
                 id: messageTypeIcon
                 visible: messageIcon.source != ""
-                height: UM.Theme.getSize("message_type_icon").height
+                height: visible ? UM.Theme.getSize("message_type_icon").height: 0
                 width: visible ? UM.Theme.getSize("message_type_icon").height : 0
-                anchors.verticalCenter: parent.verticalCenter
-                Rectangle
+                UM.RecolorImage
                 {
                     id: messageIconBackground
                     height: parent.height
                     width: parent.width
-                    radius: Math.round(width / 2)
+                    sourceSize.width: width
+                    sourceSize.height: height
+                    source: UM.Theme.getIcon("CircleSolid", "low")
                 }
                 UM.RecolorImage
                 {
@@ -191,7 +192,6 @@ ListView
                 // Account for the left and right margins of the titleBar since they are not automatically accounted
                 // for using the width - x
                 Layout.fillWidth: true
-                anchors.verticalCenter: parent.verticalCenter
 
                 text: model.title == undefined ? "" : model.title
                 color: UM.Theme.getColor("text")
@@ -207,6 +207,7 @@ ListView
                 id: closeButton
                 implicitWidth: UM.Theme.getSize("message_close").width
                 implicitHeight: UM.Theme.getSize("message_close").height
+                Layout.alignment: Qt.AlignTop
 
                 style: ButtonStyle
                 {

--- a/UM/Qt/qml/UM/MessageStack.qml
+++ b/UM/Qt/qml/UM/MessageStack.qml
@@ -79,7 +79,7 @@ ListView
         border.color: UM.Theme.getColor("message_border")
         radius: UM.Theme.getSize("message_radius").width
 
-        Row
+        RowLayout
         {
             id: titleBar
             spacing: UM.Theme.getSize("default_margin").width
@@ -190,7 +190,7 @@ ListView
                 id: messageTitle
                 // Account for the left and right margins of the titleBar since they are not automatically accounted
                 // for using the width - x
-                width: parent.width - x - 2 * UM.Theme.getSize("default_margin").width
+                Layout.fillWidth: true
                 anchors.verticalCenter: parent.verticalCenter
 
                 text: model.title == undefined ? "" : model.title
@@ -205,8 +205,8 @@ ListView
             Button
             {
                 id: closeButton
-                width: UM.Theme.getSize("message_close").width
-                height: UM.Theme.getSize("message_close").height
+                implicitWidth: UM.Theme.getSize("message_close").width
+                implicitHeight: UM.Theme.getSize("message_close").height
 
                 style: ButtonStyle
                 {

--- a/UM/Qt/qml/UM/MessageStack.qml
+++ b/UM/Qt/qml/UM/MessageStack.qml
@@ -118,40 +118,63 @@ ListView
                 visible: model.dismissable
                 enabled: model.dismissable
             }
-            UM.RecolorImage
+            Row
             {
-                id: icon
-                visible: model.progress == null
+            
+            }
+            Rectangle
+            {
+                id: messageIconBackground
                 anchors.verticalCenter: messageTitle.verticalCenter
                 anchors.left: parent.left
-                height: visible ? UM.Theme.getSize("medium_button_icon").height : 0
+                visible: model.progress == null
+                height: visible ? UM.Theme.getSize("small_button_icon").height : 0
+                width: height
+                radius: Math.round(width / 2)
+            }
+            UM.RecolorImage
+            {
+                id: messageTypeIcon
+                visible: messageIconBackground.visible
+                anchors.centerIn: messageIconBackground
+                height: messageIconBackground.height
                 width: height
                 sourceSize.width: width
                 sourceSize.height: height
+            }
 
-                states:
+            states:
                     [
                         State
                         {
-                            name: "confirmation"
+                            name: "positive"
                             when: model.message_type == 0
                             PropertyChanges
                             {
-                                target: icon
-                                source: UM.Theme.getIcon("CheckCircle")
-//                                color: UM.Theme.getColor("primary_button")
-                                color: "green"
+                                target: messageTypeIcon
+                                source: UM.Theme.getIcon("Check", "low")
+                                color: UM.Theme.getColor("message_success_icon")
+                            }
+                            PropertyChanges
+                            {
+                                target: messageIconBackground
+                                color: UM.Theme.getColor("message_success_background")
                             }
                         },
                         State
                         {
-                            name: "information"
+                            name: "neutral"
                             when: model.message_type == 1
                             PropertyChanges
                             {
-                                target: icon
-                                source: UM.Theme.getIcon("Information")
-                                color: UM.Theme.getColor("primary_button")
+                                target: messageTypeIcon
+                                source: ""
+                            }
+                            PropertyChanges
+                            {
+                                target: messageIconBackground
+                                color: "transparent"
+                                visible: false
                             }
                         },
                         State
@@ -160,34 +183,41 @@ ListView
                             when: model.message_type == 2
                             PropertyChanges
                             {
-                                target: icon
-                                source: UM.Theme.getIcon("Warning")
-//                                color: UM.Theme.getColor("primary_button")
-                                color: "gold"
+                                target: messageTypeIcon
+                                source: UM.Theme.getIcon("Warning", "low")
+                                color: UM.Theme.getColor("message_warning_icon")
+                            }
+                            PropertyChanges
+                            {
+                                target: messageIconBackground
+                                color: UM.Theme.getColor("message_warning_background")
                             }
                         },
                         State
                         {
-                            name: "failure"
+                            name: "error"
                             when: model.message_type == 3
                             PropertyChanges
                             {
-                                target: icon
-                                source: UM.Theme.getIcon("CancelCircle")
-//                                color: UM.Theme.getColor("primary_button")
-                                color: "red"
+                                target: messageTypeIcon
+                                source: UM.Theme.getIcon("Cancel", "low")
+                                color: UM.Theme.getColor("message_error_icon")
+                            }
+                            PropertyChanges
+                            {
+                                target: messageIconBackground
+                                color: UM.Theme.getColor("message_error_background")
                             }
                         }
                     ]
-            }
+
             Label
             {
                 id: messageTitle
 
                 anchors
                 {
-                    left: icon.right
-                    leftMargin: UM.Theme.getSize("default_margin").width
+                    left: messageTypeIcon.right
                     right: closeButton.left
                     rightMargin: UM.Theme.getSize("default_margin").width
                 }

--- a/UM/Qt/qml/UM/MessageStack.qml
+++ b/UM/Qt/qml/UM/MessageStack.qml
@@ -131,7 +131,7 @@ ListView
                         PropertyChanges
                         {
                             target: messageIconBackground
-                            color: UM.Theme.getColor("message_success_background")
+                            color: UM.Theme.getColor("message_success_icon_background")
                         }
                     },
                     State
@@ -167,7 +167,7 @@ ListView
                         PropertyChanges
                         {
                             target: messageIconBackground
-                            color: UM.Theme.getColor("message_warning_background")
+                            color: UM.Theme.getColor("message_warning_icon_background")
                         }
                     },
                     State
@@ -183,7 +183,7 @@ ListView
                         PropertyChanges
                         {
                             target: messageIconBackground
-                            color: UM.Theme.getColor("message_error_background")
+                            color: UM.Theme.getColor("message_error_icon_background")
                         }
                     }
                 ]

--- a/UM/Qt/qml/UM/MessageStack.qml
+++ b/UM/Qt/qml/UM/MessageStack.qml
@@ -82,6 +82,7 @@ ListView
         Row
         {
             id: titleBar
+            spacing: UM.Theme.getSize("default_margin").width
 
             anchors
             {
@@ -91,13 +92,14 @@ ListView
                 margins: UM.Theme.getSize("default_margin").width
             }
 
-            height: messageTypeIcon.height
+            height: Math.max(messageTypeIcon.height, messageTitle.height)
             Item
             {
                 id: messageTypeIcon
                 visible: model.progress == null
                 height: UM.Theme.getSize("small_button_icon").height
                 width: visible ? UM.Theme.getSize("small_button_icon").height : 0
+                anchors.verticalCenter: parent.verticalCenter
                 Rectangle
                 {
                     id: messageIconBackground
@@ -191,7 +193,9 @@ ListView
             Label
             {
                 id: messageTitle
-                width: parent.width - x
+                // Account for the left and right margins of the titleBar since they are not automatically accounted
+                // for using the width - x
+                width: parent.width - x - 2 * UM.Theme.getSize("default_margin").width
                 anchors.verticalCenter: parent.verticalCenter
 
                 text: model.title == undefined ? "" : model.title
@@ -208,8 +212,6 @@ ListView
                 id: closeButton
                 width: UM.Theme.getSize("message_close").width
                 height: UM.Theme.getSize("message_close").height
-
-                anchors.verticalCenter: parent.verticalCenter
 
                 style: ButtonStyle
                 {

--- a/UM/Qt/qml/UM/MessageStack.qml
+++ b/UM/Qt/qml/UM/MessageStack.qml
@@ -96,7 +96,7 @@ ListView
             Item
             {
                 id: messageTypeIcon
-                visible: model.progress == null
+                visible: messageIcon.source != ""
                 height: UM.Theme.getSize("small_button_icon").height
                 width: visible ? UM.Theme.getSize("small_button_icon").height : 0
                 anchors.verticalCenter: parent.verticalCenter
@@ -147,11 +147,6 @@ ListView
                         {
                             target: messageIconBackground
                             color: "transparent"
-                        }
-                        PropertyChanges
-                        {
-                            target: messageTypeIcon
-                            visible: false
                         }
                     },
                     State

--- a/UM/Qt/qml/UM/MessageStack.qml
+++ b/UM/Qt/qml/UM/MessageStack.qml
@@ -97,8 +97,8 @@ ListView
             {
                 id: messageTypeIcon
                 visible: messageIcon.source != ""
-                height: UM.Theme.getSize("small_button_icon").height
-                width: visible ? UM.Theme.getSize("small_button_icon").height : 0
+                height: UM.Theme.getSize("message_type_icon").height
+                width: visible ? UM.Theme.getSize("message_type_icon").height : 0
                 anchors.verticalCenter: parent.verticalCenter
                 Rectangle
                 {
@@ -131,7 +131,7 @@ ListView
                         PropertyChanges
                         {
                             target: messageIconBackground
-                            color: UM.Theme.getColor("message_success_icon_background")
+                            color: UM.Theme.getColor("success")
                         }
                     },
                     State
@@ -162,7 +162,7 @@ ListView
                         PropertyChanges
                         {
                             target: messageIconBackground
-                            color: UM.Theme.getColor("message_warning_icon_background")
+                            color: UM.Theme.getColor("warning")
                         }
                     },
                     State
@@ -178,7 +178,7 @@ ListView
                         PropertyChanges
                         {
                             target: messageIconBackground
-                            color: UM.Theme.getColor("message_error_icon_background")
+                            color: UM.Theme.getColor("error")
                         }
                     }
                 ]

--- a/UM/Qt/qml/UM/MessageStack.qml
+++ b/UM/Qt/qml/UM/MessageStack.qml
@@ -189,8 +189,6 @@ ListView
             Label
             {
                 id: messageTitle
-                // Account for the left and right margins of the titleBar since they are not automatically accounted
-                // for using the width - x
                 Layout.fillWidth: true
 
                 text: model.title == undefined ? "" : model.title

--- a/UM/Qt/qml/UM/MessageStack.qml
+++ b/UM/Qt/qml/UM/MessageStack.qml
@@ -118,14 +118,76 @@ ListView
                 visible: model.dismissable
                 enabled: model.dismissable
             }
+            UM.RecolorImage
+            {
+                id: icon
+                visible: model.progress == null
+                anchors.verticalCenter: messageTitle.verticalCenter
+                anchors.left: parent.left
+                height: visible ? UM.Theme.getSize("medium_button_icon").height : 0
+                width: height
+                sourceSize.width: width
+                sourceSize.height: height
 
+                states:
+                    [
+                        State
+                        {
+                            name: "confirmation"
+                            when: model.message_type == 0
+                            PropertyChanges
+                            {
+                                target: icon
+                                source: UM.Theme.getIcon("CheckCircle")
+//                                color: UM.Theme.getColor("primary_button")
+                                color: "green"
+                            }
+                        },
+                        State
+                        {
+                            name: "information"
+                            when: model.message_type == 1
+                            PropertyChanges
+                            {
+                                target: icon
+                                source: UM.Theme.getIcon("Information")
+                                color: UM.Theme.getColor("primary_button")
+                            }
+                        },
+                        State
+                        {
+                            name: "warning"
+                            when: model.message_type == 2
+                            PropertyChanges
+                            {
+                                target: icon
+                                source: UM.Theme.getIcon("Warning")
+//                                color: UM.Theme.getColor("primary_button")
+                                color: "gold"
+                            }
+                        },
+                        State
+                        {
+                            name: "failure"
+                            when: model.message_type == 3
+                            PropertyChanges
+                            {
+                                target: icon
+                                source: UM.Theme.getIcon("CancelCircle")
+//                                color: UM.Theme.getColor("primary_button")
+                                color: "red"
+                            }
+                        }
+                    ]
+            }
             Label
             {
                 id: messageTitle
 
                 anchors
                 {
-                    left: parent.left
+                    left: icon.right
+                    leftMargin: UM.Theme.getSize("default_margin").width
                     right: closeButton.left
                     rightMargin: UM.Theme.getSize("default_margin").width
                 }

--- a/plugins/LocalFileOutputDevice/LocalFileOutputDevice.py
+++ b/plugins/LocalFileOutputDevice/LocalFileOutputDevice.py
@@ -187,7 +187,10 @@ class LocalFileOutputDevice(ProjectOutputDevice):
         self.writeFinished.emit(self)
         if job.getResult():
             self.writeSuccess.emit(self)
-            message = Message(catalog.i18nc("@info:status Don't translate the XML tags <filename>!", "Saved to <filename>{0}</filename>").format(job.getFileName()), title = catalog.i18nc("@info:title", "File Saved"))
+            message = Message(
+                catalog.i18nc("@info:status Don't translate the XML tags <filename>!", "Saved to <filename>{0}</filename>").format(job.getFileName()),
+                title = catalog.i18nc("@info:title", "File Saved"),
+                message_type = Message.MessageType.POSITIVE)
             message.addAction("open_folder", catalog.i18nc("@action:button", "Open Folder"), "open-folder", catalog.i18nc("@info:tooltip", "Open the folder containing the file"))
             message._folder = os.path.dirname(job.getFileName())
             message.actionTriggered.connect(self._onMessageActionTriggered)


### PR DESCRIPTION
Now the messages contain a message type, which can be one of the following:
1. POSITIVE
2. NEUTRAL (default)
3. WARNING
4. NEGATIVE

The message types determine what icon will appear next to the title of the message. 

![image](https://user-images.githubusercontent.com/19388042/126773289-57539dfc-48ea-4521-8c67-9a771806d42c.png)
![image](https://user-images.githubusercontent.com/19388042/126773297-050bc8ee-ae99-4541-bb10-3aa9644f6ec7.png)

Requires https://github.com/Ultimaker/Cura/pull/10175.

CURA-7278