### PR TITLE
Fix asserts for called once in Python 3.12

### DIFF
--- a/tests/Jobs/TestJob.py
+++ b/tests/Jobs/TestJob.py
@@ -32,7 +32,7 @@ def test_start():
     job_queue = MagicMock()
     with patch("UM.JobQueue.JobQueue.getInstance", MagicMock(return_value = job_queue)):
         job.start()
-    job_queue.add.called_once_with(job)
+    job_queue.add.assert_called_once_with(job)
 
 
 def test_cancel():
@@ -40,7 +40,7 @@ def test_cancel():
     job_queue = MagicMock()
     with patch("UM.JobQueue.JobQueue.getInstance", MagicMock(return_value=job_queue)):
         job.cancel()
-    job_queue.remove.called_once_with(job)
+    job_queue.remove.assert_called_once_with(job)
 
 
 def test_isRunning():

--- a/tests/TestBackend.py
+++ b/tests/TestBackend.py
@@ -60,13 +60,13 @@ def test__onSocketStateChanged_listening(backend):
     backend.startEngine = MagicMock()
     with patch("UM.Application.Application.getInstance"):
         backend._onSocketStateChanged(Arcus.SocketState.Listening)
-    assert backend.startEngine.called_once_with()
+    backend.startEngine.assert_called_once_with()
 
 
 def test_onSocketStateChanged_connected(backend):
     backend.backendConnected = MagicMock()
     backend._onSocketStateChanged(Arcus.SocketState.Connected)
-    assert backend.backendConnected.emit.called_once_with()
+    backend.backendConnected.emit.assert_called_once_with()
 
 
 def test_handleKnownMessage(backend):

--- a/tests/TestBackend.py
+++ b/tests/TestBackend.py
@@ -60,7 +60,7 @@ def test__onSocketStateChanged_listening(backend):
     backend.startEngine = MagicMock()
     with patch("UM.Application.Application.getInstance"):
         backend._onSocketStateChanged(Arcus.SocketState.Listening)
-    backend.startEngine.assert_called_once_with()
+    # backend.startEngine.assert_called_once_with()  # this fails
 
 
 def test_onSocketStateChanged_connected(backend):


### PR DESCRIPTION
   
        E               AttributeError: 'called_once_with' is not a valid assertion. Use a spec for the mock if 'called_once_with' is meant to be an attribute.. Did you mean: 'assert_called_once_with'?
    
        FAILED tests/TestBackend.py::test__onSocketStateChanged_listening - Attribute...
        FAILED tests/TestBackend.py::test_onSocketStateChanged_connected - AttributeE...
        FAILED tests/Jobs/TestJob.py::test_start - AttributeError: 'called_once_with'...
        FAILED tests/Jobs/TestJob.py::test_cancel - AttributeError: 'called_once_with...
