### PR TITLE
Build mo translation files when creating conan package

### DIFF
--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -93,7 +93,11 @@ jobs:
 
             -   name: Install Linux system requirements
                 if: ${{ runner.os == 'Linux' }}
-                run: sudo apt install build-essential checkinstall libegl-dev zlib1g-dev libssl-dev ninja-build autoconf libx11-dev libx11-xcb-dev libfontenc-dev libice-dev libsm-dev libxau-dev libxaw7-dev libxcomposite-dev libxcursor-dev libxdamage-dev libxdmcp-dev libxext-dev libxfixes-dev libxi-dev libxinerama-dev libxkbfile-dev libxmu-dev libxmuu-dev libxpm-dev libxrandr-dev libxrender-dev libxres-dev libxss-dev libxt-dev libxtst-dev libxv-dev libxvmc-dev libxxf86vm-dev xtrans-dev libxcb-render0-dev libxcb-render-util0-dev libxcb-xkb-dev libxcb-icccm4-dev libxcb-image0-dev libxcb-keysyms1-dev libxcb-randr0-dev libxcb-shape0-dev libxcb-sync-dev libxcb-xfixes0-dev libxcb-xinerama0-dev xkb-data libxcb-dri3-dev uuid-dev libxcb-util-dev libxkbcommon-x11-dev -y
+                run: |
+                    sudo add-apt-repository ppa:ubuntu-toolchain-r/test -y
+                    sudo apt update
+                    sudo apt upgrade
+                    sudo apt install build-essential checkinstall libegl-dev zlib1g-dev libssl-dev ninja-build autoconf libx11-dev libx11-xcb-dev libfontenc-dev libice-dev libsm-dev libxau-dev libxaw7-dev libxcomposite-dev libxcursor-dev libxdamage-dev libxdmcp-dev libxext-dev libxfixes-dev libxi-dev libxinerama-dev libxkbfile-dev libxmu-dev libxmuu-dev libxpm-dev libxrandr-dev libxrender-dev libxres-dev libxss-dev libxt-dev libxtst-dev libxv-dev libxvmc-dev libxxf86vm-dev xtrans-dev libxcb-render0-dev libxcb-render-util0-dev libxcb-xkb-dev libxcb-icccm4-dev libxcb-image0-dev libxcb-keysyms1-dev libxcb-randr0-dev libxcb-shape0-dev libxcb-sync-dev libxcb-xfixes0-dev libxcb-xinerama0-dev xkb-data libxcb-dri3-dev uuid-dev libxcb-util-dev libxkbcommon-x11-dev pkg-config -y
 
             -   name: Get Conan configuration
                 run: conan config install https://github.com/Ultimaker/conan-config.git

--- a/conanfile.py
+++ b/conanfile.py
@@ -3,10 +3,12 @@ import os
 from pathlib import Path
 
 from conan import ConanFile
+from conan.tools.files import copy, mkdir
+from conan.tools.microsoft import unix_path
 from conan.tools.scm import Version
 from conan.errors import ConanInvalidConfiguration
 
-required_conan_version = ">=1.50.0"
+required_conan_version = ">=1.52.0"
 
 
 class UraniumConan(ConanFile):
@@ -54,6 +56,11 @@ class UraniumConan(ConanFile):
         for req in self._um_data()["requirements"]:
             self.requires(req)
 
+    def build_requirements(self):
+        if self.settings_build.os == "Windows" and not self.conf.get("tools.microsoft.bash:path", default=False, check_type=bool):
+            self.tool_requires("msys2/cci.latest")
+        self.tool_requires("gettext/0.21")
+
     @property
     def _base_dir(self):
         if self.install_folder is None:
@@ -96,7 +103,15 @@ class UraniumConan(ConanFile):
         return py_interp
 
     def build(self):
-        pass
+        if self.settings.os == "Windows":
+            self.win_bash = True  # We need gettext, which requires the bash environment
+
+        for po_file in self.source_path.joinpath("resources", "i18n").glob("**/*.po"):
+            mo_file = self.build_path.joinpath(po_file.with_suffix('.mo').relative_to(self.source_path))
+            mkdir(self, str(unix_path(self, mo_file.parent)))
+            self.run(f"msgfmt {po_file} -o {mo_file} -f", env="conanbuild")
+
+        self.win_bash = None
 
     def generate(self):
         pass
@@ -110,10 +125,11 @@ class UraniumConan(ConanFile):
         self.cpp.package.resdirs = ["resources", "plugins", "pip_requirements"]  # Note: pip_requirements should be the last item in the list
 
     def package(self):
-        self.copy("*", src = "UM", dst = self.cpp.package.libdirs[0])
-        self.copy("*", src = "resources", dst = self.cpp.package.resdirs[0])
-        self.copy("*", src = "plugins", dst = self.cpp.package.resdirs[1])
-        self.copy("requirement*.txt", src=".", dst = self.cpp.package.resdirs[-1])
+        copy(self, "*", src = self.source_path.joinpath("UM"), dst = self.package_path.joinpath(self.cpp.package.libdirs[0]))
+        copy(self, "*", src = self.source_path.joinpath("resources"), dst = self.package_path.joinpath(self.cpp.package.resdirs[0]), excludes="*.po")
+        copy(self, "*.mo", src = self.build_path.joinpath("resources"), dst = self.package_path.joinpath(self.cpp.package.resdirs[0]))
+        copy(self, "*", src = self.source_path.joinpath("plugins"), dst = self.package_path.joinpath(self.cpp.package.resdirs[1]))
+        copy(self, "requirement*.txt", src = self.source_path, dst = self.package_path.joinpath(self.cpp.package.resdirs[-1]))
 
     def package_info(self):
         self.user_info.pip_requirements = "requirements.txt"

--- a/conanfile.py
+++ b/conanfile.py
@@ -109,7 +109,7 @@ class UraniumConan(ConanFile):
         for po_file in self.source_path.joinpath("resources", "i18n").glob("**/*.po"):
             mo_file = self.build_path.joinpath(po_file.with_suffix('.mo').relative_to(self.source_path))
             mkdir(self, str(unix_path(self, mo_file.parent)))
-            self.run(f"msgfmt {po_file} -o {mo_file} -f", env="conanbuild")
+            self.run(f"msgfmt {po_file} -o {mo_file} -f", env="conanbuild", run_environment=True)
 
         # FIXME: once m4, autoconf, automake are Conan V2 ready self.win_bash = None
 
@@ -119,7 +119,7 @@ class UraniumConan(ConanFile):
             for po_file in self.source_path.joinpath("resources", "i18n").glob("**/*.po"):
                 pot_file = self.source_path.joinpath("resources", "i18n", po_file.with_suffix('.pot').name)
                 mkdir(self, str(unix_path(self, pot_file.parent)))
-                self.run(f"msgmerge --no-wrap --no-fuzzy-matching -width=140 -o {po_file} {po_file} {pot_file}", env = "conanbuild")
+                self.run(f"msgmerge --no-wrap --no-fuzzy-matching -width=140 -o {po_file} {po_file} {pot_file}", env = "conanbuild", run_environment=True)
 
     def layout(self):
         self.folders.source = "."

--- a/conanfile.py
+++ b/conanfile.py
@@ -103,20 +103,22 @@ class UraniumConan(ConanFile):
 
     def build(self):
         if self.settings_build.os != "Windows" or self.conf.get("tools.microsoft.bash:path", check_type = str):
+            msgfmt = self.deps_cpp_info["gettext"].bin_paths[0].joinpath("msgfmt")
             for po_file in self.source_path.joinpath("resources", "i18n").glob("**/*.po"):
                 mo_file = self.build_path.joinpath(po_file.with_suffix('.mo').relative_to(self.source_path))
                 mkdir(self, str(unix_path(self, mo_file.parent)))
-                self.run(f"msgfmt {po_file} -o {mo_file} -f", env="conanbuild", run_environment=True)
+                self.run(f"{msgfmt} {po_file} -o {mo_file} -f", env="conanbuild", run_environment=True)
 
             # FIXME: once m4, autoconf, automake are Conan V2 ready self.win_bash = None
 
     def generate(self):
         # Update the po files
         if self.settings_build.os != "Windows" or self.conf.get("tools.microsoft.bash:path", check_type = str):
+            msgmerge = self.deps_cpp_info["gettext"].bin_paths[0].joinpath("msgmerge")
             for po_file in self.source_path.joinpath("resources", "i18n").glob("**/*.po"):
                 pot_file = self.source_path.joinpath("resources", "i18n", po_file.with_suffix('.pot').name)
                 mkdir(self, str(unix_path(self, pot_file.parent)))
-                self.run(f"msgmerge --no-wrap --no-fuzzy-matching -width=140 -o {po_file} {po_file} {pot_file}", env = "conanbuild", run_environment=True)
+                self.run(f"{msgmerge} --no-wrap --no-fuzzy-matching -width=140 -o {po_file} {po_file} {pot_file}", env = "conanbuild", run_environment=True)
 
     def layout(self):
         self.folders.source = "."

--- a/conanfile.py
+++ b/conanfile.py
@@ -57,7 +57,7 @@ class UraniumConan(ConanFile):
             self.requires(req)
 
     def build_requirements(self):
-        if self.settings_build.os != "Windows" or self.conf.get("tools.microsoft.bash:path", default=False, check_type=bool):
+        if self.settings_build.os != "Windows" or self.conf.get("tools.microsoft.bash:path", check_type = str):
             self.tool_requires("gettext/0.21")
 
     @property
@@ -102,20 +102,17 @@ class UraniumConan(ConanFile):
         return py_interp
 
     def build(self):
-        if self.settings_build.os == "Windows" and not self.conf.get("tools.microsoft.bash:path", default=False, check_type=bool):
-            return
-            # FIXME: once m4, autoconf, automake are Conan V2 ready self.win_bash = True  # We need gettext, which requires the bash environment
+        if self.settings_build.os != "Windows" or self.conf.get("tools.microsoft.bash:path", check_type = str):
+            for po_file in self.source_path.joinpath("resources", "i18n").glob("**/*.po"):
+                mo_file = self.build_path.joinpath(po_file.with_suffix('.mo').relative_to(self.source_path))
+                mkdir(self, str(unix_path(self, mo_file.parent)))
+                self.run(f"msgfmt {po_file} -o {mo_file} -f", env="conanbuild", run_environment=True)
 
-        for po_file in self.source_path.joinpath("resources", "i18n").glob("**/*.po"):
-            mo_file = self.build_path.joinpath(po_file.with_suffix('.mo').relative_to(self.source_path))
-            mkdir(self, str(unix_path(self, mo_file.parent)))
-            self.run(f"msgfmt {po_file} -o {mo_file} -f", env="conanbuild", run_environment=True)
-
-        # FIXME: once m4, autoconf, automake are Conan V2 ready self.win_bash = None
+            # FIXME: once m4, autoconf, automake are Conan V2 ready self.win_bash = None
 
     def generate(self):
         # Update the po files
-        if self.settings_build.os != "Windows" or self.conf.get("tools.microsoft.bash:path", default = False, check_type = bool):
+        if self.settings_build.os != "Windows" or self.conf.get("tools.microsoft.bash:path", check_type = str):
             for po_file in self.source_path.joinpath("resources", "i18n").glob("**/*.po"):
                 pot_file = self.source_path.joinpath("resources", "i18n", po_file.with_suffix('.pot').name)
                 mkdir(self, str(unix_path(self, pot_file.parent)))

--- a/conanfile.py
+++ b/conanfile.py
@@ -103,22 +103,20 @@ class UraniumConan(ConanFile):
 
     def build(self):
         if self.settings_build.os != "Windows" or self.conf.get("tools.microsoft.bash:path", check_type = str):
-            msgfmt = self.deps_cpp_info["gettext"].bin_paths[0].joinpath("msgfmt")
             for po_file in self.source_path.joinpath("resources", "i18n").glob("**/*.po"):
                 mo_file = self.build_path.joinpath(po_file.with_suffix('.mo').relative_to(self.source_path))
                 mkdir(self, str(unix_path(self, mo_file.parent)))
-                self.run(f"{msgfmt} {po_file} -o {mo_file} -f", env="conanbuild", run_environment=True)
+                self.run(f"msgfmt {po_file} -o {mo_file} -f", env="conanbuild", run_environment=True)
 
             # FIXME: once m4, autoconf, automake are Conan V2 ready self.win_bash = None
 
     def generate(self):
         # Update the po files
         if self.settings_build.os != "Windows" or self.conf.get("tools.microsoft.bash:path", check_type = str):
-            msgmerge = self.deps_cpp_info["gettext"].bin_paths[0].joinpath("msgmerge")
             for po_file in self.source_path.joinpath("resources", "i18n").glob("**/*.po"):
                 pot_file = self.source_path.joinpath("resources", "i18n", po_file.with_suffix('.pot').name)
                 mkdir(self, str(unix_path(self, pot_file.parent)))
-                self.run(f"{msgmerge} --no-wrap --no-fuzzy-matching -width=140 -o {po_file} {po_file} {pot_file}", env = "conanbuild", run_environment=True)
+                self.run(f"msgmerge --no-wrap --no-fuzzy-matching -width=140 -o {po_file} {po_file} {pot_file}", env = "conanbuild", run_environment=True)
 
     def layout(self):
         self.folders.source = "."

--- a/conanfile.py
+++ b/conanfile.py
@@ -114,7 +114,12 @@ class UraniumConan(ConanFile):
         # FIXME: once m4, autoconf, automake are Conan V2 ready self.win_bash = None
 
     def generate(self):
-        pass
+        # Update the po files
+        if self.settings_build.os != "Windows" or self.conf.get("tools.microsoft.bash:path", default = False, check_type = bool):
+            for po_file in self.source_path.joinpath("resources", "i18n").glob("**/*.po"):
+                pot_file = self.source_path.joinpath("resources", "i18n", po_file.with_suffix('.pot').name)
+                mkdir(self, str(unix_path(self, pot_file.parent)))
+                self.run(f"msgmerge --no-wrap --no-fuzzy-matching -width=140 -o {po_file} {po_file} {pot_file}", env = "conanbuild")
 
     def layout(self):
         self.folders.source = "."

--- a/conanfile.py
+++ b/conanfile.py
@@ -57,9 +57,8 @@ class UraniumConan(ConanFile):
             self.requires(req)
 
     def build_requirements(self):
-        if self.settings_build.os == "Windows" and not self.conf.get("tools.microsoft.bash:path", default=False, check_type=bool):
-            self.tool_requires("msys2/cci.latest")
-        self.tool_requires("gettext/0.21")
+        if self.settings_build.os != "Windows" or self.conf.get("tools.microsoft.bash:path", default=False, check_type=bool):
+            self.tool_requires("gettext/0.21")
 
     @property
     def _base_dir(self):
@@ -103,7 +102,7 @@ class UraniumConan(ConanFile):
         return py_interp
 
     def build(self):
-        if self.settings.os == "Windows":
+        if self.settings_build.os == "Windows" and not self.conf.get("tools.microsoft.bash:path", default=False, check_type=bool):
             return
             # FIXME: once m4, autoconf, automake are Conan V2 ready self.win_bash = True  # We need gettext, which requires the bash environment
 


### PR DESCRIPTION
Added a build step which uses the Conan package gettext as a tool_requires to convert the po files to mo files and store these in the resources folder

When on Windows the msys2 recipe is used to ensure that we have a bash environment to run gnu gettext

Creating the mo files as part of the conan package will ensures that we no longer need to store them in the cura-binary-data and generate them manually. This should result in less risk of human error during the release cycle

See also:
- https://github.com/Ultimaker/Cura/pull/13596
- https://github.com/Ultimaker/cura-binary-data/pull/26