### PR TITLE
[SEC-240] Fix items that would be copied outside of storage location.

### DIFF
--- a/UM/CentralFileStorage.py
+++ b/UM/CentralFileStorage.py
@@ -69,8 +69,8 @@ class CentralFileStorage:
                 cls._unmoved_files[full_identifier] = path
             return
 
-        if not os.path.exists(cls.centralStorageLocation()):
-            os.makedirs(cls.centralStorageLocation())
+        if not os.path.exists(cls.getCentralStorageLocation()):
+            os.makedirs(cls.getCentralStorageLocation())
         if not os.path.exists(path):
             Logger.debug(f"{path_id} {str(version)} was already stored centrally or the provided path is not correct")
             return
@@ -129,10 +129,10 @@ class CentralFileStorage:
         :return: A path to store such an item.
         """
         item_name = item_id + "." + str(version)
-        return os.path.join(cls.centralStorageLocation(), item_name)
+        return os.path.join(cls.getCentralStorageLocation(), item_name)
 
     @classmethod
-    def centralStorageLocation(cls) -> str:
+    def getCentralStorageLocation(cls) -> str:
         """
         Gets a directory to store things in a version-neutral location.
         :return: A directory to store things centrally.

--- a/UM/CentralFileStorage.py
+++ b/UM/CentralFileStorage.py
@@ -69,8 +69,8 @@ class CentralFileStorage:
                 cls._unmoved_files[full_identifier] = path
             return
 
-        if not os.path.exists(cls._centralStorageLocation()):
-            os.makedirs(cls._centralStorageLocation())
+        if not os.path.exists(cls.centralStorageLocation()):
+            os.makedirs(cls.centralStorageLocation())
         if not os.path.exists(path):
             Logger.debug(f"{path_id} {str(version)} was already stored centrally or the provided path is not correct")
             return
@@ -129,10 +129,10 @@ class CentralFileStorage:
         :return: A path to store such an item.
         """
         item_name = item_id + "." + str(version)
-        return os.path.join(cls._centralStorageLocation(), item_name)
+        return os.path.join(cls.centralStorageLocation(), item_name)
 
     @classmethod
-    def _centralStorageLocation(cls) -> str:
+    def centralStorageLocation(cls) -> str:
         """
         Gets a directory to store things in a version-neutral location.
         :return: A directory to store things centrally.

--- a/UM/PluginRegistry.py
+++ b/UM/PluginRegistry.py
@@ -730,7 +730,7 @@ class PluginRegistry(QObject):
             full_path = os.path.join(plugin_path, file_to_move[0])
             try:
                 CentralFileStorage.store(full_path, file_to_move[1], Version(file_to_move[2]), move_file = not is_bundled_plugin)
-            except (FileExistsError, TypeError, IndexError):
+            except (FileExistsError, TypeError, IndexError, OSError):
                 Logger.logException("w", f"Can't move file {file_to_move[0]} to central storage for '{plugin_path}'.")
         return True
 

--- a/tests/TestTrust.py
+++ b/tests/TestTrust.py
@@ -242,14 +242,13 @@ class TestTrust:
         assert TrustBasics.getFileSignature("file-not-found", private_key) is None
 
     def test_isPathInLocation(self):
-        assert TrustBasics.isPathInLocation(r"C:\a\b\c", r"C:\a\b\c\d")
-        assert TrustBasics.isPathInLocation(r"C:/a\b/c", r"C:/a/b/c/d\..")
-        assert not TrustBasics.isPathInLocation(r"C:\a\b\c", r"C:\a\b\c\d\..\..")
-        assert not TrustBasics.isPathInLocation(r"C:\a\b\c", r"C:\a\b")
+        assert TrustBasics.isPathInLocation(r"/a/b/c", r"/a/b/c/d")
+        assert TrustBasics.isPathInLocation(r"/a/b/c", r"/a/b/c/d/..")
+        assert not TrustBasics.isPathInLocation(r"/a/b/c", r"/a/b/c/d/../..")
+        assert not TrustBasics.isPathInLocation(r"/a/b/c", r"/a/b")
         assert not TrustBasics.isPathInLocation(r"/a/b/c", r"/d/q/f")
-        assert TrustBasics.isPathInLocation(r"C:\a\b\c", r"C:\a\b\..\b\c\d\..\e")
-        assert TrustBasics.isPathInLocation(r"/a/b/../d/c", r"\a\d\c")
-        assert not TrustBasics.isPathInLocation(r"/a/b/../d/c", r"\a\d\c.txt")
-        assert not TrustBasics.isPathInLocation(r"D:\a\b\c", r"C:\a\b\c\d")
-        assert not TrustBasics.isPathInLocation(r"C:\a\b\..\d\c", r"C:\a\b\..\b\c\d\..\e")
-        assert not TrustBasics.isPathInLocation(r"/a/b/../d/c.txt", r"\a\d\c")
+        assert TrustBasics.isPathInLocation(r"/a/b/c", r"/a/b/../b/c/d/../e")
+        assert TrustBasics.isPathInLocation(r"/a/b/../d/c", r"/a/d/c")
+        assert not TrustBasics.isPathInLocation(r"/a/b/../d/c", r"/a/d/c.txt")
+        assert not TrustBasics.isPathInLocation(r"/a/b/../d/c", r"/a/b/../b/c/d/../e")
+        assert not TrustBasics.isPathInLocation(r"/a/b/../d/c.txt", r"/a/d/c")

--- a/tests/TestTrust.py
+++ b/tests/TestTrust.py
@@ -122,6 +122,10 @@ class TestTrust:
         # A folder without a central storage file should just pass, no matter what:
         assert trust_instance.signedFolderPreStorageCheck(folderpath_without_storage)
 
+        # From here on out, make sure we're testing the other part of that functionality (prevent early out):
+        trust_instance._verifyFile = MagicMock(return_value = True)
+        trust_instance._verifyManifestIntegrety = MagicMock(return_value=True)
+
         # Overwrite the central storage dictionary with files moved to an arbitrary location (then fail the check):
         central_storage_dict = [["/root/.importantfile", "/home/eve", "1.0.0", "dummy"]]
         central_storage_file_path = os.path.join(folderpath_signed, TrustBasics.getCentralStorageFilename())

--- a/tests/TestTrust.py
+++ b/tests/TestTrust.py
@@ -122,7 +122,21 @@ class TestTrust:
         # A folder without a central storage file should just pass, no matter what:
         assert trust_instance.signedFolderPreStorageCheck(folderpath_without_storage)
 
-    def test_signFolderAndVerify(self, init_trust, pytestconfig):
+        # Overwrite the central storage dictionary with files moved to an arbitrary location (then fail the check):
+        central_storage_dict = [["/root/.importantfile", "/home/eve", "1.0.0", "dummy"]]
+        central_storage_file_path = os.path.join(folderpath_signed, TrustBasics.getCentralStorageFilename())
+        with open(central_storage_file_path, "w") as file:
+            json.dump(central_storage_dict, file, indent=2)
+        assert not trust_instance.signedFolderPreStorageCheck(folderpath_signed)
+
+        # Overwrite the central storage dictionary with files-to-move outside of the storage area (then fail the check):
+        central_storage_dict = [["signatures.json", "../../signatures.json", "1.0.0", "dummy"]]
+        central_storage_file_path = os.path.join(folderpath_signed, TrustBasics.getCentralStorageFilename())
+        with open(central_storage_file_path, "w") as file:
+            json.dump(central_storage_dict, file, indent=2)
+        assert not trust_instance.signedFolderPreStorageCheck(folderpath_signed)
+
+    def test_signFolderAndVerify(self, init_trust):
         temp_dir, private_path, trust_instance, violation_callback, central_storage_dir = init_trust
         folderpath_signed = os.path.join(temp_dir, _folder_names[0])
         folderpath_unsigned = os.path.join(temp_dir, _folder_names[1])
@@ -181,7 +195,7 @@ class TestTrust:
         violation_callback.reset_mock()
 
         # * 'Central file storage'-enabled section *
-        with patch("UM.CentralFileStorage.CentralFileStorage._centralStorageLocation", MagicMock(return_value = central_storage_dir)):
+        with patch("UM.CentralFileStorage.CentralFileStorage.centralStorageLocation", MagicMock(return_value = central_storage_dir)):
 
             # Do some set-up (signing, moving files around with the central file storage):
             assert signFolder(private_path, folderpath_large, [], _passphrase)
@@ -226,3 +240,16 @@ class TestTrust:
     def test_signNonexisting(self):
         private_key, public_key = TrustBasics.generateNewKeyPair()
         assert TrustBasics.getFileSignature("file-not-found", private_key) is None
+
+    def test_isPathInLocation(self):
+        assert TrustBasics.isPathInLocation(r"C:\a\b\c", r"C:\a\b\c\d")
+        assert TrustBasics.isPathInLocation(r"C:/a\b/c", r"C:/a/b/c/d\..")
+        assert not TrustBasics.isPathInLocation(r"C:\a\b\c", r"C:\a\b\c\d\..\..")
+        assert not TrustBasics.isPathInLocation(r"C:\a\b\c", r"C:\a\b")
+        assert not TrustBasics.isPathInLocation(r"/a/b/c", r"/d/q/f")
+        assert TrustBasics.isPathInLocation(r"C:\a\b\c", r"C:\a\b\..\b\c\d\..\e")
+        assert TrustBasics.isPathInLocation(r"/a/b/../d/c", r"\a\d\c")
+        assert not TrustBasics.isPathInLocation(r"/a/b/../d/c", r"\a\d\c.txt")
+        assert not TrustBasics.isPathInLocation(r"D:\a\b\c", r"C:\a\b\c\d")
+        assert not TrustBasics.isPathInLocation(r"C:\a\b\..\d\c", r"C:\a\b\..\b\c\d\..\e")
+        assert not TrustBasics.isPathInLocation(r"/a/b/../d/c.txt", r"\a\d\c")


### PR DESCRIPTION
Also refactor those sorts of test into the signed folder pre-storage check, where they belong. (Otherwise a part of that security was handled by the plugin system.) Also amend unit-tests to take into account these situations. While doing that, found an oversight in the `isPathInLocation` functionality, which is by necessity now also in Trust.

SEC-240 / CURA-8407