### PR TITLE
[CURA-9347] Line-out right/left-buttons correctly in dialogs.

### DIFF
--- a/UM/Qt/qml/UM/Dialog.qml
+++ b/UM/Qt/qml/UM/Dialog.qml
@@ -37,19 +37,19 @@ Window
     property Component buttonRow: RowLayout
     {
         height: childrenRect.height
-        anchors.left: parent.left
-        anchors.right: parent.right
+        Layout.fillWidth: true
+        Layout.alignment: Qt.AlignRight
 
         RowLayout
         {
-            Layout.alignment: Qt.AlignLeft
+            anchors.left: parent.left
             spacing: base.buttonSpacing
             children: leftButtons
         }
 
         RowLayout
         {
-            Layout.alignment: Qt.AlignRight
+            anchors.right: parent.right
             spacing: base.buttonSpacing
             children: rightButtons
         }


### PR DESCRIPTION
Sometimes after re-opening the same dialog with different buttons visible, things would get out of alignment. That should be fixed by this.

Related to: https://github.com/Ultimaker/Cura/pull/13938