### PR TITLE
In secure version: disable loading themes from unbundled folders.

### DIFF
--- a/UM/Qt/QtApplication.py
+++ b/UM/Qt/QtApplication.py
@@ -36,6 +36,7 @@ from UM.Message import Message #For typing.
 from UM.i18n import i18nCatalog
 from UM.Job import Job #For typing.
 from UM.JobQueue import JobQueue
+from UM.Trust import TrustBasics
 from UM.VersionUpgradeManager import VersionUpgradeManager
 from UM.View.GL.OpenGLContext import OpenGLContext
 from UM.Version import Version
@@ -136,10 +137,18 @@ class QtApplication(QApplication, Application):
         self._cli_parser.add_argument("-qmljsdebugger",
                                       help = "For Qt's QML debugger compatibility")
 
-    def initialize(self) -> None:
+    def _evaluatePathOfTheme(self, theme_id: str) -> bool:
+        install_prefix = os.path.abspath(self.getInstallPrefix())
+        theme_path = Resources.getPath(Resources.Themes, theme_id)
+        return TrustBasics.isPathInLocation(install_prefix, theme_path)
+
+    def initialize(self, check_if_trusted: bool = False) -> None:
         super().initialize()
 
         preferences = Application.getInstance().getPreferences()
+        if check_if_trusted:
+            # Need to do this before the preferences are read for the first time, but after obj-creation, which is here.
+            preferences.indicateUntrustedSetting("general", "theme", lambda value: self._evaluatePathOfTheme(value))
         preferences.addPreference("view/force_empty_shader_cache", False)
         preferences.addPreference("view/opengl_version_detect", OpenGLContext.OpenGlVersionDetect.Autodetect)
 


### PR DESCRIPTION
5.0 version of: https://github.com/Ultimaker/Uranium/pull/822
So we can merge to the main branch later without (much?) conflicts should that be needed.

Of course this also has a corresponding front-end PR.