### PR TITLE
[5.0b1] Fix TooltipArea

### DIFF
--- a/UM/Qt/qml/UM/TooltipArea.qml
+++ b/UM/Qt/qml/UM/TooltipArea.qml
@@ -3,41 +3,36 @@
 
 import QtQuick 2.4
 
+import UM 1.5 as UM
+
 // TooltipArea.qml
-// This file contains private Qt Quick modules that might change in future versions of Qt
-// Tested on: Qt 5.4.1
-// Based on https://www.kullo.net/blog/tooltiparea-the-missing-tooltip-component-of-qt-quick/
 
 MouseArea
 {
     id: _root
-    property string text: ""
+    property alias text: tooltip.text
 
     hoverEnabled: _root.enabled
     acceptedButtons: Qt.NoButton
 
-    onExited: Tooltip.hideText()
-    onCanceled: Tooltip.hideText()
+    onExited: tooltip.hide()
+    onCanceled: tooltip.hide()
+
+    UM.ToolTip
+    {
+        id: tooltip
+        arrowSize: 0
+    }
 
     Timer
     {
         interval: 1000
         running: _root.enabled && _root.containsMouse && _root.text.length
-        onTriggered: Tooltip.showText(_root, Qt.point(_root.mouseX, _root.mouseY), wrapText(_root.text))
-    }
-
-    /**
-     * Wrap a line of text automatically to a readable width.
-     *
-     * This automatically wraps the line around if it is too wide.
-     *
-     * \param text The text to wrap.
-     */
-    function wrapText(text)
-    {
-        /* The divider automatically adapts to 100% of the parent width and
-        wraps properly, so this causes the tooltips to be wrapped to the width
-        of the tooltip as set by the operating system. */
-        return "<div>" + text + "</div>"
+        onTriggered:
+        {
+            tooltip.x = _root.mouseX
+            tooltip.y = _root.height - _root.mouseY
+            tooltip.show()
+        }
     }
 }


### PR DESCRIPTION
This PR fixes the TooltipArea control, which is no longer working because it was using a private QtQuick Controls 1 element. The PR wraps the UM.Tooltip, so tooltips are now styled like the rest of the app. The tooltip does not have an arrow pointing towards the TooltipArea, so we are more free to place oversize tooltips in such a way that they don't pop up in a way that they need to immediately close because they obscure the TooltipArea.