### PR TITLE
Remove extra resource path from Python file

### DIFF
--- a/UM/Application.py
+++ b/UM/Application.py
@@ -176,7 +176,6 @@ class Application:
 
         app_root = os.path.abspath(os.path.join(os.path.dirname(sys.executable)))
         Resources.addSearchPath(os.path.join(app_root, "share", "uranium", "resources"))
-        Resources.addSearchPath(os.path.join(os.path.abspath(os.path.dirname(__file__)), "..", "share", "uranium", "resources"))
 
         Resources.addSearchPath(os.path.join(os.path.dirname(sys.executable), "resources"))
         Resources.addSearchPath(os.path.join(self._app_install_dir, "share", "uranium", "resources"))


### PR DESCRIPTION
This was recently added. However it appears that we have the same path multiple times in the resources, leading to the resources being found twice. This would normally get removed by virtue of being a set, but not this time since it's a different way of writing the same path.
For the themes, it finds the following paths (in my unpacked directory): `{'/home/trin/tempy/cura5/UM/../share/uranium/resources/themes', '/home/trin/tempy/cura5/cura/../share/cura/resources/themes', '/home/trin/tempy/cura5/share/cura/resources/themes', '/home/trin/.local/share/cura/5.0/themes', '/home/trin/tempy/cura5/share/uranium/resources/themes'}` For both Cura and Uranium, this points to /home/trin/tempy/cura5/curanium/resources/themes twice. So let's remove this one.

Contributes to issue CURA-9147.