### PR TITLE
Prevent unneeded copy in container query

### DIFF
--- a/UM/Settings/ContainerQuery.py
+++ b/UM/Settings/ContainerQuery.py
@@ -87,7 +87,7 @@ class ContainerQuery:
         # cache if it's not there yet.
         key_so_far = (self._ignore_case, )  # type: Tuple[Any, ...]
         if candidates is None:
-            filtered_candidates = list(self._registry.metadata.values())
+            filtered_candidates = self._registry.metadata.values()
         else:
             filtered_candidates = candidates
 

--- a/UM/Settings/ContainerQuery.py
+++ b/UM/Settings/ContainerQuery.py
@@ -3,7 +3,7 @@
 
 import collections  # To cache queries.
 import re
-from typing import Any, cast, Dict, List, Optional, Tuple, Type, TYPE_CHECKING
+from typing import Any, cast, Dict, List, Optional, Tuple, Type, TYPE_CHECKING, Union, ValuesView
 import functools
 
 if TYPE_CHECKING:
@@ -87,9 +87,9 @@ class ContainerQuery:
         # cache if it's not there yet.
         key_so_far = (self._ignore_case, )  # type: Tuple[Any, ...]
         if candidates is None:
-            filtered_candidates = self._registry.metadata.values()
+            filtered_candidates: Union[ValuesView[Dict[str, Any]], List[Dict[str, Any]]] = self._registry.metadata.values()
         else:
-            filtered_candidates = candidates
+            filtered_candidates = cast(List[Dict[str, Any]], candidates)
 
         # Filter on all the key-word arguments one by one.
         for key, value in self._kwargs.items():  # For each progressive filter...
@@ -121,6 +121,8 @@ class ContainerQuery:
                 self.cache[key_so_far] = ContainerQuery(self._registry, ignore_case = self._ignore_case, **cached_arguments)  # Cache this query for the next time.
                 self.cache[key_so_far]._result = filtered_candidates
 
+        if not isinstance(filtered_candidates, list):
+            filtered_candidates = list(filtered_candidates)
         self._result = filtered_candidates
 
     def __str__(self):


### PR DESCRIPTION
By adding the values of the medatada dict to a list, a complete copy of the list is made. This isn't actually needed, since we just want to filter results (wich are then copied to a list). As unneeded copies tend to be on the expensive side, this makes profile loading a lot faster