### PR TITLE
Repaired Views dropdown in Preview stage

### DIFF
--- a/UM/Qt/Bindings/ViewModel.py
+++ b/UM/Qt/Bindings/ViewModel.py
@@ -5,7 +5,6 @@ from PyQt5.QtCore import Qt
 
 from UM.Qt.ListModel import ListModel
 from UM.Application import Application
-from UM.PluginRegistry import PluginRegistry
 
 
 class ViewModel(ListModel):
@@ -36,15 +35,7 @@ class ViewModel(ListModel):
             return
 
         for view_id,view in views.items():
-            # A view may be named as "PluginName" or "PluginName_ViewName" (in case of plugins with 2+ views)
-            plugin_name = view.getPluginId()
             view_meta_data = view.getMetaData()
-
-            # If a plugin has multiple views, we get a list of dicts and filter for the one we want
-            # Note: will only work if metadata 'name' and View's _name have the same value
-            if type(view_meta_data) == list:
-                view_name = view_id.split('_', maxsplit=1)[1]  # Get everything after the first '_'
-                view_meta_data = list(filter(lambda view: view['name'] == view_name , view_meta_data))[0]
 
             # Skip view modes that are marked as not visible
             if "visible" in view_meta_data and not view_meta_data["visible"]:

--- a/UM/Qt/Bindings/ViewModel.py
+++ b/UM/Qt/Bindings/ViewModel.py
@@ -35,8 +35,16 @@ class ViewModel(ListModel):
         if current_view is None:
             return
 
-        for view_id in views:
-            view_meta_data = PluginRegistry.getInstance().getMetaData(view_id).get("view", {})
+        for view_id,view in views.items():
+            # A view may be named as "PluginName" or "PluginName_ViewName" (in case of plugins with 2+ views)
+            plugin_name = view.getPluginId()
+            view_meta_data = PluginRegistry.getInstance().getMetaData(plugin_name).get("view", {})
+
+            # If a plugin has multiple views, we get a list of dicts and filter for the one we want
+            # Note: will only work if metadata 'name' and View's _name have the same value
+            if type(view_meta_data) == list:
+                view_name = view_id.split('_', maxsplit=1)[1]  # Get everything after the first '_'
+                view_meta_data = list(filter(lambda view: view['name'] == view_name , view_meta_data))[0]
 
             # Skip view modes that are marked as not visible
             if "visible" in view_meta_data and not view_meta_data["visible"]:

--- a/UM/Qt/Bindings/ViewModel.py
+++ b/UM/Qt/Bindings/ViewModel.py
@@ -38,7 +38,7 @@ class ViewModel(ListModel):
         for view_id,view in views.items():
             # A view may be named as "PluginName" or "PluginName_ViewName" (in case of plugins with 2+ views)
             plugin_name = view.getPluginId()
-            view_meta_data = PluginRegistry.getInstance().getMetaData(plugin_name).get("view", {})
+            view_meta_data = view.getMetaData()
 
             # If a plugin has multiple views, we get a list of dicts and filter for the one we want
             # Note: will only work if metadata 'name' and View's _name have the same value


### PR DESCRIPTION
(for plugins with 2 views or more)

If a view has a _name, its ID is not PluginName but rather PluginName_ViewName. This is necessary to give unique IDs to each view in a plugin that has multiple views. However, it breaks this line:
```
   view_meta_data = PluginRegistry.getInstance().getMetaData(view_id).get("view", {})
```
because it tries to look for a plugin called PluginName_ViewName.

More info in [Cura forums thread](https://community.ultimaker.com/topic/38259-plugin-development-hide-a-new-view-from-the-view-selector-in-preview-stage/?tab=comments#comment-297251) & issue #744.