### PR TITLE
Render labels using `Text.QtRendering` on OSX

### DIFF
--- a/UM/Qt/qml/UM/CheckBox.qml
+++ b/UM/Qt/qml/UM/CheckBox.qml
@@ -96,7 +96,6 @@ CheckBox
         height: contentHeight
         color: control.enabled ? UM.Theme.getColor("checkbox_text"): UM.Theme.getColor("checkbox_text_disabled")
         elide: Text.ElideRight
-        renderType: Text.NativeRendering
         verticalAlignment: Text.AlignVCenter
         leftPadding: control.indicator.width
     }

--- a/UM/Qt/qml/UM/ImageButton.qml
+++ b/UM/Qt/qml/UM/ImageButton.qml
@@ -3,7 +3,7 @@
 
 import QtQuick 2.15
 import QtQuick.Controls 2.15
-import UM 1.3 as UM
+import UM 1.5 as UM
 
 Button
 {
@@ -40,7 +40,7 @@ Button
             Behavior on width { NumberAnimation { duration: 100; } }
             Behavior on opacity { NumberAnimation { duration: 100; } }
 
-            Label
+            UM.Label
             {
                 id: button_tip
 
@@ -48,7 +48,6 @@ Button
                 anchors.verticalCenter: parent.verticalCenter
 
                 text: control.text
-                font: UM.Theme.getFont("default")
                 color: UM.Theme.getColor("tooltip_text")
             }
         }

--- a/UM/Qt/qml/UM/Label.qml
+++ b/UM/Qt/qml/UM/Label.qml
@@ -7,7 +7,7 @@ Label
     color: UM.Theme.getColor("text")
     font: UM.Theme.getFont("default")
     wrapMode: Text.Wrap
-    renderType: Text.NativeRendering
+    renderType: Qt.platform.os == "osx" ? Text.QtRendering : Text.NativeRendering
     linkColor: UM.Theme.getColor("text_link")
     verticalAlignment: Text.AlignVCenter
 }

--- a/UM/Qt/qml/UM/MessageStack.qml
+++ b/UM/Qt/qml/UM/MessageStack.qml
@@ -175,7 +175,7 @@ ListView
                 mipmap: true
             }
 
-            Label
+            UM.Label
             {
                 id: imageCaption
                 anchors
@@ -186,7 +186,6 @@ ListView
                 text: model.image_caption
                 horizontalAlignment: Text.AlignHCenter
                 elide: Text.ElideRight
-                color: UM.Theme.getColor("text")
                 font: UM.Theme.getFont("large_bold")
                 height: text != "" ? contentHeight : 0
                 linkColor: UM.Theme.getColor("text_link")

--- a/UM/Qt/qml/UM/ToolTip.qml
+++ b/UM/Qt/qml/UM/ToolTip.qml
@@ -62,7 +62,6 @@ ToolTip
         id: label
         text: tooltip.text
         font: tooltip.font
-        wrapMode: Text.Wrap
         textFormat: Text.RichText
         color: UM.Theme.getColor("tooltip_text")
     }


### PR DESCRIPTION
Fonts were looking a bit to thick on when using `Text.NativeRendering`, so using `Text.QtRendering` instead. After this the font weight looks identical to figma (as far as I can see).

In this commit I also changed all `Label`'s to `UM.Label`'s and removed default properties where I could.

CURA-9154