### PR TITLE
[CURA-8358/b] Fix (change name each time when) save to disk, then save to dl, then export to disk.

### DIFF
--- a/UM/OutputDevice/OutputDevice.py
+++ b/UM/OutputDevice/OutputDevice.py
@@ -36,7 +36,6 @@ class OutputDevice():
         self._description = "Do something with an unknown device"
         self._icon_name = "generic_device"
         self._priority = 0
-        self._last_filename = None  # Optional[str]
 
     metaDataChanged = Signal()
 

--- a/UM/OutputDevice/ProjectOutputDevice.py
+++ b/UM/OutputDevice/ProjectOutputDevice.py
@@ -78,8 +78,8 @@ class ProjectOutputDevice(QObject, OutputDevice):
 
     @staticmethod
     def getLastOutputName() -> Optional[str]:
-        return OutputDevice.last_out_name
+        return ProjectOutputDevice.last_out_name
 
     @staticmethod
     def setLastOutputName(name: Optional[str] = None) -> None:
-        OutputDevice.last_out_name = name
+        ProjectOutputDevice.last_out_name = name

--- a/UM/OutputDevice/ProjectOutputDevice.py
+++ b/UM/OutputDevice/ProjectOutputDevice.py
@@ -23,6 +23,10 @@ class ProjectOutputDevice(QObject, OutputDevice):
     """Signal which informs whether the project output device has been enabled or disabled, so that it can be added or removed 
      from the 'File->Save Project...' submenu"""
 
+    last_out_name = None  # type: Optional[str]
+    """Last output project name, gives the possibility to do something with the updated project-name on saving, if any.
+    """
+
     def __init__(self, device_id: str, add_to_output_devices: bool = False, parent = None, **kwargs):
         super().__init__(device_id = device_id, parent = parent)
 
@@ -46,11 +50,6 @@ class ProjectOutputDevice(QObject, OutputDevice):
         self.shortcut = None  # type: Optional[str]
         """
         Shortcut key combination
-        """
-
-        self._last_out_name = None  # type: Optional[str]
-        """
-        Last output project name, gives the possibility to do something with the updated project-name on saving, if any.
         """
 
     @property
@@ -77,8 +76,10 @@ class ProjectOutputDevice(QObject, OutputDevice):
                 else:
                     Application.getInstance().getOutputDeviceManager().removeOutputDevice(self.getId())
 
-    def getLastOutputName(self) -> Optional[str]:
-        return self._last_out_name
+    @staticmethod
+    def getLastOutputName() -> Optional[str]:
+        return OutputDevice.last_out_name
 
-    def setLastOutputName(self, name: Optional[str] = None) -> None:
-        self._last_out_name = name
+    @staticmethod
+    def setLastOutputName(name: Optional[str] = None) -> None:
+        OutputDevice.last_out_name = name


### PR DESCRIPTION
When altering the name of a project when saving a project to output device A, then altering the name while saving it to output device B, then altering the name again, and _exporting_ to output device A again, the name as saved first to output device A will be the project name again, after saving the correct name via output device A.

Anyway, I made the variable static and now it shares the last saved _project_ name between all output devices, so things like that shouldn't happen again :-)
