### PR TITLE
Set the width of a Menu to fit the widest MenuItem

### DIFF
--- a/UM/Qt/qml/UM/Menu.qml
+++ b/UM/Qt/qml/UM/Menu.qml
@@ -19,6 +19,20 @@ Menu
             root.parent.height = shouldBeVisible ? UM.Theme.getSize("menu").height : 0
         }
     }
+
+    // Automatically set the width to fit the widest MenuItem
+    // https://martin.rpdev.net/2018/03/13/qt-quick-controls-2-automatically-set-the-width-of-menus.html
+    width: {
+        var result = 0;
+        var padding = 0;
+        for (var i = 0; i < count; ++i) {
+            var item = itemAt(i);
+            result = Math.max(item.contentItem.implicitWidth, result);
+            padding = Math.max(item.padding, padding);
+        }
+        return result + padding * 2;
+    }
+
     Component.onCompleted: handleVisibility()
     onShouldBeVisibleChanged: handleVisibility()
 }


### PR DESCRIPTION
This PR adds a width to Menu.qml so the Menu is wide enough to fit the widest MenuItem. This way MenuItems don't need to be elided, which causes confusion about the interactivity of MenuItems ending in an ellipsis (`...`)

The technique is copied from here: https://martin.rpdev.net/2018/03/13/qt-quick-controls-2-automatically-set-the-width-of-menus.html

This PR is a partial fix for https://github.com/Ultimaker/Uranium/issues/799