### PR TITLE
Fix the rotation direction of the 90 degree rotation arrows

### DIFF
--- a/plugins/Tools/RotateTool/RotateTool.py
+++ b/plugins/Tools/RotateTool/RotateTool.py
@@ -198,7 +198,7 @@ class RotateTool(Tool):
                 if id in self._handle.getExtraWidgetsColorMap() and self._active_widget == self._handle.ExtraWidgets(id):
                     axis = math.floor((self._active_widget.value - self._active_widget.XPositive90.value) / 2)
 
-                    angle = math.radians(-90 if self._active_widget.value - 2 * axis else 90)
+                    angle = math.radians(90 if (self._active_widget.value - ToolHandle.AllAxis) % 2 else -90)
                     axis +=  self._handle.XAxis
 
                     rotation = Quaternion()


### PR DESCRIPTION
This PR fixes the rotation direction of the 90 degree rotation arrows in the Rotate Tool. Currently the arrows in both directions rotate the model in the same direction. They should operate in opposite directions.

Fixes https://github.com/Ultimaker/Cura/issues/10279