### PR TITLE
Round coordinates on getFaceIdAtPosition

### DIFF
--- a/UM/View/SelectionPass.py
+++ b/UM/View/SelectionPass.py
@@ -158,8 +158,8 @@ class SelectionPass(RenderPass):
 
         window_size = self._renderer.getWindowSize()
 
-        px = (0.5 + x / 2.0) * window_size[0]
-        py = (0.5 + y / 2.0) * window_size[1]
+        px = round((0.5 + x / 2.0) * window_size[0])
+        py = round((0.5 + y / 2.0) * window_size[1])
 
         if px < 0 or px > (output.width() - 1) or py < 0 or py > (output.height() - 1):
             return -1


### PR DESCRIPTION
PyQt Pixel expects integer coordinates as parameters.

This fixes the crash on cura when using the
"Select face to align to the build plate" tool