### PR TITLE
Add a preference to make tray icon optional

### DIFF
--- a/UM/Qt/QtApplication.py
+++ b/UM/Qt/QtApplication.py
@@ -517,9 +517,6 @@ class QtApplication(QApplication, Application):
         if self._qml_engine:
             self._qml_engine.deleteLater()
 
-        if self._tray_icon_widget:
-            self._tray_icon_widget.deleteLater()
-
         self.quit()
 
     def checkWindowMinimizedState(self) -> bool:

--- a/UM/Qt/QtApplication.py
+++ b/UM/Qt/QtApplication.py
@@ -275,10 +275,13 @@ class QtApplication(QApplication, Application):
                 continue
             self._recent_files.append(QUrl.fromLocalFile(file_name))
 
+        self._preferences.addPreference("general/use_tray_icon", True)
+        use_tray_icon = self._preferences.getValue("general/use_tray_icon")
+
         if not self.getIsHeadLess():
             # Initialize System tray icon and make it invisible because it is used only to show pop up messages
             self._tray_icon = None
-            if self._tray_icon_name:
+            if use_tray_icon and self._tray_icon_name:
                 try:
                     self._tray_icon = QIcon(Resources.getPath(Resources.Images, self._tray_icon_name))
                     self._tray_icon_widget = QSystemTrayIcon(self._tray_icon)


### PR DESCRIPTION
This PR adds a preference to make the system tray icon (and notifications popped up from it) optional.

The PR also has a minor cleanup of a merge conflict from long ago.

This is a partial fix for https://github.com/Ultimaker/Cura/issues/11476 and https://github.com/Ultimaker/Cura/issues/2687. Also see the companion PR for Cura.