### PR TITLE
CURA-9145 Small Black window appears on macOS

### DIFF
--- a/UM/View/GL/OpenGLContext.py
+++ b/UM/View/GL/OpenGLContext.py
@@ -176,6 +176,10 @@ class OpenGLContext:
                         Logger.log("e", "DecodeError while getting GL_RENDERER via glGetString!")
 
                 Logger.log("d", "OpenGL renderer type for this OpenGL version: %s", gpu_type)
+
+                # Leaving this assigned to QWindow() causes a second small window to open in the background
+                cls.gl_window = None
+
                 if "software" in gpu_type.lower():
                     Logger.log("w", "Unfortunately OpenGL 4.1 uses software rendering")
                 else:


### PR DESCRIPTION
gl_window is used to detect the opengl version on some MacOs versions. This seems to have been unassigned automagically in QT5. With QT6 it was staying open in the background.

The fix here is to assign it to null to remove it from memory.

CURA-9145