### PR TITLE
Store metadata in database. 

### DIFF
--- a/UM/Settings/ContainerProvider.py
+++ b/UM/Settings/ContainerProvider.py
@@ -104,10 +104,16 @@ class ContainerProvider(PluginObject):
                 return None
         return self._metadata[container_id]
 
-    # Gets the container file path with for the container with the given ID. Returns None if the container/file doesn't
-    # exist.
     def getContainerFilePathById(self, container_id: str) -> Optional[str]:
-        raise NotImplementedError("The container provider {class_name} doesn't properly implement getAllIds.".format(class_name = self.__class__.__name__))
+        """ Gets the container file path with for the container with the given ID. Returns None if the container/file
+        doesn't exist.
+        :param container_id:
+        :return:
+        """
+        raise NotImplementedError(f"The container provider {self.__class__.__name__} doesn't properly implement getContainerFilePathById.")
+
+    def getLastModifiedTime(self, container_id: str) -> Optional[float]:
+        raise NotImplementedError(f"The container provider {self.__class__.__name__} doesn't properly implement getLastModifiedTime.")
 
     def getAllIds(self) -> Iterable[str]:
         """Gets a list of IDs of all containers this provider provides.

--- a/UM/Settings/ContainerRegistry.py
+++ b/UM/Settings/ContainerRegistry.py
@@ -24,6 +24,7 @@ from UM.Settings.DefinitionContainer import DefinitionContainer
 from UM.Settings.InstanceContainer import InstanceContainer
 from UM.Settings.Interfaces import ContainerInterface, ContainerRegistryInterface, DefinitionContainerInterface
 from UM.Signal import Signal, signalemitter
+from .DatabaseContainerMetadataController import DatabaseMetadataContainerController
 
 if TYPE_CHECKING:
     from UM.PluginObject import PluginObject
@@ -68,9 +69,9 @@ class ContainerRegistry(ContainerRegistryInterface):
         # Since queries are based on metadata, we need to make sure to clear the cache when a container's metadata changes.
         self.containerMetaDataChanged.connect(self._clearQueryCache)
 
-        self._db_connection = None
+        self._db_connection: Optional[apsw.Connection] = None
 
-        self._database_handlers = {}
+        self._database_handlers: Dict[str, DatabaseMetadataContainerController] = {}
         self._explicit_read_only_container_ids = set()  # type: Set[str]
 
     containerAdded = Signal()

--- a/UM/Settings/ContainerRegistry.py
+++ b/UM/Settings/ContainerRegistry.py
@@ -68,12 +68,8 @@ class ContainerRegistry(ContainerRegistryInterface):
         # Since queries are based on metadata, we need to make sure to clear the cache when a container's metadata changes.
         self.containerMetaDataChanged.connect(self._clearQueryCache)
 
-        self._prepare_for_database_handlers = {}
-        self._insert_into_database_queries = {}
-        self._get_from_database_handlers = {}
         self._db_connection = None
 
-        self._cached_inserts = {}
         self._database_handlers = {}
         self._explicit_read_only_container_ids = set()  # type: Set[str]
 
@@ -417,11 +413,10 @@ class ContainerRegistry(ContainerRegistryInterface):
                         Logger.log("w", f"Invalid metadata for container {container_id}: {metadata}")
                         continue
                     modified_time = provider.getLastModifiedTime(container_id)
-                    if metadata["type"] in self._prepare_for_database_handlers:
+                    if metadata["type"] in self._database_handlers:
                         # Only add it to the database if we have an actual handler.
                         # TODO: Might need to change this in the future, but this allows for gradual implementation now
                         containers_to_add.append((container_id, metadata["name"], modified_time, metadata["type"]))
-
                         self._addToDatabaseInsertBatch(metadata)
 
                     self.metadata[container_id] = metadata

--- a/UM/Settings/ContainerRegistry.py
+++ b/UM/Settings/ContainerRegistry.py
@@ -435,6 +435,7 @@ class ContainerRegistry(ContainerRegistryInterface):
         # Since it could well be that we have to make a *lot* of changes to the database, we want to do that in
         # a single transaction to speed it up.
         cursor.execute('begin')
+        Logger.log("d", "Added %s containers to the database", len(containers_to_add))
         cursor.executemany("INSERT INTO containers (id, name, last_modified, container_type) VALUES (?, ?, ?, ?)", containers_to_add)
         self._insertAllCachedProfilesIntoDatabase(cursor)
         cursor.execute("commit")

--- a/UM/Settings/ContainerRegistry.py
+++ b/UM/Settings/ContainerRegistry.py
@@ -344,13 +344,13 @@ class ContainerRegistry(ContainerRegistryInterface):
         connection = apsw.Connection(os.path.join(Resources.getDataStoragePath(), "containers.db"))
         cursor = connection.cursor()
         cursor.execute("""
-                CREATE TABLE profiles(
+                CREATE TABLE containers(
                     id text,
                     name text,
                     last_modified integer,
                     container_type text
                 );
-                CREATE UNIQUE INDEX idx_profiles_id on profiles (id);
+                CREATE UNIQUE INDEX idx_containers_id on containers (id);
             """)
         return connection
 
@@ -364,14 +364,14 @@ class ContainerRegistry(ContainerRegistryInterface):
         return self._db_connection
 
     def _getProfileType(self, container_id: str, db_cursor):
-        db_cursor.execute("select id, container_type from profiles where id = ?", (container_id, ))
+        db_cursor.execute("select id, container_type from containers where id = ?", (container_id, ))
         row = db_cursor.fetchone()
         if row:
             return row[1]
         return None
 
     def _getProfileModificationTime(self, container_id: str, db_cursor):
-        query = f"select id, last_modified from profiles where id = '{container_id}'"
+        query = f"select id, last_modified from containers where id = '{container_id}'"
         db_cursor.execute(query)
         row = db_cursor.fetchone()
         if row:
@@ -411,9 +411,10 @@ class ContainerRegistry(ContainerRegistryInterface):
                     if metadata["type"] in self._add_to_database_handlers:
                         # Only add it to the database if we have an actual handler.
                         # TODO: Might need to change this in the future, but this allows for gradual implementation now
-                        cursor.execute("INSERT INTO profiles (id, name, last_modified, container_type) VALUES (?, ?, ?, ?)",
+                        cursor.execute("INSERT INTO containers (id, name, last_modified, container_type) VALUES (?, ?, ?, ?)",
                                                (container_id, metadata["name"], modified_time, metadata["type"]))
                         self._addMetadataToDatabase(metadata)
+
                     self.metadata[container_id] = metadata
                     self.source_provider[container_id] = provider
 

--- a/UM/Settings/DatabaseContainerMetadataController.py
+++ b/UM/Settings/DatabaseContainerMetadataController.py
@@ -1,29 +1,31 @@
-from typing import Tuple
+from typing import Tuple, Dict, Any, List
+
+metadata_type = Dict[str, Any]
 
 
 class DatabaseMetadataContainerController:
     def __init__(self, insert_query: str = "", select_query: str = "" ,update_query: str = "", table_query: str = "") -> None:
 
-        self._insert_batch = []
+        self._insert_batch: List[Tuple] = []
 
         self._insert_query = insert_query
         self._update_query = update_query
         self._table_query = table_query
         self._select_query = select_query
 
-    def setupTable(self, cursor):
+    def setupTable(self, cursor) -> None:
         cursor.execute(self._table_query)
 
-    def _convertMetadataToInsertBatch(self, metadata):
+    def _convertMetadataToInsertBatch(self, metadata: metadata_type) -> Tuple:
         raise NotImplementedError("Subclass of should provide way to convert metadata")
 
-    def _convertRawDataToMetadata(self, data):
+    def _convertRawDataToMetadata(self, data: Tuple) -> metadata_type:
         raise NotImplementedError("Subclass of should provide way to convert to metadata")
 
-    def addToInsertBatch(self, metadata):
+    def addToInsertBatch(self, metadata: metadata_type) -> None:
         self._insert_batch.append(self._convertMetadataToInsertBatch(metadata))
 
-    def getMetadata(self, container_id: str, cursor):
+    def getMetadata(self, container_id: str, cursor) -> metadata_type:
         result = cursor.execute(self._select_query, (container_id,))
         data = result.fetchone()
         return self._convertRawDataToMetadata(data)

--- a/UM/Settings/DatabaseContainerMetadataController.py
+++ b/UM/Settings/DatabaseContainerMetadataController.py
@@ -1,0 +1,41 @@
+from typing import Tuple
+
+
+class DatabaseMetadataContainerController:
+    def __init__(self, insert_query: str = "", select_query: str = "" ,update_query: str = "", table_query: str = "") -> None:
+
+        self._insert_batch = []
+
+        self._insert_query = insert_query
+        self._update_query = update_query
+        self._table_query = table_query
+        self._select_query = select_query
+
+    def setupTable(self, cursor):
+        cursor.execute(self._table_query)
+
+    def _convertMetadataToInsertBatch(self, metadata):
+        raise NotImplementedError("Subclass of should provide way to convert metadata")
+
+    def _convertRawDataToMetadata(self, data):
+        raise NotImplementedError("Subclass of should provide way to convert to metadata")
+
+    def addToInsertBatch(self, metadata):
+        self._insert_batch.append(self._convertMetadataToInsertBatch(metadata))
+
+    def getMetadata(self, container_id: str, cursor):
+        result = cursor.execute(self._select_query, (container_id,))
+        data = result.fetchone()
+        return self._convertRawDataToMetadata(data)
+
+    def executeAllBatchedInserts(self, cursor) -> None:
+        cursor.executemany(self._insert_query, self._insert_batch)
+        self._insert_batch.clear()
+
+    def insert(self, data: Tuple, cursor) -> None:
+        cursor.execute(self._insert_query, data)
+
+
+
+
+

--- a/UM/VersionUpgradeManager.py
+++ b/UM/VersionUpgradeManager.py
@@ -109,7 +109,8 @@ class VersionUpgradeManager:
             "plugins\\.*",    # Don't upgrade manually installed plug-ins.
             "plugins/.*",
             "./*packages\.json",
-            "./*plugins\.json"
+            "./*plugins\.json",
+            "./containers\.db"
         ]  # type: List[str]
 
     def registerIgnoredFile(self, file_name: str) -> None:

--- a/plugins/LocalContainerProvider/LocalContainerProvider.py
+++ b/plugins/LocalContainerProvider/LocalContainerProvider.py
@@ -54,6 +54,9 @@ class LocalContainerProvider(ContainerProvider):
             self._updatePathCache()
         return self._id_to_path.keys()
 
+    def getLastModifiedTime(self, container_id: str) -> Optional[float]:
+        return os.path.getmtime(self._id_to_path[container_id])
+
     def loadContainer(self, container_id: str) -> "ContainerInterface":
         # First get the actual (base) ID of the path we're going to read.
         file_path = self._id_to_path[container_id]  # Raises KeyError if container ID does not exist in the (cache of the) files.


### PR DESCRIPTION
Instead of re-reading the metadata from the files on every boot, which is pretty slow on windows (10+ seconds, even on machines with a fast SSD), we store the profiles in a database. By using the modified time of the files, we can check if the database needs updating. 

Creating the database is about as fast as what it used to do, but every subsequent run, it knocked my boot time from 10s on windows to 0.6s. It also increases the booting time on Linux, but there it's only 300ms faster. 

CURA-6096