### PR TITLE
[CURA-8491] Update SDK 7.6 -> 7.7 because of API changes.

### DIFF
--- a/resources/bundled_packages/uranium.json
+++ b/resources/bundled_packages/uranium.json
@@ -5,8 +5,7 @@
             "package_type": "plugin",
             "display_name": "Console Logger",
             "description": "Outputs log information to the console.",
-            "package_version": "1.0.1",
-            "sdk_version": "7.6.0",
+            "package_version": "1.0.1", "sdk_version": "7.7.0",
             "website": "https://ultimaker.com",
             "author": {
                 "author_id": "UltimakerPackages",
@@ -23,7 +22,7 @@
             "display_name": "Wavefront OBJ Reader",
             "description": "Makes it possible to read Wavefront OBJ files.",
             "package_version": "1.0.1",
-            "sdk_version": "7.6.0",
+            "sdk_version": "7.7.0",
             "website": "https://ultimaker.com",
             "author": {
                 "author_id": "UltimakerPackages",
@@ -40,7 +39,7 @@
             "display_name": "Wavefront OBJ Writer",
             "description": "Makes it possible to write Wavefront OBJ files.",
             "package_version": "1.0.1",
-            "sdk_version": "7.6.0",
+            "sdk_version": "7.7.0",
             "website": "https://ultimaker.com",
             "author": {
                 "author_id": "UltimakerPackages",
@@ -57,7 +56,7 @@
             "display_name": "STL Reader",
             "description": "Provides support for reading STL files.",
             "package_version": "1.0.1",
-            "sdk_version": "7.6.0",
+            "sdk_version": "7.7.0",
             "website": "https://ultimaker.com",
             "author": {
                 "author_id": "UltimakerPackages",
@@ -74,7 +73,7 @@
             "display_name": "STL Writer",
             "description": "Provides support for writing STL files.",
             "package_version": "1.0.1",
-            "sdk_version": "7.6.0",
+            "sdk_version": "7.7.0",
             "website": "https://ultimaker.com",
             "author": {
                 "author_id": "UltimakerPackages",
@@ -91,7 +90,7 @@
             "display_name": "File Logger",
             "description": "Outputs log information to a file in your settings folder.",
             "package_version": "1.0.1",
-            "sdk_version": "7.6.0",
+            "sdk_version": "7.7.0",
             "website": "https://ultimaker.com",
             "author": {
                 "author_id": "UltimakerPackages",
@@ -108,7 +107,7 @@
             "display_name": "Local Container Provider",
             "description": "Provides built-in setting containers that come with the installation of the application.",
             "package_version": "1.0.1",
-            "sdk_version": "7.6.0",
+            "sdk_version": "7.7.0",
             "website": "https://ultimaker.com",
             "author": {
                 "author_id": "UltimakerPackages",
@@ -125,7 +124,7 @@
             "display_name": "Local File Output Device",
             "description": "Enables saving to local files.",
             "package_version": "1.0.1",
-            "sdk_version": "7.6.0",
+            "sdk_version": "7.7.0",
             "website": "https://ultimaker.com",
             "author": {
                 "author_id": "UltimakerPackages",
@@ -142,7 +141,7 @@
             "display_name": "Camera Tool",
             "description": "Provides the tool to manipulate the camera.",
             "package_version": "1.0.1",
-            "sdk_version": "7.6.0",
+            "sdk_version": "7.7.0",
             "website": "https://ultimaker.com",
             "author": {
                 "author_id": "UltimakerPackages",
@@ -159,7 +158,7 @@
             "display_name": "Mirror Tool",
             "description": "Provides the Mirror tool.",
             "package_version": "1.0.1",
-            "sdk_version": "7.6.0",
+            "sdk_version": "7.7.0",
             "website": "https://ultimaker.com",
             "author": {
                 "author_id": "UltimakerPackages",
@@ -176,7 +175,7 @@
             "display_name": "Rotate Tool",
             "description": "Provides the Rotate tool.",
             "package_version": "1.0.1",
-            "sdk_version": "7.6.0",
+            "sdk_version": "7.7.0",
             "website": "https://ultimaker.com",
             "author": {
                 "author_id": "UltimakerPackages",
@@ -193,7 +192,7 @@
             "display_name": "Scale Tool",
             "description": "Provides the Scale tool.",
             "package_version": "1.0.1",
-            "sdk_version": "7.6.0",
+            "sdk_version": "7.7.0",
             "website": "https://ultimaker.com",
             "author": {
                 "author_id": "UltimakerPackages",
@@ -210,7 +209,7 @@
             "display_name": "Selection Tool",
             "description": "Provides the Selection tool.",
             "package_version": "1.0.1",
-            "sdk_version": "7.6.0",
+            "sdk_version": "7.7.0",
             "website": "https://ultimaker.com",
             "author": {
                 "author_id": "UltimakerPackages",
@@ -227,7 +226,7 @@
             "display_name": "Move Tool",
             "description": "Provides the Move tool.",
             "package_version": "1.0.1",
-            "sdk_version": "7.6.0",
+            "sdk_version": "7.7.0",
             "website": "https://ultimaker.com",
             "author": {
                 "author_id": "UltimakerPackages",
@@ -244,7 +243,7 @@
             "display_name": "Update Checker",
             "description": "Checks for updates of the software.",
             "package_version": "1.0.1",
-            "sdk_version": "7.6.0",
+            "sdk_version": "7.7.0",
             "website": "https://ultimaker.com",
             "author": {
                 "author_id": "UltimakerPackages",
@@ -261,7 +260,7 @@
             "display_name": "Simple View",
             "description": "Provides a simple solid mesh view.",
             "package_version": "1.0.1",
-            "sdk_version": "7.6.0",
+            "sdk_version": "7.7.0",
             "website": "https://ultimaker.com",
             "author": {
                 "author_id": "UltimakerPackages",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -19,7 +19,7 @@ class FixtureApplication(Application):
     engineCreatedSignal = Signal()
 
     def __init__(self):
-        super().__init__(name = "test", version = "1.0", api_version = "7.6.0")
+        super().__init__(name = "test", version = "1.0", api_version = "7.7.0")
         super().initialize()
         Signal._signalQueue = self
 


### PR DESCRIPTION
URANIUM:

* Added optional 'message_type' argument to Message.__init__
* Added Message.MessageType enum-class
* Added Message.getMessageType(self) -> MessageType
  Messages can have types now, this determines the sort of icon they get for now as well.

* Added TrustBasics.isPathInLocation(location: str, path: str) -> bool
  Whether a path is a sub-folder (or equal) of a given location (path).

* Changed OpenGL.createShaderProgram(self, file_name: str) -> Optional[ShaderProgram]
  Now returns optional instead of 'just' a shader-program, since part of the code already expected that to be the case.

* Removed 'UpdateCheckerJob' class
  Now just handled withint the UpdateCheckerJob.