### PR TITLE
Make dialogs draggable

### DIFF
--- a/UM/Qt/qml/UM/Dialog.qml
+++ b/UM/Qt/qml/UM/Dialog.qml
@@ -1,4 +1,4 @@
-// Copyright (c) 2017 Ultimaker B.V.
+// Copyright (c) 2022 Ultimaker B.V.
 // Uranium is released under the terms of the LGPLv3 or higher.
 
 import QtQuick 2.10
@@ -12,8 +12,8 @@ Window
 {
     id: base
 
-    modality: Qt.ApplicationModal;
-    flags: Qt.Dialog | Qt.CustomizeWindowHint | Qt.WindowTitleHint | Qt.WindowCloseButtonHint;
+    modality: Qt.ApplicationModal
+    flags: Qt.CustomizeWindowHint | Qt.WindowTitleHint | Qt.WindowCloseButtonHint
 
     minimumWidth: screenScaleFactor * 640;
     minimumHeight: screenScaleFactor * 480;


### PR DESCRIPTION
Fixed by removing the `Qt.Dialog` flag. According to the [documentation](https://doc.qt.io/qt-5/qt.html#WindowType-enum) this flag achieves two things
- block events to the main window
- Only present the close button in the dialog title bar, and leave out the minimize, full screen buttons

When removing the `Qt.Dialog` flag the behavior was still as expected. Was only able to test this on Ubuntu.

CURA-8988