### PR TITLE
Split requestWrite to Allow Intercepting Writes.

### DIFF
--- a/plugins/LocalFileOutputDevice/LocalFileOutputDevice.py
+++ b/plugins/LocalFileOutputDevice/LocalFileOutputDevice.py
@@ -139,6 +139,18 @@ class LocalFileOutputDevice(ProjectOutputDevice):
             result = QMessageBox.question(None, catalog.i18nc("@title:window", "File Already Exists"), catalog.i18nc("@label Don't translate the XML tag <filename>!", "The file <filename>{0}</filename> already exists. Are you sure you want to overwrite it?").format(file_name))
             if result == QMessageBox.No:
                 raise OutputDeviceError.UserCanceledError()
+        self._performWrite(file_name, selected_type, file_handler, nodes)
+
+    def _performWrite(self, file_name, selected_type, file_handler, nodes):
+        """Writes the specified nodes to a file. This is split from requestWrite to allow interception
+        in other plugins. See Ultimaker/Cura#10918.
+
+        :param file_name: File path to write to.
+        :param selected_type: Selected file type to write.
+        :param file_handler: File handler for writing to the file.
+        :param nodes: A collection of scene nodes that should be written to the
+        file.
+        """
 
         # Actually writing file
         if file_handler:

--- a/plugins/LocalFileOutputDevice/LocalFileOutputDevice.py
+++ b/plugins/LocalFileOutputDevice/LocalFileOutputDevice.py
@@ -143,7 +143,7 @@ class LocalFileOutputDevice(ProjectOutputDevice):
 
     def _performWrite(self, file_name, selected_type, file_handler, nodes):
         """Writes the specified nodes to a file. This is split from requestWrite to allow interception
-        in other plugins. See Ultimaker/Cura#10918.
+        in other plugins. See Ultimaker/Cura#10917.
 
         :param file_name: File path to write to.
         :param selected_type: Selected file type to write.


### PR DESCRIPTION
This pull request splits the `requestWrite` method in the `LocalFileOutputDevice` plugin to allow intercepting of writes for logging purposes. The specifics of this are covered in Ultimaker/Cura#10917.

Example usage for The Construct @ RIT that uses a patch to get this change: https://github.com/TheConstructRIT/Construct-Cura-Plugins/blob/master/ConstructPaymentWindow/__init__.py