### PR TITLE
Fixed the _blacklist variable

### DIFF
--- a/UM/Settings/SettingFunction.py
+++ b/UM/Settings/SettingFunction.py
@@ -327,8 +327,8 @@ class _SettingExpressionVisitor(ast.NodeVisitor):
         "file",
         "subprocess",
         "globals",
-        "__class__"
-        "__globals__"
+        "__class__",
+        "__globals__",
         "hasattr",
         "raw_input",
         "input",


### PR DESCRIPTION
Fixed _blacklist variable to include '__class__', '__globals__', 'hasattr' as 3 seperate strings and not '__class____globals__hasattr' as 1 combined string