### PR TITLE
Azis and transform widget visualisation improvements

### DIFF
--- a/plugins/Tools/RotateTool/RotateToolHandle.py
+++ b/plugins/Tools/RotateTool/RotateToolHandle.py
@@ -35,7 +35,7 @@ class RotateToolHandle(ToolHandle):
         self._handle_offset_a = self._inner_radius * math.cos(math.radians(self._angle_offset))
         self._handle_offset_b = self._inner_radius * math.sin(math.radians(self._angle_offset))
 
-        self._handle_height = 7
+        self._handle_height = 5
         self._handle_width = 3
         self._active_handle_height = 9
         self._active_handle_width = 7

--- a/plugins/Tools/RotateTool/RotateToolHandle.py
+++ b/plugins/Tools/RotateTool/RotateToolHandle.py
@@ -26,7 +26,7 @@ class RotateToolHandle(ToolHandle):
         self._name = "RotateToolHandle"
         self._inner_radius = 40
         self._outer_radius = 40.5
-        self._line_width = 0.5
+        self._line_width = 0.3
         self._active_inner_radius = 37
         self._active_outer_radius = 44
         self._active_line_width = 3

--- a/plugins/Tools/ScaleTool/ScaleToolHandle.py
+++ b/plugins/Tools/ScaleTool/ScaleToolHandle.py
@@ -12,7 +12,7 @@ class ScaleToolHandle(ToolHandle):
     def __init__(self, parent = None):
         super().__init__(parent)
         self._handle = "ScaleToolHandle"
-        self._line_width = 0.5
+        self._line_width = 0.3
         self._line_length= 40
         self._handle_position = 40
         self._handle_width = 4

--- a/plugins/Tools/TranslateTool/TranslateToolHandle.py
+++ b/plugins/Tools/TranslateTool/TranslateToolHandle.py
@@ -16,7 +16,7 @@ class TranslateToolHandle(ToolHandle):
         self._line_width = 0.3
         self._line_length = 40
         self._handle_position = 40
-        self._handle_height = 7
+        self._handle_height = 5
         self._handle_width = 3
 
         self._active_line_width = 0.8

--- a/plugins/Tools/TranslateTool/TranslateToolHandle.py
+++ b/plugins/Tools/TranslateTool/TranslateToolHandle.py
@@ -13,7 +13,7 @@ class TranslateToolHandle(ToolHandle):
         super().__init__(parent)
         self._name = "TranslateToolHandle"
         self._enabled_axis = [self.XAxis, self.YAxis, self.ZAxis]
-        self._line_width = 0.5
+        self._line_width = 0.3
         self._line_length = 40
         self._handle_position = 40
         self._handle_height = 7

--- a/resources/shaders/composite.shader
+++ b/resources/shaders/composite.shader
@@ -35,7 +35,7 @@ fragment =
 
     float kernel[9];
 
-    const vec3 x_axis = vec3(1.0, 0.0, 0.0);
+    const vec3 x_axis = vec3(0.0, 0.0, 0.0);
     const vec3 y_axis = vec3(0.0, 1.0, 0.0);
     const vec3 z_axis = vec3(0.0, 0.0, 1.0);
 

--- a/resources/shaders/toolhandle.shader
+++ b/resources/shaders/toolhandle.shader
@@ -18,19 +18,19 @@ vertex =
 fragment =
     uniform lowp vec4 u_disabledColor;
     uniform lowp vec4 u_activeColor;
-    uniform lowp float u_disabledMultiplier;
+    uniform lowp float u_enableMultiplier;
 
     varying lowp vec4 v_color;
 
     void main()
     {
-        if(u_activeColor == v_color)
+      if(u_activeColor == v_color)
         {
-            gl_FragColor = v_color;
+            frag_color = v_color * u_enableMultiplier;
         }
         else
         {
-            gl_FragColor = v_color * u_disabledMultiplier;
+            frag_color = v_color;
         }
     }
 
@@ -55,7 +55,7 @@ fragment41core =
     #version 410
     uniform lowp vec4 u_disabledColor;
     uniform lowp vec4 u_activeColor;
-    uniform lowp float u_disabledMultiplier;
+    uniform lowp float u_enableMultiplier;
 
     in lowp vec4 v_color;
     out vec4 frag_color;
@@ -64,18 +64,19 @@ fragment41core =
     {
         if(u_activeColor == v_color)
         {
-            frag_color = v_color;
+            frag_color = v_color * u_enableMultiplier;
         }
         else
         {
-            frag_color = v_color * u_disabledMultiplier;
+            frag_color = v_color;
         }
     }
 
 [defaults]
 u_disabledColor = [0.5, 0.5, 0.5, 1.0]
 u_activeColor = [0.5, 0.5, 0.5, 1.0]
-u_disabledMultiplier = 0.75
+u_enableMultiplier = 1.2
+
 
 [bindings]
 u_modelMatrix = model_matrix


### PR DESCRIPTION
This PR Improve the visualization of the widgets used to translate, rotate, mirror and scale. 
- minor adjustments were made to the shape of the 3d arrows for translate and rotate
- the line thickness of the widget was decreased
- and to keep the colours of the axis aligned with the origin widget color the behaviour of the over was changed: Instead of decreasing the brightness on hover, we now increase the brightness.

See also https://github.com/Ultimaker/Cura/pull/11486