### PR TITLE
Don't allow containers without type and name in container registry

### DIFF
--- a/UM/Settings/ContainerRegistry.py
+++ b/UM/Settings/ContainerRegistry.py
@@ -843,13 +843,11 @@ class ContainerRegistry(ContainerRegistryInterface):
     def _isMetadataValid(self, metadata: Optional[metadata_type]) -> bool:
         """Validate a metadata object.
 
-        If the metadata is invalid, the container is not allowed to be in the
-        registry.
+        If the metadata is invalid, the container is not allowed to be in the registry.
         :param metadata: A metadata object.
         :return: Whether this metadata was valid.
         """
-
-        return metadata is not None
+        return metadata is not None and "type" in metadata and "name" in metadata
 
     def getLockFilename(self) -> str:
         """Get the lock filename including full path


### PR DESCRIPTION
If the name was missing it would cause Cura to crash. If the type was missing it wouldn't crash, but it would silently fail to load the model which is also not good. With this change, in both cases it will add a warning to the log.

Contributes to issue CURA-3Z4.

This PR requires https://github.com/Ultimaker/Cura/pull/12473 to be merged as well. Otherwise the Cura tests will fail because of this change.