### PR TITLE
Using xdgdektopportal for File dialogs on Windows

### DIFF
--- a/plugins/LocalFileOutputDevice/LocalFileOutputDevice.py
+++ b/plugins/LocalFileOutputDevice/LocalFileOutputDevice.py
@@ -62,9 +62,6 @@ class LocalFileOutputDevice(ProjectOutputDevice):
         # Ensure platform never ask for overwrite confirmation since we do this ourselves
         dialog.setOption(QFileDialog.Option.DontConfirmOverwrite)
 
-        if sys.platform == "linux" and "KDE_FULL_SESSION" in os.environ:
-            dialog.setOption(QFileDialog.Option.DontUseNativeDialog)
-
         filters = []
         mime_types = []
         selected_filter = None


### PR DESCRIPTION
Setting this env: `export QT_QPA_PLATFORMTHEME=xdgdesktopportal`
should fix the File dialogs not opening up on various Linux systems,
or opening up very slowely. This should use the native dialog on,
every system. Our previous implementation was depended on a Filedialog
which used a DirectoryList qml object which wasn't part of the PyQt6
binaries.

Contributes to CURA-9123