### PR TITLE
[CURA-8943] Update Tool Panel Icons style

### DIFF
--- a/UM/Qt/qml/UM/Enums.qml
+++ b/UM/Qt/qml/UM/Enums.qml
@@ -1,0 +1,14 @@
+// Copyright (c) 2022 Ultimaker B.V.
+// Uranium is released under the terms of the LGPLv3 or higher.
+
+import QtQuick 2.15
+import QtQuick.Controls 2.10
+
+Item
+{
+    enum ContentAlignment
+    {
+        AlignLeft,
+        AlignRight
+    }
+}

--- a/UM/Qt/qml/UM/ToolTip.qml
+++ b/UM/Qt/qml/UM/ToolTip.qml
@@ -9,7 +9,7 @@ import UM 1.5 as UM
 ToolTip
 {
     // Defines the alignment of the content, by default to the left
-    property int contentAlignment: Text.AlignRight
+    property int contentAlignment: UM.Enums.ContentAlignment.AlignRight
 
     property alias tooltipText: tooltip.text
     property alias arrowSize: backgroundRect.arrowSize
@@ -35,7 +35,7 @@ ToolTip
 
     x:
     {
-        if (contentAlignment == Text.AlignLeft)
+        if (contentAlignment == UM.Enums.ContentAlignment.AlignLeft)
         {
             return (label.width + Math.round(UM.Theme.getSize("default_arrow").width * 1.2) + padding * 2) * -1
         }

--- a/UM/Qt/qml/UM/ToolTip.qml
+++ b/UM/Qt/qml/UM/ToolTip.qml
@@ -1,0 +1,75 @@
+// Copyright (c) 2022 Ultimaker B.V.
+// Uranium is released under the terms of the LGPLv3 or higher.
+
+import QtQuick 2.7
+import QtQuick.Controls 2.3
+
+import UM 1.5 as UM
+
+ToolTip
+{
+    // Defines the alignment of the content, by default to the left
+    property int contentAlignment: Text.AlignRight
+
+    property alias tooltipText: tooltip.text
+    property alias arrowSize: backgroundRect.arrowSize
+    property var targetPoint: Qt.point(parent.x, y + Math.round(height/2))
+
+    id: tooltip
+    text: ""
+    delay: 500
+    font: UM.Theme.getFont("default")
+    visible: opacity != 0.0
+    opacity: 0.0 // initially hidden
+
+    Behavior on opacity
+    {
+        NumberAnimation { duration: 100; }
+    }
+
+    onAboutToShow: show()
+    onAboutToHide: hide()
+
+    // If the text is not set, just set the height to 0 to prevent it from showing
+    height: label.contentHeight + 2 * UM.Theme.getSize("thin_margin").width
+
+    x:
+    {
+        if (contentAlignment == Text.AlignLeft)
+        {
+            return (label.width + Math.round(UM.Theme.getSize("default_arrow").width * 1.2) + padding * 2) * -1
+        }
+        return parent.width + Math.round(UM.Theme.getSize("default_arrow").width * 1.2 + padding)
+    }
+
+    y: Math.round(parent.height / 2 - label.height / 2 ) - padding
+
+    padding: UM.Theme.getSize("thin_margin").width
+
+    background: UM.PointingRectangle
+    {
+        id: backgroundRect
+        color: UM.Theme.getColor("tooltip")
+        target: Qt.point(targetPoint.x - tooltip.x, targetPoint.y - tooltip.y)
+        arrowSize: UM.Theme.getSize("default_arrow").width
+        visible: tooltip.height != 0
+    }
+
+    contentItem: UM.Label
+    {
+        id: label
+        text: tooltip.text
+        font: tooltip.font
+        wrapMode: Text.Wrap
+        textFormat: Text.RichText
+        color: UM.Theme.getColor("tooltip_text")
+    }
+
+    function show() {
+        opacity = text != "" ? 1 : 0
+    }
+
+    function hide() {
+        opacity = 0
+    }
+}

--- a/UM/Qt/qml/UM/ToolTip.qml
+++ b/UM/Qt/qml/UM/ToolTip.qml
@@ -35,11 +35,13 @@ ToolTip
 
     x:
     {
-        if (contentAlignment == UM.Enums.ContentAlignment.AlignLeft)
+        switch (contentAlignment)
         {
-            return (label.width + Math.round(UM.Theme.getSize("default_arrow").width * 1.2) + padding * 2) * -1
+            case UM.Enums.ContentAlignment.AlignLeft:
+                return (label.width + Math.round(UM.Theme.getSize("default_arrow").width * 1.2) + padding * 2) * -1;
+            case UM.Enums.ContentAlignment.AlignRight:
+                return parent.width + Math.round(UM.Theme.getSize("default_arrow").width * 1.2 + padding);
         }
-        return parent.width + Math.round(UM.Theme.getSize("default_arrow").width * 1.2 + padding)
     }
 
     y: Math.round(parent.height / 2 - label.height / 2 ) - padding

--- a/UM/Qt/qml/UM/ToolbarButton.qml
+++ b/UM/Qt/qml/UM/ToolbarButton.qml
@@ -1,0 +1,109 @@
+// Copyright (c) 2022 Ultimaker B.V.
+// Uranium is released under the terms of the LGPLv3 or higher.
+
+import QtQuick 2.7
+import QtQuick.Controls 2.3
+
+import UM 1.5 as UM
+
+Button
+{
+    id: base
+
+    property alias toolItem: contentItemLoader.sourceComponent
+
+    // These two properties indicate whether the toolbar button is at the top of the toolbar column or at the bottom.
+    // If it is somewhere in the middle, then both has to be false. If there is only one element in the column, then
+    // both properties have to be set to true. This is used to create a rounded corner.
+    property bool isTopElement: false
+    property bool isBottomElement: false
+
+    hoverEnabled: true
+
+    background: Rectangle
+    {
+        implicitWidth: UM.Theme.getSize("button").width
+        implicitHeight: UM.Theme.getSize("button").height
+        color: UM.Theme.getColor("toolbar_background")
+        radius: UM.Theme.getSize("default_radius").width
+
+        Rectangle
+        {
+            id: topSquare
+            anchors
+            {
+                left: parent.left
+                right: parent.right
+                top: parent.top
+            }
+            height: parent.radius
+            color: parent.color
+            visible: !base.isTopElement
+        }
+
+        Rectangle
+        {
+            id: bottomSquare
+            anchors
+            {
+                left: parent.left
+                right: parent.right
+                bottom: parent.bottom
+            }
+            height: parent.radius
+            color: parent.color
+            visible: !base.isBottomElement
+        }
+
+        Rectangle
+        {
+            id: leftSquare
+            anchors
+            {
+                left: parent.left
+                top: parent.top
+                bottom: parent.bottom
+            }
+            width: parent.radius
+            color: parent.color
+        }
+    }
+    contentItem: Rectangle
+    {
+        opacity: parent.enabled ? 1.0 : 0.2
+        implicitWidth: Math.round(UM.Theme.getSize("button").width * 0.75)
+        implicitHeight: Math.round(UM.Theme.getSize("button").height * 0.75)
+        radius: Math.round(width * 0.5)
+
+        color:
+        {
+            if (base.checked && base.hovered)
+            {
+                return UM.Theme.getColor("toolbar_button_active_hover")
+            }
+            else if (base.checked)
+            {
+                return UM.Theme.getColor("toolbar_button_active")
+            }
+            else if(base.hovered)
+            {
+                return UM.Theme.getColor("toolbar_button_hover")
+            }
+            return UM.Theme.getColor("toolbar_background")
+        }
+        Loader
+        {
+            id: contentItemLoader
+            anchors.centerIn: parent
+            width: Math.round(UM.Theme.getSize("button").width / 2)
+            height: Math.round(UM.Theme.getSize("button").height / 2)
+        }
+    }
+
+    UM.ToolTip
+    {
+        id: tooltip
+        tooltipText: base.text
+        visible: base.hovered
+    }
+}

--- a/UM/Qt/qml/UM/qmldir
+++ b/UM/Qt/qml/UM/qmldir
@@ -1,39 +1,41 @@
 module Uranium
 
-ApplicationMenu 1.0 ApplicationMenu.qml
-RecolorImage 1.0 RecolorImage.qml
-MessageStack 1.0 MessageStack.qml
-Dialog 1.0 Dialog.qml
+ApplicationMenu         1.0 ApplicationMenu.qml
+RecolorImage            1.0 RecolorImage.qml
+MessageStack            1.0 MessageStack.qml
+Dialog                  1.0 Dialog.qml
 
-PreferencesDialog 1.0 Preferences/PreferencesDialog.qml
-PreferencesPage 1.0 Preferences/PreferencesPage.qml
-ManagementPage 1.0 Preferences/ManagementPage.qml
-RenameDialog 1.1 Preferences/RenameDialog.qml
-ConfirmRemoveDialog 1.1 Preferences/ConfirmRemoveDialog.qml
-SettingVisibilityItem 1.1 Preferences/SettingVisibilityItem.qml
+PreferencesDialog       1.0 Preferences/PreferencesDialog.qml
+PreferencesPage         1.0 Preferences/PreferencesPage.qml
+ManagementPage          1.0 Preferences/ManagementPage.qml
+RenameDialog            1.1 Preferences/RenameDialog.qml
+ConfirmRemoveDialog     1.1 Preferences/ConfirmRemoveDialog.qml
+SettingVisibilityItem   1.1 Preferences/SettingVisibilityItem.qml
 SettingVisibilityCategory 1.1 Preferences/SettingVisibilityCategory.qml
 
-SettingItem 1.0 Settings/SettingItem.qml
-SettingItemStyle 1.0 Settings/SettingItemStyle.qml
-SettingView 1.0 Settings/SettingView.qml
-SidebarCategoryHeader 1.0 Settings/SidebarCategoryHeader.qml
+SettingItem             1.0 Settings/SettingItem.qml
+SettingItemStyle        1.0 Settings/SettingItemStyle.qml
+SettingView             1.0 Settings/SettingView.qml
+SidebarCategoryHeader   1.0 Settings/SidebarCategoryHeader.qml
 
-TooltipArea 1.1 TooltipArea.qml
+TooltipArea             1.1 TooltipArea.qml
 
-ProgressBar 1.3 ProgressBar.qml
-ScrollBar 1.5 ScrollBar.qml
-SimpleButton 1.1 SimpleButton.qml
-TabRow 1.3 TabRow.qml
-TabRowButton 1.3 TabRowButton.qml
-CheckBox 1.5 CheckBox.qml
+ProgressBar             1.3 ProgressBar.qml
+ScrollBar               1.5 ScrollBar.qml
+SimpleButton            1.1 SimpleButton.qml
+TabRow                  1.3 TabRow.qml
+TabRowButton            1.3 TabRowButton.qml
+CheckBox                1.5 CheckBox.qml
 
-StatusIcon 1.4 StatusIcon.qml
+StatusIcon              1.4 StatusIcon.qml
 
-ImageButton 1.5 ImageButton.qml
-CheckBox 1.5 CheckBox.qml
-TextFieldWithUnit 1.5 TextFieldWithUnit.qml
-Label 1.5 Label.qml
-MenuItem 1.5 MenuItem.qml
-Menu 1.5 Menu.qml
-MessageDialog 1.5 MessageDialog.qml
-UnderlineBackground 1.5 UnderlineBackground.qml
+ImageButton             1.5 ImageButton.qml
+CheckBox                1.5 CheckBox.qml
+TextFieldWithUnit       1.5 TextFieldWithUnit.qml
+Label                   1.5 Label.qml
+MenuItem                1.5 MenuItem.qml
+Menu                    1.5 Menu.qml
+MessageDialog           1.5 MessageDialog.qml
+UnderlineBackground     1.5 UnderlineBackground.qml
+ToolTip                 1.5 ToolTip.qml
+ToolbarButton           1.5 ToolbarButton.qml

--- a/UM/Qt/qml/UM/qmldir
+++ b/UM/Qt/qml/UM/qmldir
@@ -39,3 +39,4 @@ MessageDialog           1.5 MessageDialog.qml
 UnderlineBackground     1.5 UnderlineBackground.qml
 ToolTip                 1.5 ToolTip.qml
 ToolbarButton           1.5 ToolbarButton.qml
+Enums                   1.5 Enums.qml

--- a/plugins/Tools/RotateTool/RotateTool.qml
+++ b/plugins/Tools/RotateTool/RotateTool.qml
@@ -9,17 +9,19 @@ Item
     width: childrenRect.width
     height: childrenRect.height
     UM.I18nCatalog { id: catalog; name: "uranium"}
-    UM.ImageButton
+
+    UM.ToolbarButton
     {
         id: resetRotationButton
 
         anchors.left: parent.left;
 
-        //: Reset Rotation tool button
         text: catalog.i18nc("@action:button", "Reset")
-        imageSource: UM.Theme.getIcon("ArrowReset")
-        imageWidth: UM.Theme.getSize("medium_button_icon").width
-        imageHeight: UM.Theme.getSize("medium_button_icon").height
+        toolItem: UM.RecolorImage
+        {
+            source: UM.Theme.getIcon("ArrowReset")
+            color: UM.Theme.getColor("icon")
+        }
         property bool needBorder: true
 
         z: 2
@@ -27,7 +29,7 @@ Item
         onClicked: UM.ActiveTool.triggerAction("resetRotation")
     }
 
-    UM.ImageButton
+    UM.ToolbarButton
     {
         id: layFlatButton
 
@@ -36,9 +38,12 @@ Item
 
         //: Lay Flat tool button
         text: catalog.i18nc("@action:button", "Lay flat")
-        imageSource: UM.Theme.getIcon("LayFlat")
-        imageWidth: UM.Theme.getSize("medium_button_icon").width
-        imageHeight: UM.Theme.getSize("medium_button_icon").height
+
+        toolItem: UM.RecolorImage
+        {
+            source: UM.Theme.getIcon("LayFlat")
+            color: UM.Theme.getColor("icon")
+        }
 
         z: 1
 
@@ -48,8 +53,7 @@ Item
         // visible: ! UM.ActiveTool.properties.getValue("SelectFaceSupported");
     }
 
-    UM.ImageButton
-    {
+    UM.ToolbarButton{
         id: alignFaceButton
 
         anchors.left: layFlatButton.visible ? layFlatButton.right : resetRotationButton.right
@@ -57,13 +61,18 @@ Item
         width: visible ? UM.Theme.getIcon("LayFlatOnFace").width : 0
 
         text: catalog.i18nc("@action:button", "Select face to align to the build plate")
-        imageSource: UM.Theme.getIcon("LayFlatOnFace")
 
-        imageWidth: UM.Theme.getSize("medium_button_icon").width
-        imageHeight: UM.Theme.getSize("medium_button_icon").height
+        toolItem: UM.RecolorImage
+        {
+            source: UM.Theme.getIcon("LayFlatOnFace")
+            color: UM.Theme.getColor("icon")
+        }
+
+        checkable: true
+
         enabled: UM.Selection.selectionCount == 1
         checked: UM.ActiveTool.properties.getValue("SelectFaceToLayFlatMode")
-        onClicked: UM.ActiveTool.setProperty("SelectFaceToLayFlatMode", !checked)
+        onClicked: UM.ActiveTool.setProperty("SelectFaceToLayFlatMode", checked)
 
         visible: UM.ActiveTool.properties.getValue("SelectFaceSupported") == true //Might be undefined if we're switching away from the RotateTool!
     }
@@ -71,7 +80,6 @@ Item
     UM.CheckBox
     {
         id: snapRotationCheckbox
-        anchors.left: parent.left;
         anchors.top: resetRotationButton.bottom
         anchors.topMargin: UM.Theme.getSize("default_margin").width
 

--- a/plugins/Tools/ScaleTool/ScaleTool.qml
+++ b/plugins/Tools/ScaleTool/ScaleTool.qml
@@ -53,7 +53,7 @@ Item
         selected_item.focus = true
     }
 
-    UM.ImageButton
+    UM.ToolbarButton
     {
         id: resetScaleButton
         anchors.top: textfields.bottom
@@ -64,9 +64,12 @@ Item
 
         //: Reset scale tool button
         text: catalog.i18nc("@action:button","Reset")
-        imageSource: UM.Theme.getIcon("ArrowReset")
-        imageWidth: UM.Theme.getSize("medium_button_icon").width
-        imageHeight: UM.Theme.getSize("medium_button_icon").height
+
+        toolItem: UM.RecolorImage
+        {
+            source: UM.Theme.getIcon("ArrowReset")
+            color: UM.Theme.getColor("icon")
+        }
 
         onClicked: UM.ActiveTool.triggerAction("resetScale")
     }


### PR DESCRIPTION
Rotate Tool & Scale tool image buttons swapped out for new style _ToolbarButton_ that is used in _Per Model Settings_

Moved Tooltip.qml and ToolbarButton.qml into Uranium so that the plugins/Tools can access these elements.

CURA-8943