### PR TITLE
[Cura 12625] Added decimals capability to the RotateToolHandle Hint

### DIFF
--- a/plugins/Tools/RotateTool/RotateTool.py
+++ b/plugins/Tools/RotateTool/RotateTool.py
@@ -278,7 +278,7 @@ class RotateTool(Tool):
         :return: type(String) fully formatted string showing the angle by which the mesh(es) are rotated
         """
 
-        return "%d°" % round(math.degrees(self._angle)) if self._angle else None
+        return ("%f" % round(math.degrees(self._angle), 2)).rstrip('0').rstrip('.') + "°" if self._angle else None
 
     def getSelectFaceSupported(self) -> bool:
         """Get whether the select face feature is supported.


### PR DESCRIPTION
Added decimals capability to the RotateToolHandle Hint without modifing the integer displaying of snap rotation.

I think this change can improve the user experience when using rotation without snap, which with just displaying the unit could cause some issues (see https://github.com/Ultimaker/Cura/issues/12625).

Can it be integrated within the next version of Cura?