### PR TITLE
Use UltiMaker for display name plugins

### DIFF
--- a/resources/bundled_packages/uranium.json
+++ b/resources/bundled_packages/uranium.json
@@ -10,7 +10,7 @@
             "website": "https://ultimaker.com",
             "author": {
                 "author_id": "UltimakerPackages",
-                "display_name": "Ultimaker B.V.",
+                "display_name": "UltiMaker",
                 "email": "plugins@ultimaker.com",
                 "website": "https://ultimaker.com"
             }
@@ -27,7 +27,7 @@
             "website": "https://ultimaker.com",
             "author": {
                 "author_id": "UltimakerPackages",
-                "display_name": "Ultimaker B.V.",
+                "display_name": "UltiMaker",
                 "email": "plugins@ultimaker.com",
                 "website": "https://ultimaker.com"
             }
@@ -44,7 +44,7 @@
             "website": "https://ultimaker.com",
             "author": {
                 "author_id": "UltimakerPackages",
-                "display_name": "Ultimaker B.V.",
+                "display_name": "UltiMaker",
                 "email": "plugins@ultimaker.com",
                 "website": "https://ultimaker.com"
             }
@@ -61,7 +61,7 @@
             "website": "https://ultimaker.com",
             "author": {
                 "author_id": "UltimakerPackages",
-                "display_name": "Ultimaker B.V.",
+                "display_name": "UltiMaker",
                 "email": "plugins@ultimaker.com",
                 "website": "https://ultimaker.com"
             }
@@ -78,7 +78,7 @@
             "website": "https://ultimaker.com",
             "author": {
                 "author_id": "UltimakerPackages",
-                "display_name": "Ultimaker B.V.",
+                "display_name": "UltiMaker",
                 "email": "plugins@ultimaker.com",
                 "website": "https://ultimaker.com"
             }
@@ -95,7 +95,7 @@
             "website": "https://ultimaker.com",
             "author": {
                 "author_id": "UltimakerPackages",
-                "display_name": "Ultimaker B.V.",
+                "display_name": "UltiMaker",
                 "email": "plugins@ultimaker.com",
                 "website": "https://ultimaker.com"
             }
@@ -112,7 +112,7 @@
             "website": "https://ultimaker.com",
             "author": {
                 "author_id": "UltimakerPackages",
-                "display_name": "Ultimaker B.V.",
+                "display_name": "UltiMaker",
                 "email": "plugins@ultimaker.com",
                 "website": "https://ultimaker.com"
             }
@@ -129,7 +129,7 @@
             "website": "https://ultimaker.com",
             "author": {
                 "author_id": "UltimakerPackages",
-                "display_name": "Ultimaker B.V.",
+                "display_name": "UltiMaker",
                 "email": "plugins@ultimaker.com",
                 "website": "https://ultimaker.com"
             }
@@ -146,7 +146,7 @@
             "website": "https://ultimaker.com",
             "author": {
                 "author_id": "UltimakerPackages",
-                "display_name": "Ultimaker B.V.",
+                "display_name": "UltiMaker",
                 "email": "plugins@ultimaker.com",
                 "website": "https://ultimaker.com"
             }
@@ -163,7 +163,7 @@
             "website": "https://ultimaker.com",
             "author": {
                 "author_id": "UltimakerPackages",
-                "display_name": "Ultimaker B.V.",
+                "display_name": "UltiMaker",
                 "email": "plugins@ultimaker.com",
                 "website": "https://ultimaker.com"
             }
@@ -180,7 +180,7 @@
             "website": "https://ultimaker.com",
             "author": {
                 "author_id": "UltimakerPackages",
-                "display_name": "Ultimaker B.V.",
+                "display_name": "UltiMaker",
                 "email": "plugins@ultimaker.com",
                 "website": "https://ultimaker.com"
             }
@@ -197,7 +197,7 @@
             "website": "https://ultimaker.com",
             "author": {
                 "author_id": "UltimakerPackages",
-                "display_name": "Ultimaker B.V.",
+                "display_name": "UltiMaker",
                 "email": "plugins@ultimaker.com",
                 "website": "https://ultimaker.com"
             }
@@ -214,7 +214,7 @@
             "website": "https://ultimaker.com",
             "author": {
                 "author_id": "UltimakerPackages",
-                "display_name": "Ultimaker B.V.",
+                "display_name": "UltiMaker",
                 "email": "plugins@ultimaker.com",
                 "website": "https://ultimaker.com"
             }
@@ -231,7 +231,7 @@
             "website": "https://ultimaker.com",
             "author": {
                 "author_id": "UltimakerPackages",
-                "display_name": "Ultimaker B.V.",
+                "display_name": "UltiMaker",
                 "email": "plugins@ultimaker.com",
                 "website": "https://ultimaker.com"
             }
@@ -248,7 +248,7 @@
             "website": "https://ultimaker.com",
             "author": {
                 "author_id": "UltimakerPackages",
-                "display_name": "Ultimaker B.V.",
+                "display_name": "UltiMaker",
                 "email": "plugins@ultimaker.com",
                 "website": "https://ultimaker.com"
             }
@@ -265,7 +265,7 @@
             "website": "https://ultimaker.com",
             "author": {
                 "author_id": "UltimakerPackages",
-                "display_name": "Ultimaker B.V.",
+                "display_name": "UltiMaker",
                 "email": "plugins@ultimaker.com",
                 "website": "https://ultimaker.com"
             }


### PR DESCRIPTION
Changes the plugin  display name: from `Ultimaker B.V.` to `UltiMaker`

Contributes to CURA-9808