### PR TITLE
[CURA-8968] Also check afterwards.

### DIFF
--- a/UM/Preferences.py
+++ b/UM/Preferences.py
@@ -36,7 +36,7 @@ class Preferences:
         self._preferences = {}  # type: Dict[str, Dict[str, _Preference]]
         self._untrusted_preferences: Dict[(str, str), Callable] = {}
 
-    def indicateUntrustedPreference(self, group: str, key: str, eval_func: Callable) -> None:
+    def indicateUntrustedPreference(self, group: str, key: str, eval_func: Callable[[str], bool]) -> None:
         """Indicates that the value of this setting should be evaluated before acceptance, and otherwise not loaded."""
         self._untrusted_preferences[(group, key)] = eval_func
 

--- a/UM/Preferences.py
+++ b/UM/Preferences.py
@@ -34,11 +34,17 @@ class Preferences:
 
         self._parser = None  # type: Optional[configparser.ConfigParser]
         self._preferences = {}  # type: Dict[str, Dict[str, _Preference]]
-        self._untrusted_settings: Dict[(str, str), Callable] = {}
+        self._untrusted_preferences: Dict[(str, str), Callable] = {}
 
-    def indicateUntrustedSetting(self, group: str, key: str, eval_func: Callable) -> None:
+    def indicateUntrustedPreference(self, group: str, key: str, eval_func: Callable) -> None:
         """Indicates that the value of this setting should be evaluated before acceptance, and otherwise not loaded."""
-        self._untrusted_settings[(group, key)] = eval_func
+        self._untrusted_preferences[(group, key)] = eval_func
+
+        # While this method should preferably have run before any load from file, also handle a call afterwards.
+        if group in self._preferences and key in self._preferences[group]:
+            if not eval_func(self._preferences[group][key]):
+                self._preferences[group][key].setValue(self._preferences[group][key].getDefault())
+                self.preferenceChanged.emit(group + "/" + key)
 
     def addPreference(self, key: str, default_value: Any) -> None:
         """Add a new preference to the list.
@@ -140,7 +146,7 @@ class Preferences:
                 if key not in self._preferences[group]:
                     self._preferences[group][key] = _Preference(key)
 
-                if (group, key) in self._untrusted_settings and not self._untrusted_settings[(group, key)](value):
+                if (group, key) in self._untrusted_preferences and not self._untrusted_preferences[(group, key)](value):
                     continue
 
                 self._preferences[group][key].setValue(value)

--- a/UM/Qt/QtApplication.py
+++ b/UM/Qt/QtApplication.py
@@ -140,10 +140,10 @@ class QtApplication(QApplication, Application):
         preferences = Application.getInstance().getPreferences()
         if check_if_trusted:
             # Need to do this before the preferences are read for the first time, but after obj-creation, which is here.
-            preferences.indicateUntrustedSetting("general", "theme",
-                lambda value: self._isPathSecure(Resources.getPath(Resources.Themes, value)))
-            preferences.indicateUntrustedSetting("backend", "location",
-                lambda value: self._isPathSecure(os.path.abspath(value)))
+            preferences.indicateUntrustedPreference("general", "theme",
+                                                    lambda value: self._isPathSecure(Resources.getPath(Resources.Themes, value)))
+            preferences.indicateUntrustedPreference("backend", "location",
+                                                    lambda value: self._isPathSecure(os.path.abspath(value)))
         preferences.addPreference("view/force_empty_shader_cache", False)
         preferences.addPreference("view/opengl_version_detect", OpenGLContext.OpenGlVersionDetect.Autodetect)
 


### PR DESCRIPTION
Seems like we _may_ start the socket for listening for the engine first, depending on threading, which doesn't open the engine itself, but does mess with the order of the preference reading. Also rename settings -> preferences.

SEC-257 | CURA-8968