### PR TITLE
Fix "Zoom Toward Mouse Direction" #6775

### DIFF
--- a/plugins/Tools/CameraTool/CameraTool.py
+++ b/plugins/Tools/CameraTool/CameraTool.py
@@ -288,14 +288,12 @@ class CameraTool(Tool):
             move_vector = Vector(0.0, 0.0, 1.0)
 
             if event is not None and self._zoom_to_mouse:
-                viewport_center_x = QtApplication.getInstance().getRenderer().getViewportWidth() / 2
-                viewport_center_y = QtApplication.getInstance().getRenderer().getViewportHeight() / 2
+                viewport_width = QtApplication.getInstance().getRenderer().getViewportWidth()
+                viewport_height = QtApplication.getInstance().getRenderer().getViewportHeight()
+                
                 main_window = cast(MainWindow, QtApplication.getInstance().getMainWindow())
-                mouse_diff_center_x = viewport_center_x - main_window.mouseX
-                mouse_diff_center_y = viewport_center_y - main_window.mouseY
-
-                x_component = mouse_diff_center_x / QtApplication.getInstance().getRenderer().getViewportWidth()
-                y_component = mouse_diff_center_y / QtApplication.getInstance().getRenderer().getViewportHeight()
+                x_component = main_window.mouseX / viewport_width
+                y_component = main_window.mouseY / viewport_height
 
                 move_vector = Vector(x_component, -y_component, 1)
                 move_vector = move_vector.normalized()

--- a/plugins/Tools/CameraTool/CameraTool.py
+++ b/plugins/Tools/CameraTool/CameraTool.py
@@ -294,14 +294,12 @@ class CameraTool(Tool):
                 viewport_center_y = viewport_height / 2
                 
                 main_window = cast(MainWindow, QtApplication.getInstance().getMainWindow())
-                mouse_diff_center_x = viewport_center_x - main_window.mouseX
-                mouse_diff_center_y = viewport_center_y - main_window.mouseY
-                if sys.platform.startswith("linux"):
-                    x_component = mouse_diff_center_x / viewport_width
-                    y_component = mouse_diff_center_y / viewport_height
-                else:    
-                    x_component = main_window.mouseX / viewport_width
-                    y_component = main_window.mouseY / viewport_height
+                window_PixelRatio = main_window.devicePixelRatio()
+                mouse_diff_center_x = viewport_center_x - (main_window.mouseX * window_PixelRatio)
+                mouse_diff_center_y = viewport_center_y - (main_window.mouseY * window_PixelRatio)
+                
+                x_component = mouse_diff_center_x / viewport_width
+                y_component = mouse_diff_center_y / viewport_height
 
                 move_vector = Vector(x_component, -y_component, 1)
                 move_vector = move_vector.normalized()

--- a/plugins/Tools/CameraTool/CameraTool.py
+++ b/plugins/Tools/CameraTool/CameraTool.py
@@ -294,9 +294,9 @@ class CameraTool(Tool):
                 viewport_center_y = viewport_height / 2
                 
                 main_window = cast(MainWindow, QtApplication.getInstance().getMainWindow())
-                window_PixelRatio = main_window.devicePixelRatio()
-                mouse_diff_center_x = viewport_center_x - (main_window.mouseX * window_PixelRatio)
-                mouse_diff_center_y = viewport_center_y - (main_window.mouseY * window_PixelRatio)
+                window_pixel_ratio = main_window.devicePixelRatio()
+                mouse_diff_center_x = viewport_center_x - (main_window.mouseX * window_pixel_ratio)
+                mouse_diff_center_y = viewport_center_y - (main_window.mouseY * window_pixel_ratio)
                 
                 x_component = mouse_diff_center_x / viewport_width
                 y_component = mouse_diff_center_y / viewport_height

--- a/plugins/Tools/CameraTool/CameraTool.py
+++ b/plugins/Tools/CameraTool/CameraTool.py
@@ -290,10 +290,18 @@ class CameraTool(Tool):
             if event is not None and self._zoom_to_mouse:
                 viewport_width = QtApplication.getInstance().getRenderer().getViewportWidth()
                 viewport_height = QtApplication.getInstance().getRenderer().getViewportHeight()
+                viewport_center_x = viewport_width / 2
+                viewport_center_y = viewport_height / 2
                 
                 main_window = cast(MainWindow, QtApplication.getInstance().getMainWindow())
-                x_component = main_window.mouseX / viewport_width
-                y_component = main_window.mouseY / viewport_height
+                mouse_diff_center_x = viewport_center_x - main_window.mouseX
+                mouse_diff_center_y = viewport_center_y - main_window.mouseY
+                if sys.platform.startswith("linux"):
+                    x_component = mouse_diff_center_x / viewport_width
+                    y_component = mouse_diff_center_y / viewport_height
+                else:    
+                    x_component = main_window.mouseX / viewport_width
+                    y_component = main_window.mouseY / viewport_height
 
                 move_vector = Vector(x_component, -y_component, 1)
                 move_vector = move_vector.normalized()


### PR DESCRIPTION
Zoom toward mouse always referenced the mouse position as half the actual position. Mainly due to calculations based on the viewport centre rather than the dimensions and native mouse positions. This patch fixes it by not referencing the centre of the viewport, but to the mouse position directly.