### PR TITLE
Fix longstanding bug with 'platform_offset'

### DIFF
--- a/UM/Scene/Platform.py
+++ b/UM/Scene/Platform.py
@@ -71,6 +71,9 @@ class Platform(SceneNode.SceneNode):
 
                 offset = container.getMetaDataEntry("platform_offset")
                 if offset:
+                    if isinstance(offset, str):
+                        offset = list(map(float,offset.split(',')))
+
                     if len(offset) == 3:
                         self.setPosition(Vector(offset[0], offset[1], offset[2]))
                     else:


### PR DESCRIPTION
Re: https://community.ultimaker.com/topic/34232-how-do-i-add-my-printers-logo-to-the-cura-bed/?do=findComment&comment=293900

The x, y, z offset is read in from the user .cfg file as a string, but the code expects a list of floats. The check for 3 items always fails with sensible data as it returns the number of characters in the string.

I am checking if the instance of offset is a string because I believe this offset is also provided by .json printer definition files as the correct data type and we don't want to break that.