### PR TITLE
Fix invalid string escapes

### DIFF
--- a/UM/Settings/InstanceContainer.py
+++ b/UM/Settings/InstanceContainer.py
@@ -50,9 +50,9 @@ class InstanceContainer(QObject, ContainerInterface, PluginObject):
     """A container for SettingInstance objects."""
 
     Version = 4
-    version_regex = re.compile("\nversion ?= ?(\d+)")
-    setting_version_regex = re.compile("\nsetting_version ?= ?(\d+)")
-    type_regex = re.compile("\ntype ?= ?(\w+)")
+    version_regex = re.compile(r"\nversion ?= ?(\d+)")
+    setting_version_regex = re.compile(r"\nsetting_version ?= ?(\d+)")
+    type_regex = re.compile(r"\ntype ?= ?(\w+)")
 
     def __init__(self, container_id: str, parent: QObject = None, *args: Any, **kwargs: Any) -> None:
         """Constructor

--- a/UM/VersionUpgrade.py
+++ b/UM/VersionUpgrade.py
@@ -19,8 +19,8 @@ class VersionUpgrade(PluginObject):
         """Initialises a version upgrade plugin instance."""
 
         super().__init__()
-        self._version_regex = re.compile("\nversion ?= ?(\d+)")
-        self._setting_version_regex = re.compile("\nsetting_version ?= ?(\d+)")
+        self._version_regex = re.compile(r"\nversion ?= ?(\d+)")
+        self._setting_version_regex = re.compile(r"\nsetting_version ?= ?(\d+)")
 
     def getCfgVersion(self, serialised: str) -> int:
         """

--- a/UM/VersionUpgradeManager.py
+++ b/UM/VersionUpgradeManager.py
@@ -95,11 +95,11 @@ class VersionUpgradeManager:
 
         #Regular expressions of the files that should not be checked, such as log files.
         self._ignored_files = [
-            ".*\.lock",       # Don't upgrade the configuration file lock. It's not persistent.
-            "plugins\.json",  # plugins.json and packages.json need to remain the same for the version upgrade plug-ins.
-            "packages\.json",
-            ".*\.log",        # Don't process the log. It's not needed and it could be really big.
-            ".*\.log.?",      # Don't process the backup of the log. It's not needed and it could be really big.
+            ".*\\.lock",       # Don't upgrade the configuration file lock. It's not persistent.
+            "plugins\\.json",  # plugins.json and packages.json need to remain the same for the version upgrade plug-ins.
+            "packages\\.json",
+            ".*\\.log",        # Don't process the log. It's not needed and it could be really big.
+            ".*\\.log.?",      # Don't process the backup of the log. It's not needed and it could be really big.
             "3.[0-3]\\.*",    # Don't upgrade folders that are back-ups from older version upgrades. Until v3.3 we stored the back-up in the config folder itself.
             "3.[0-3]/.*",
             "2.[0-7]\\.*",
@@ -108,8 +108,8 @@ class VersionUpgradeManager:
             "cura/.*",
             "plugins\\.*",    # Don't upgrade manually installed plug-ins.
             "plugins/.*",
-            "./*packages\.json",
-            "./*plugins\.json"
+            "./*packages\\.json",
+            "./*plugins\\.json"
         ]  # type: List[str]
 
     def registerIgnoredFile(self, file_name: str) -> None:


### PR DESCRIPTION
Invalid string escapes print ugly DeprecationWarnings, but might result
in SyntaxErrors somewhen in the future. I'd rather fix them, so my Log
files aren't cluttered with pointless warnings.

Currently starting Cura will look like that for me:

```
/usr/lib/python3.10/site-packages/UM/PluginRegistry.py:4: DeprecationWarning: the imp module is deprecated in favour of importlib and slated for removal in Python 3.12; see the module's documentation for alternative uses
  import imp
/usr/lib/python3.10/site-packages/UM/Settings/InstanceContainer.py:53: DeprecationWarning: invalid escape sequence '\d'
  version_regex = re.compile("\nversion ?= ?(\d+)")
/usr/lib/python3.10/site-packages/UM/Settings/InstanceContainer.py:55: DeprecationWarning: invalid escape sequence '\w'
  type_regex = re.compile("\ntype ?= ?(\w+)")
/usr/lib/python3.10/site-packages/UM/VersionUpgradeManager.py:98: DeprecationWarning: invalid escape sequence '\.'
  ".*\.lock",       # Don't upgrade the configuration file lock. It's not persistent.
```

The first warning is mentioned in #765 (and not addressed in this PR), the other warnings are easy enough to fix. 


<s>This PR also contains some PEP8 formatting changes my IDE does on save. I can remove those changes from the PR if requested, but usually don't see any harm keeping them. </s>