### PR TITLE
[SEC-240] Add Pre-Storage Check To Trust

### DIFF
--- a/UM/Trust.py
+++ b/UM/Trust.py
@@ -407,7 +407,7 @@ class Trust:
         is concerned, is the one where the items are already in central storage. Otherwise there would either be a whole
         range of 'acceptable answers' (and that's harder to test against) or, there would always be a need to verify
         a situation that shouldn't be that frequent (items need to be copied to central storage). This creates a problem
-        in that the central storage mechanism needs to run _first_, however. The central storage has it's own security
+        in that the central storage mechanism needs to run _first_, however. The central storage has its own security
         measures, but this means that the central storage file in a folder (which contains info on what items should be
         copied) hasn't been checked against the trust manifest file in that folder yet.
 
@@ -428,7 +428,7 @@ class Trust:
 
             # Open the file containing signatures (just reading the json is negligible compared to the verify or store):
             json_filename = os.path.join(path, TrustBasics.getSignaturesLocalFilename())
-            with open(json_filename, "r", encoding="utf-8") as data_file:
+            with open(json_filename, "r", encoding = "utf-8") as data_file:
                 json_data = json.load(data_file)
                 signatures_json = json_data.get(TrustBasics.getRootSignatureCategory(), None)
                 if signatures_json is None:

--- a/tests/MimeTypes/TestMimeTypes.py
+++ b/tests/MimeTypes/TestMimeTypes.py
@@ -42,7 +42,7 @@ def mime_database():
 def test_system_mimetypes(mime_database):
     mime = mime_database.getMimeTypeForFile(os.path.abspath(__file__))
     assert mime.name == "text/x-python"
-    assert mime.comment == "Python script"
+    assert "Python" in mime.comment  # Check only part of the string, because comments are translated!
     assert "py" in mime.suffixes
     assert mime.preferredSuffix == "py"
 
@@ -139,7 +139,7 @@ def test_getMimeType(mime_database):
     assert mime.comment == "Custom JPEG MIME Type" # We must get the custom one, not Qt's MIME type.
 
     mime = mime_database.getMimeType("image/png")
-    assert mime.comment == "PNG image" # Qt's MIME type (at least on my system).
+    assert "PNG" in mime.comment  # Qt's MIME type.  # Check only part of the string, because comments are translated!
 
     with pytest.raises(MimeTypeNotFoundError):
         mime_database.getMimeType("archive/x-file-that-your-mom-would-fit-in") # Try to fetch some non-existing MIME type.

--- a/tests/TestTrust.py
+++ b/tests/TestTrust.py
@@ -181,9 +181,9 @@ class TestTrust:
         violation_callback.reset_mock()
 
         # * 'Central file storage'-enabled section *
-        with patch("UM.CentralFileStorage.CentralFileStorage._centralStorageLocation", MagicMock(return_value=central_storage_dir)):
+        with patch("UM.CentralFileStorage.CentralFileStorage._centralStorageLocation", MagicMock(return_value = central_storage_dir)):
 
-            # Do some set-up (signing, moveing files around with the central file storage):
+            # Do some set-up (signing, moving files around with the central file storage):
             assert signFolder(private_path, folderpath_large, [], _passphrase)
             assert violation_callback.call_count == 0
             subfolder_path = os.path.join(folderpath_large, _subfolder_names[0])


### PR DESCRIPTION
In enterprise scenario's:

Before moving the files, run a quicker security check on the central storage file itself, since it could be potentially used to copy files from an elevated account (even if the plugin itself isn't run yet).

To prevent this, two things where done;
- one is that it's checked that the file that's being moved is (to) _within_ the plugin folder.
- The other is a quick 'pre-check' that doesn't scan the whole folder but only checks the integrity of the central storage file (and the manifest). This should, (and now _can_) be done _before_ moving however.

P.S. Internal ticket is also cloned as CURA-8407