### PR TITLE
Retain the last saved filename after saving a file

### DIFF
--- a/UM/OutputDevice/OutputDevice.py
+++ b/UM/OutputDevice/OutputDevice.py
@@ -161,12 +161,6 @@ class OutputDevice():
 
         raise NotImplementedError("requestWrite needs to be implemented")
 
-    def getLastOutputName(self) -> Optional[str]:
-        return self._last_out_name
-
-    def setLastOutputName(self, name: Optional[str] = None) -> None:
-        self._last_out_name = name
-
     writeStarted = Signal()
     writeProgress = Signal()
     writeFinished = Signal()

--- a/UM/OutputDevice/OutputDevice.py
+++ b/UM/OutputDevice/OutputDevice.py
@@ -36,6 +36,7 @@ class OutputDevice():
         self._description = "Do something with an unknown device"
         self._icon_name = "generic_device"
         self._priority = 0
+        self._last_filename = None  # Optional[str]
 
     metaDataChanged = Signal()
 
@@ -159,6 +160,12 @@ class OutputDevice():
         """
 
         raise NotImplementedError("requestWrite needs to be implemented")
+
+    def getLastOutputName(self) -> Optional[str]:
+        return self._last_out_name
+
+    def setLastOutputName(self, name: Optional[str] = None) -> None:
+        self._last_out_name = name
 
     writeStarted = Signal()
     writeProgress = Signal()

--- a/UM/OutputDevice/ProjectOutputDevice.py
+++ b/UM/OutputDevice/ProjectOutputDevice.py
@@ -48,6 +48,11 @@ class ProjectOutputDevice(QObject, OutputDevice):
         Shortcut key combination
         """
 
+        self._last_out_name = None  # type: Optional[str]
+        """
+        Last output project name, gives the possibility to do something with the updated project-name on saving, if any.
+        """
+
     @property
     def enabled(self) -> bool:
         return self._enabled
@@ -71,3 +76,9 @@ class ProjectOutputDevice(QObject, OutputDevice):
                     Application.getInstance().getOutputDeviceManager().addOutputDevice(self)
                 else:
                     Application.getInstance().getOutputDeviceManager().removeOutputDevice(self.getId())
+
+    def getLastOutputName(self) -> Optional[str]:
+        return self._last_out_name
+
+    def setLastOutputName(self, name: Optional[str] = None) -> None:
+        self._last_out_name = name

--- a/plugins/LocalFileOutputDevice/LocalFileOutputDevice.py
+++ b/plugins/LocalFileOutputDevice/LocalFileOutputDevice.py
@@ -14,7 +14,6 @@ from UM.Logger import Logger
 from UM.Mesh.MeshWriter import MeshWriter
 from UM.Message import Message
 from UM.OutputDevice import OutputDeviceError
-from UM.OutputDevice.OutputDevice import OutputDevice
 from UM.OutputDevice.ProjectOutputDevice import ProjectOutputDevice
 from UM.i18n import i18nCatalog
 

--- a/plugins/LocalFileOutputDevice/LocalFileOutputDevice.py
+++ b/plugins/LocalFileOutputDevice/LocalFileOutputDevice.py
@@ -15,6 +15,7 @@ from UM.Mesh.MeshWriter import MeshWriter
 from UM.Message import Message
 from UM.OutputDevice import OutputDeviceError
 from UM.OutputDevice.ProjectOutputDevice import ProjectOutputDevice
+from UM.Workspace.WorkspaceWriter import WorkspaceWriter
 from UM.i18n import i18nCatalog
 
 catalog = i18nCatalog("uranium")
@@ -138,14 +139,15 @@ class LocalFileOutputDevice(ProjectOutputDevice):
             if result == QMessageBox.No:
                 raise OutputDeviceError.UserCanceledError()
 
-        self.setLastOutputName(file_name)
-        self.writeStarted.emit(self)
-
         # Actually writing file
         if file_handler:
             file_writer = file_handler.getWriter(selected_type["id"])
         else:
             file_writer = Application.getInstance().getMeshFileHandler().getWriter(selected_type["id"])
+
+        if isinstance(file_writer, WorkspaceWriter):
+            self.setLastOutputName(file_name)
+        self.writeStarted.emit(self)
 
         try:
             mode = selected_type["mode"]

--- a/plugins/LocalFileOutputDevice/LocalFileOutputDevice.py
+++ b/plugins/LocalFileOutputDevice/LocalFileOutputDevice.py
@@ -3,7 +3,6 @@
 
 import os
 import sys
-from typing import Optional
 
 from PyQt5.QtCore import QUrl
 from PyQt5.QtGui import QDesktopServices
@@ -35,8 +34,6 @@ class LocalFileOutputDevice(ProjectOutputDevice):
 
         self.shortcut = "Ctrl+S"
         self.menu_entry_text = catalog.i18nc("@item:inmenu About saving files to the hard drive", "To Disk")
-        self._last_saved_filename = ""
-        Application.getInstance().workspaceLoaded.connect(self._resetLastSavedFilename)
 
         self._writing = False
 
@@ -71,9 +68,6 @@ class LocalFileOutputDevice(ProjectOutputDevice):
         filters = []
         mime_types = []
         selected_filter = None
-
-        if self._last_saved_filename:
-            file_name = self._last_saved_filename
 
         if "preferred_mimetypes" in kwargs and kwargs["preferred_mimetypes"] is not None:
             preferred_mimetypes = kwargs["preferred_mimetypes"]
@@ -146,10 +140,7 @@ class LocalFileOutputDevice(ProjectOutputDevice):
                 raise OutputDeviceError.UserCanceledError()
 
         self.writeStarted.emit(self)
-
-        # Keep the name (without the rest of the path and the extension) that was used for saving the file, so that the
-        # next time the dialog opens it will be set as the default name
-        self._last_saved_filename = os.path.splitext(os.path.basename(file_name))[0]
+        Application.getInstance().workspaceLoaded.emit(file_name)
 
         # Actually writing file
         if file_handler:
@@ -228,12 +219,3 @@ class LocalFileOutputDevice(ProjectOutputDevice):
     def _onMessageActionTriggered(self, message, action):
         if action == "open_folder" and hasattr(message, "_folder"):
             QDesktopServices.openUrl(QUrl.fromLocalFile(message._folder))
-
-    def _resetLastSavedFilename(self, workspace_file_name: str) -> None:
-        """
-        Reset the last saved filename whenever another project (workspace) file is loaded.
-        
-        :param workspace_file_name: The new workspace file that was loaded
-        """
-        if workspace_file_name != self._last_saved_filename:
-            self._last_saved_filename = ""

--- a/plugins/LocalFileOutputDevice/LocalFileOutputDevice.py
+++ b/plugins/LocalFileOutputDevice/LocalFileOutputDevice.py
@@ -138,8 +138,8 @@ class LocalFileOutputDevice(ProjectOutputDevice):
             if result == QMessageBox.No:
                 raise OutputDeviceError.UserCanceledError()
 
+        self.setLastOutputName(file_name)
         self.writeStarted.emit(self)
-        Application.getInstance().workspaceLoaded.emit(file_name)
 
         # Actually writing file
         if file_handler:


### PR DESCRIPTION
Cura was not retaining the last saved filename selected by the user after they were saving their file. This PR fixes that by making sure that the filename selected by the user in the save file dialog will update the name of the workspace (project) all around Cura.

**Note:** The stored filename is forgotten when the user loads another project file, creates a new project (Ctrl+N) or clears the buildplate (Ctrl+D).

Original feature request: https://github.com/Ultimaker/Cura/issues/10061

Required by https://github.com/Ultimaker/Cura/pull/10328.

CURA-8358