### PR TITLE
[CURA-8856] Don't spam the user already running the beta with a notification for said beta.

### DIFF
--- a/UM/Version.py
+++ b/UM/Version.py
@@ -111,6 +111,14 @@ class Version:
 
         return self._postfix_version
 
+    def getWithoutPostfix(self) -> "Version":
+        """Returns this as _only_ a major.minor.revision, without the postfix type/version.
+
+        The postfix is everything beyond the patch, like '-beta+1' in 5.0.0-beta+1 -- in this example 5.0.0 is returned.
+        """
+
+        return Version([self._major, self._minor, self._revision])
+
     def hasPostFix(self) -> bool:
         """Check if a version has a postfix."""
 

--- a/plugins/UpdateChecker/UpdateChecker.py
+++ b/plugins/UpdateChecker/UpdateChecker.py
@@ -117,13 +117,13 @@ class UpdateChecker(Extension):
         local_version = Version(app_version)
         preferences = Application.getInstance().getPreferences()
         if preferences.getValue("info/latest_update_source") == "beta":
-            local_version = local_version.getWithoutPostfix()  # Since we can't specify postfix in the latest.json.
             if newest_version >= newest_beta_version:
                 # The stable release is higher than the beta, check if we need to show that!
                 self._handleLatestUpdate(local_version, newest_version, silent, display_same_version, NewVersionMessage,
                                          "info/latest_update_version_shown")
             else:
                 # Beta version is the highest, check for that
+                local_version = local_version.getWithoutPostfix()  # Since we can't specify postfix in the latest.json.
                 if download_url is not None:
                     self._download_url = beta_download_url
                 self._handleLatestUpdate(local_version, newest_beta_version, silent, display_same_version,

--- a/plugins/UpdateChecker/UpdateChecker.py
+++ b/plugins/UpdateChecker/UpdateChecker.py
@@ -114,7 +114,7 @@ class UpdateChecker(Extension):
         if download_url is not None:
             self._download_url = download_url
 
-        local_version = Version(app_version)
+        local_version = Version(app_version).getWithoutPostfix()  # Since we can't specify postfix in the latest.json.
         preferences = Application.getInstance().getPreferences()
         if preferences.getValue("info/latest_update_source") == "beta":
             if newest_version >= newest_beta_version:

--- a/plugins/UpdateChecker/UpdateChecker.py
+++ b/plugins/UpdateChecker/UpdateChecker.py
@@ -114,9 +114,10 @@ class UpdateChecker(Extension):
         if download_url is not None:
             self._download_url = download_url
 
-        local_version = Version(app_version).getWithoutPostfix()  # Since we can't specify postfix in the latest.json.
+        local_version = Version(app_version)
         preferences = Application.getInstance().getPreferences()
         if preferences.getValue("info/latest_update_source") == "beta":
+            local_version = local_version.getWithoutPostfix()  # Since we can't specify postfix in the latest.json.
             if newest_version >= newest_beta_version:
                 # The stable release is higher than the beta, check if we need to show that!
                 self._handleLatestUpdate(local_version, newest_version, silent, display_same_version, NewVersionMessage,


### PR DESCRIPTION
Retrieved beta version would always be > local beta version.

Since we can't store the postfix (only up to 'revision' level) and major.minor.revision is loaded as 3 intergers from (online) latest.json -- the latest BETA version would always be (stoed online and) retrieved as a.b.c (withouth postfix info), but compared against the local a.b.c-beta+whatever (so, with postfix). The algorithm would then quite correctly deduce that a.b.c-beta+whatever was in fact a 'smaller' version than a.b.c (no postfix). Which then would lead to a message that a new beta was avialable _even if the user was already runnng said beta_.

This fixes that, but the underlying issue (not providing a postfix version) still remains. Problems this could cause are when we want to release and announce a second beta, without already incrementing the patch/revision nr. just because of that.

( Sadly this will only fix the issue for whenever we release 5.1.0-beta+1 of course... )
