### PR TITLE
Fix for tooltip

### DIFF
--- a/UM/Qt/qml/UM/TooltipArea.qml
+++ b/UM/Qt/qml/UM/TooltipArea.qml
@@ -6,33 +6,40 @@ import QtQuick 2.4
 import UM 1.5 as UM
 
 // TooltipArea.qml
-
-MouseArea
-{
+Item {
     id: _root
+
     property alias text: tooltip.text
+    property alias acceptedButtons: mouse_area.acceptedButtons
 
-    hoverEnabled: _root.enabled
-    acceptedButtons: Qt.NoButton
-
-    onExited: tooltip.hide()
-    onCanceled: tooltip.hide()
-
-    UM.ToolTip
+    MouseArea
     {
-        id: tooltip
-        arrowSize: 0
-    }
+        id: mouse_area
+        anchors.fill: _root
+        z: 1000
+        propagateComposedEvents: true
+        hoverEnabled: _root.enabled
+        acceptedButtons: Qt.NoButton
 
-    Timer
-    {
-        interval: 1000
-        running: _root.enabled && _root.containsMouse && _root.text.length
-        onTriggered:
+        onExited: tooltip.hide()
+        onCanceled: tooltip.hide()
+
+        UM.ToolTip
         {
-            tooltip.x = _root.mouseX
-            tooltip.y = _root.height - _root.mouseY
-            tooltip.show()
+            id: tooltip
+            arrowSize: 0
+        }
+
+        Timer
+        {
+            interval: 1000
+            running: _root.enabled && mouse_area.containsMouse && _root.text.length
+            onTriggered:
+            {
+                tooltip.x = mouse_area.mouseX
+                tooltip.y = mouse_area.height - mouse_area.mouseY
+                tooltip.show()
+            }
         }
     }
 }


### PR DESCRIPTION
Problem was that the mouse events were not properly propagated to the underlying mouse area. Fixed by placing the MouseArea on top of the content (instead of under) and allowing the mouse events to propagate through the mouse area. This way we don't have to propagate the mouse event for each individual component that could be located within the ToolTipArea.

Also removed some logic where the properties of the Mouse area were exposed. However this was only used in one instance (as far as I could find) and in my opinion this was abusing the intended use of the ToolTipArea component. This last issue is simply fixed by adding an additional mouse area.

CURA-9219