### PR TITLE
Fix Insecure deserialization of DefinitionContainer

### DIFF
--- a/UM/Settings/DefinitionContainerUnpickler.py
+++ b/UM/Settings/DefinitionContainerUnpickler.py
@@ -1,0 +1,28 @@
+import pickle
+
+safe_globals = {
+    "UM.Settings.DefinitionContainer.DefinitionContainer",
+    "collections.OrderedDict",
+    "UM.Settings.SettingDefinition.SettingDefinition",
+    "UM.Settings.SettingFunction.SettingFunction",
+    "UM.Settings.SettingRelation.SettingRelation",
+    "UM.Settings.SettingRelation.RelationType"
+}
+
+
+class DefinitionContainerUnpickler(pickle.Unpickler):
+    """
+    Pickle by itself is not safe at all. We can't use any kind of signing, since the code itself is open (and at that
+    point it would be trivially easy to read the secret used to sign it).
+
+    What we can do is simply whitelist the things that the DefinitionContainer needs (and prevent everything else!)
+
+    This obviously only protects against malicious cache files where the attacker (or user) can't modify the python
+    files. This is common for setups where users don't have admin permission or have other more strict restrictions.
+    """
+    def find_class(self, module, name):
+        if module + "." + name in safe_globals:
+            return super().find_class(module, name)
+
+        # Raise exception for everything that isn't in the safe list.
+        raise pickle.UnpicklingError(f"global '{module}.{name}' is forbidden")

--- a/plugins/LocalContainerProvider/LocalContainerProvider.py
+++ b/plugins/LocalContainerProvider/LocalContainerProvider.py
@@ -253,6 +253,8 @@ class LocalContainerProvider(ContainerProvider):
         try:
             with open(cache_path, "rb") as f:
                 definition = pickle.load(f)
+                # Defend a bit against injected files to deserialize.
+                assert type(definition) == DefinitionContainer, "Can only restore DefinitionContainers from cache!"
         except Exception as e: #TODO: Switch to multi-catch once we've upgraded to Python 3.6. Catch: OSError, PermissionError, IOError, AttributeError, EOFError, ImportError, IndexError and UnpicklingError.
             Logger.log("w", "Failed to load definition {definition_id} from cached file: {error_msg}".format(definition_id = definition_id, error_msg = str(e)))
             return None

--- a/plugins/LocalContainerProvider/LocalContainerProvider.py
+++ b/plugins/LocalContainerProvider/LocalContainerProvider.py
@@ -255,7 +255,7 @@ class LocalContainerProvider(ContainerProvider):
             with open(cache_path, "rb") as f:
                 # The DefinitionContainerUnpickler has a list of whitelisted globals
                 definition = DefinitionContainerUnpickler(f).load()
-        except Exception as e: #TODO: Switch to multi-catch once we've upgraded to Python 3.6. Catch: OSError, PermissionError, IOError, AttributeError, EOFError, ImportError, IndexError and UnpicklingError.
+        except (OSError, PermissionError, IOError, AttributeError, EOFError, ImportError, IndexError, pickle.UnpicklingError) as e:
             Logger.log("w", "Failed to load definition {definition_id} from cached file: {error_msg}".format(definition_id = definition_id, error_msg = str(e)))
             return None
 

--- a/plugins/LocalContainerProvider/LocalContainerProvider.py
+++ b/plugins/LocalContainerProvider/LocalContainerProvider.py
@@ -17,6 +17,7 @@ from UM.SaveFile import SaveFile
 from UM.Settings.ContainerProvider import ContainerProvider  # The class we're implementing.
 from UM.Settings.ContainerRegistry import ContainerRegistry  # To get the resource types for containers.
 from UM.Settings.DefinitionContainer import DefinitionContainer  # To check if we need to cache this container.
+from UM.Settings.DefinitionContainerUnpickler import DefinitionContainerUnpickler
 
 MYPY = False
 if MYPY:  # Things to import for type checking only.
@@ -252,9 +253,8 @@ class LocalContainerProvider(ContainerProvider):
 
         try:
             with open(cache_path, "rb") as f:
-                definition = pickle.load(f)
-                # Defend a bit against injected files to deserialize.
-                assert type(definition) == DefinitionContainer, "Can only restore DefinitionContainers from cache!"
+                # The DefinitionContainerUnpickler has a list of whitelisted globals
+                definition = DefinitionContainerUnpickler(f).load()
         except Exception as e: #TODO: Switch to multi-catch once we've upgraded to Python 3.6. Catch: OSError, PermissionError, IOError, AttributeError, EOFError, ImportError, IndexError and UnpicklingError.
             Logger.log("w", "Failed to load definition {definition_id} from cached file: {error_msg}".format(definition_id = definition_id, error_msg = str(e)))
             return None


### PR DESCRIPTION
CURA-8399 

We used to just load stuff from pickle. This meant that malicious stuff could be done if the cache was somehow compromised. 