### PR TITLE
Fix ToolHandle rendering in compatibility mode

### DIFF
--- a/resources/shaders/toolhandle.shader
+++ b/resources/shaders/toolhandle.shader
@@ -26,11 +26,11 @@ fragment =
     {
       if(u_activeColor == v_color)
         {
-            frag_color = v_color * u_enableMultiplier;
+            gl_FragColor = v_color * u_enableMultiplier;
         }
         else
         {
-            frag_color = v_color;
+            gl_FragColor = v_color;
         }
     }
 


### PR DESCRIPTION
This PR fixes the rendering of ToolHandles when in "compatibility mode" (OpenGL 2). In legacy GLSL, `gl_FragColor` is a fixed keyword.

Fixes https://github.com/Ultimaker/Cura/issues/11882