### PR TITLE
CURA-8500: Safely convert message image sources to QUrls

### DIFF
--- a/UM/Qt/Bindings/VisibleMessagesModel.py
+++ b/UM/Qt/Bindings/VisibleMessagesModel.py
@@ -67,7 +67,7 @@ class VisibleMessagesModel(ListModel):
         message.progressChanged.connect(self._onMessageProgress)
 
     @staticmethod
-    def getImageSourceAsQUrl(image_source):
+    def getImageSourceAsQUrl(image_source: Union[QUrl, str]) -> QUrl:
         if type(image_source) is str:
             return QUrl.fromLocalFile(image_source)
         elif type(image_source) is QUrl:

--- a/UM/Qt/Bindings/VisibleMessagesModel.py
+++ b/UM/Qt/Bindings/VisibleMessagesModel.py
@@ -1,5 +1,6 @@
-# Copyright (c) 2015 Ultimaker B.V.
+# Copyright (c) 2021 Ultimaker B.V.
 # Uranium is released under the terms of the LGPLv3 or higher.
+from typing import Union
 
 from PyQt5.QtCore import Qt, QUrl
 

--- a/UM/Qt/Bindings/VisibleMessagesModel.py
+++ b/UM/Qt/Bindings/VisibleMessagesModel.py
@@ -56,7 +56,7 @@ class VisibleMessagesModel(ListModel):
             "actions": self.createActionsModel(message.getActions()),
             "dismissable": message.isDismissable(),
             "title": message.getTitle(),
-            "image_source": QUrl.fromLocalFile(message.getImageSource()),
+            "image_source": self.getImageSourceAsQUrl(message.getImageSource()),
             "image_caption": message.getImageCaption(),
             "option_text": message.getOptionText(),
             "option_state": message.getOptionState(),
@@ -65,6 +65,14 @@ class VisibleMessagesModel(ListModel):
         message.titleChanged.connect(self._onMessageTitleChanged)
         message.textChanged.connect(self._onMessageTextChanged)
         message.progressChanged.connect(self._onMessageProgress)
+
+    @staticmethod
+    def getImageSourceAsQUrl(image_source):
+        if type(image_source) is str:
+            return QUrl.fromLocalFile(image_source)
+        elif type(image_source) is QUrl:
+            return image_source
+        return QUrl.fromLocalFile("")
 
     def createActionsModel(self, actions):
         model = ListModel()


### PR DESCRIPTION
Some messages may already provide a QUrl as the image source. In such cases, Cura would crash because the `QUrl.fromLocalFile()` expects a string and not a QUrl as input. 
This is now accounted for to make sure that in the image source will not be converted to QUrl again.

CURA-8500