### PR TITLE
[CURA-10722] Add 'additional settings providers' (Engine Plugins)

### DIFF
--- a/UM/Settings/AdditionalSettingDefinitionAppender.py
+++ b/UM/Settings/AdditionalSettingDefinitionAppender.py
@@ -11,69 +11,22 @@ from UM.PluginObject import PluginObject
 from UM.Settings.SettingDefinition import DefinitionPropertyType, SettingDefinition
 
 
-def prependIdToSettings(tag_type: str, tag_id: str, tag_version: str, settings: Dict[str, Any]) -> Dict[str, Any]:
-    """ This takes the whole (extra) settings-map as defined by the provider, and returns a tag-renamed version.
-
-    Additional (appended) settings will need to be prepended with (an) extra identifier(s)/namespaces to not collide.
-    This is done for when there are multiple additional settings appenders that might not know about each other.
-    This includes any formulas, which will also be included in the renaming process.
-
-    Appended settings may not be the same as 'baseline' (so any 'non-appended' settings) settings.
-    (But may of course clash between different providers and versions, that's the whole point of this function...)
-    Furthermore, it's assumed that formulas within the appended settings will only use settings either;
-     - as defined within the baseline, or;
-     - any other settings defined _by the provider itself_.
-
-    For each key that is renamed, this results in a mapping <key> -> _<provider_type>__<id*>__<version>__<key>
-     where '<id*>' is the version of the provider, but converted from using points to using underscores.
-    Example: 'tapdance_factor' might become '_plugin__dancingprinter__1_2_99__tapdance_factor'
-    Also note that all the tag_... parameters will be forced to lower-case.
-
-    :param tag_type: Type of the additional settings appender, for example; "PLUGIN".
-    :param tag_id: ID of the provider. Should be unique.
-    :param tag_version: Version of the provider. Points will be replaced by underscores.
-    :param settings: The settings as originally provided.
-
-    :returns: Remapped settings, where each settings-name is properly tagged/'namespaced'.
-    """
-    tag_type = tag_type.lower()
-    tag_id = tag_id.lower()
-    tag_version = tag_version.lower().replace(".", "_")
-
-    # First get the mapping, so that both the 'headings' and formula's can be renamed at the same time later.
-    def _getMapping(values: Dict[str, Any]) -> Dict[str, str]:
-        result = {}
-        for key, value in values.items():
-            mapped_key = key
-            if isinstance(value, dict):
-                if "type" in value and value["type"] != "category":
-                    mapped_key = f"_{tag_type}__{tag_id}__{tag_version}__{key}"
-                result.update(_getMapping(value))
-            result[key] = mapped_key
-        return result
-    key_map = _getMapping(settings)
-
-    # Get all values that can be functions, so it's known where to replace.
-    function_type_names = set(SettingDefinition.getPropertyNames(DefinitionPropertyType.Function))
-
-    # Replace all, both as key-names and their use in formulas.
-    def _doReplace(values: Dict[str, Any]) -> Dict[str, str]:
-        result = {}
-        for key, value in values.items():
-            if key in function_type_names and isinstance(value, str):
-                # Replace key-names in the specified settings-function.
-                for original, mapped in key_map.items():
-                    value = value.replace(original, mapped)
-            elif isinstance(value, dict):
-                # Replace key-name 'heading'.
-                key = key_map.get(key, key)
-                value = _doReplace(value)
-            result[key] = value
-        return result
-    return _doReplace(settings)
-
-
 class AdditionalSettingDefinitionsAppender(PluginObject):
+    """
+    This class is a way for plugins to append additional settings, not defined by/for the main program itself.
+
+    Each plugin needs to register as either a 'setting_definitions_appender' or 'backend_plugin'.
+
+    Any implementation also needs to fill 'self.definition_file_paths' with a list of files with setting definitions.
+    Each file should be a json list of setting categories, either matching existing names, or be a new category.
+    Each category and setting has the same json structure as the main settings otherwise.
+
+    It's also possible to set the 'self.appender_type', if there are many kinds of plugins to implement this,
+    in order to prevent name-clashes.
+
+    Lastly, if setting-definitions are to be made on the fly by the plugin, override 'getAdditionalSettingDefinitions',
+    instead of providing the files. This should then return a dict, as if parsed by json.
+    """
 
     def __init__(self) -> None:
         super().__init__()
@@ -81,6 +34,9 @@ class AdditionalSettingDefinitionsAppender(PluginObject):
         self.definition_file_paths: List[Path] = []
 
     def getAppenderType(self) -> str:
+        """
+        Return an extra identifier prepended to the setting internal id, to prevent name-clashes with other plugins.
+        """
         return self.appender_type
 
     def getAdditionalSettingDefinitions(self) -> Dict[str, Dict[str, Any]]:
@@ -90,6 +46,8 @@ class AdditionalSettingDefinitionsAppender(PluginObject):
 
         The settings should be divided by category (either existing or new ones).
         Settings in existing categories will be appended, new categories will be created.
+
+        :return:
         """
         result = {}
         for path in self.definition_file_paths:
@@ -106,3 +64,67 @@ class AdditionalSettingDefinitionsAppender(PluginObject):
                 Logger.error(f"Could not parse additional settings provided by '{self.getId()}' because: {str(jex)}")
                 continue
         return result
+
+    @classmethod
+    def prependIdToSettings(cls, tag_type: str, tag_id: str, tag_version: str, settings: Dict[str, Any]) -> Dict[str, Any]:
+        """ This takes the whole (extra) settings-map as defined by the provider, and returns a tag-renamed version.
+
+        Additional (appended) settings will need to be prepended with (an) extra identifier(s)/namespaces to not collide.
+        This is done for when there are multiple additional settings appenders that might not know about each other.
+        This includes any formulas, which will also be included in the renaming process.
+
+        Appended settings may not be the same as 'baseline' (so any 'non-appended' settings) settings.
+        (But may of course clash between different providers and versions, that's the whole point of this function...)
+        Furthermore, it's assumed that formulas within the appended settings will only use settings either;
+         - as defined within the baseline, or;
+         - any other settings defined _by the provider itself_.
+
+        For each key that is renamed, this results in a mapping <key> -> _<provider_type>__<id*>__<version>__<key>
+         where '<id*>' is the version of the provider, but converted from using points to using underscores.
+        Example: 'tapdance_factor' might become '_plugin__dancingprinter__1_2_99__tapdance_factor'
+        Also note that all the tag_... parameters will be forced to lower-case.
+
+        :param tag_type: Type of the additional settings appender, for example; "PLUGIN".
+        :param tag_id: ID of the provider. Should be unique.
+        :param tag_version: Version of the provider. Points will be replaced by underscores.
+        :param settings: The settings as originally provided.
+
+        :returns: Remapped settings, where each settings-name is properly tagged/'namespaced'.
+        """
+        tag_type = tag_type.lower()
+        tag_id = tag_id.lower()
+        tag_version = tag_version.lower().replace(".", "_")
+
+        # First get the mapping, so that both the 'headings' and formula's can be renamed at the same time later.
+        def _getMapping(values: Dict[str, Any]) -> Dict[str, str]:
+            result = {}
+            for key, value in values.items():
+                mapped_key = key
+                if isinstance(value, dict):
+                    if "type" in value and value["type"] != "category":
+                        mapped_key = f"_{tag_type}__{tag_id}__{tag_version}__{key}"
+                    result.update(_getMapping(value))
+                result[key] = mapped_key
+            return result
+
+        key_map = _getMapping(settings)
+
+        # Get all values that can be functions, so it's known where to replace.
+        function_type_names = set(SettingDefinition.getPropertyNames(DefinitionPropertyType.Function))
+
+        # Replace all, both as key-names and their use in formulas.
+        def _doReplace(values: Dict[str, Any]) -> Dict[str, str]:
+            result = {}
+            for key, value in values.items():
+                if key in function_type_names and isinstance(value, str):
+                    # Replace key-names in the specified settings-function.
+                    for original, mapped in key_map.items():
+                        value = value.replace(original, mapped)
+                elif isinstance(value, dict):
+                    # Replace key-name 'heading'.
+                    key = key_map.get(key, key)
+                    value = _doReplace(value)
+                result[key] = value
+            return result
+
+        return _doReplace(settings)

--- a/UM/Settings/AdditionalSettingDefinitionAppender.py
+++ b/UM/Settings/AdditionalSettingDefinitionAppender.py
@@ -77,7 +77,11 @@ class AdditionalSettingDefinitionsAppender(PluginObject):
 
     def __init__(self) -> None:
         super().__init__()
+        self.appender_type = "EXTRA"
         self.definition_file_paths: List[Path] = []
+
+    def getAppenderType(self) -> str:
+        return self.appender_type
 
     def getAdditionalSettingDefinitions(self) -> Dict[str, Dict[str, Any]]:
         """

--- a/UM/Settings/AdditionalSettingDefinitionAppender.py
+++ b/UM/Settings/AdditionalSettingDefinitionAppender.py
@@ -1,0 +1,19 @@
+# Copyright (c) 2023 UltiMaker.
+# Uranium is released under the terms of the LGPLv3 or higher.
+
+from typing import Any, Dict
+from UM.PluginObject import PluginObject
+
+
+class AdditionalSettingDefinitionsAppender(PluginObject):
+
+    def __init__(self) -> None:
+        super().__init__()
+
+    def getAdditionalSettingDefinitions(self) -> Dict[str, Dict[str, Any]]:
+        """
+        Should return the settings added by this plugin in json format.
+        The settings should be divided by category (either existing or new ones).
+        Settings in existing categories will be appended, new categories will be created.
+        """
+        raise NotImplementedError("A setting_definitions_appender needs to implement getAdditionalSettingDefinitions.")

--- a/UM/Settings/AdditionalSettingDefinitionAppender.py
+++ b/UM/Settings/AdditionalSettingDefinitionAppender.py
@@ -21,7 +21,8 @@ def prependIdToSettings(tag_type: str, tag_id: str, tag_version: str, settings: 
 
     For each key that is renamed, this results in a mapping <key> -> _<provider_type>__<id*>__<version>__<key>
      where '<id*>' is the version of the provider, but converted from using points to using underscores.
-    Example: 'tapdance_factor' might become '_PLUGIN__DancingPrinter__1_2_99__tapdance_factor'
+    Example: 'tapdance_factor' might become '_plugin__dancingprinter__1_2_99__tapdance_factor'
+    Also note that all the tag_... parameters will be forced to lower-case.
 
     :param tag_type: Type of the additional settings appender, for example; "PLUGIN".
     :param tag_id: ID of the provider. Should be unique.
@@ -30,7 +31,9 @@ def prependIdToSettings(tag_type: str, tag_id: str, tag_version: str, settings: 
 
     :returns: Remapped settings, where each settings-name is properly tagged/'namespaced'.
     """
-    tag_version = tag_version.replace(".", "_")
+    tag_type = tag_type.lower()
+    tag_id = tag_id.lower()
+    tag_version = tag_version.lower().replace(".", "_")
 
     # First get the mapping, so that both the 'headings' and formula's can be renamed at the same time later.
     def _getMapping(values: Dict[str, Any]) -> Dict[str, str]:

--- a/UM/Settings/AdditionalSettingDefinitionAppender.py
+++ b/UM/Settings/AdditionalSettingDefinitionAppender.py
@@ -5,6 +5,16 @@ from typing import Any, Dict
 from UM.PluginObject import PluginObject
 
 
+def prependIdToSettings(id: str, settings: Dict[str, Dict[str, Any]]) -> Dict[str, Dict[str, Any]]:
+    result = {}
+    for key, value in settings.items():
+        if isinstance(value, dict):
+            key = f"{id}:{key}" if ("type" in value and "category" not in value) else key
+            value = prependIdToSettings(id, value)
+        result[key] = value
+    return result
+
+
 class AdditionalSettingDefinitionsAppender(PluginObject):
 
     def __init__(self) -> None:

--- a/UM/Settings/AdditionalSettingDefinitionAppender.py
+++ b/UM/Settings/AdditionalSettingDefinitionAppender.py
@@ -30,7 +30,7 @@ class AdditionalSettingDefinitionsAppender(PluginObject):
 
     def __init__(self) -> None:
         super().__init__()
-        self.appender_type = "EXTRA"
+        self.appender_type = "PLUGIN"
         self.definition_file_paths: List[Path] = []
 
     def getAppenderType(self) -> str:

--- a/UM/Settings/ContainerRegistry.py
+++ b/UM/Settings/ContainerRegistry.py
@@ -17,7 +17,7 @@ from UM.Resources import Resources
 from UM.Settings.EmptyInstanceContainer import EmptyInstanceContainer
 from UM.Settings.ContainerFormatError import ContainerFormatError
 from UM.Settings.ContainerProvider import ContainerProvider
-from UM.Settings.AdditionalSettingDefinitionAppender import AdditionalSettingDefinitionsAppender, prependIdToSettings
+from UM.Settings.AdditionalSettingDefinitionAppender import AdditionalSettingDefinitionsAppender
 from UM.Settings.constant_instance_containers import empty_container
 from . import ContainerQuery
 from UM.Settings.ContainerStack import ContainerStack
@@ -123,7 +123,7 @@ class ContainerRegistry(ContainerRegistryInterface):
         """Adds a provider for additional setting definitions to append to each definition-container."""
 
         additional_settings = appender.getAdditionalSettingDefinitions()
-        plugin_id_settings = prependIdToSettings(appender.getAppenderType(), appender.getId(), appender.getVersion(), additional_settings)
+        plugin_id_settings = AdditionalSettingDefinitionsAppender.prependIdToSettings(appender.getAppenderType(), appender.getId(), appender.getVersion(), additional_settings)
         self._additional_setting_definitions_list.append(plugin_id_settings)
 
     def findDefinitionContainers(self, **kwargs: Any) -> List[DefinitionContainerInterface]:

--- a/UM/Settings/ContainerRegistry.py
+++ b/UM/Settings/ContainerRegistry.py
@@ -17,7 +17,7 @@ from UM.Resources import Resources
 from UM.Settings.EmptyInstanceContainer import EmptyInstanceContainer
 from UM.Settings.ContainerFormatError import ContainerFormatError
 from UM.Settings.ContainerProvider import ContainerProvider
-from UM.Settings.AdditionalSettingDefinitionAppender import AdditionalSettingDefinitionsAppender
+from UM.Settings.AdditionalSettingDefinitionAppender import AdditionalSettingDefinitionsAppender, prependIdToSettings
 from UM.Settings.constant_instance_containers import empty_container
 from . import ContainerQuery
 from UM.Settings.ContainerStack import ContainerStack
@@ -122,7 +122,8 @@ class ContainerRegistry(ContainerRegistryInterface):
     def addAdditionalSettingDefinitionsAppender(self, appender: AdditionalSettingDefinitionsAppender) -> None:
         """Adds a provider for additional setting definitions to append to each definition-container."""
 
-        self._additional_setting_definitions_list.append(appender.getAdditionalSettingDefinitions())
+        plugin_id_settings = prependIdToSettings(appender.getId(), appender.getAdditionalSettingDefinitions())
+        self._additional_setting_definitions_list.append(plugin_id_settings)
 
     def findDefinitionContainers(self, **kwargs: Any) -> List[DefinitionContainerInterface]:
         """Find all DefinitionContainer objects matching certain criteria.

--- a/UM/Settings/ContainerRegistry.py
+++ b/UM/Settings/ContainerRegistry.py
@@ -122,9 +122,7 @@ class ContainerRegistry(ContainerRegistryInterface):
     def addAdditionalSettingDefinitionsAppender(self, appender: AdditionalSettingDefinitionsAppender) -> None:
         """Adds a provider for additional setting definitions to append to each definition-container."""
 
-        additional_settings = appender.getAdditionalSettingDefinitions()
-        plugin_id_settings = AdditionalSettingDefinitionsAppender.prependIdToSettings(appender.getAppenderType(), appender.getId(), appender.getVersion(), additional_settings)
-        self._additional_setting_definitions_list.append(plugin_id_settings)
+        self._additional_setting_definitions_list.append(appender.getAdditionalSettingDefinitions())
 
     def findDefinitionContainers(self, **kwargs: Any) -> List[DefinitionContainerInterface]:
         """Find all DefinitionContainer objects matching certain criteria.

--- a/UM/Settings/ContainerRegistry.py
+++ b/UM/Settings/ContainerRegistry.py
@@ -123,7 +123,7 @@ class ContainerRegistry(ContainerRegistryInterface):
         """Adds a provider for additional setting definitions to append to each definition-container."""
 
         additional_settings = appender.getAdditionalSettingDefinitions()
-        plugin_id_settings = prependIdToSettings("PLUGIN", appender.getId(), appender.getVersion(), additional_settings)
+        plugin_id_settings = prependIdToSettings(appender.getAppenderType(), appender.getId(), appender.getVersion(), additional_settings)
         self._additional_setting_definitions_list.append(plugin_id_settings)
 
     def findDefinitionContainers(self, **kwargs: Any) -> List[DefinitionContainerInterface]:

--- a/UM/Settings/ContainerRegistry.py
+++ b/UM/Settings/ContainerRegistry.py
@@ -122,7 +122,8 @@ class ContainerRegistry(ContainerRegistryInterface):
     def addAdditionalSettingDefinitionsAppender(self, appender: AdditionalSettingDefinitionsAppender) -> None:
         """Adds a provider for additional setting definitions to append to each definition-container."""
 
-        plugin_id_settings = prependIdToSettings(appender.getId(), appender.getAdditionalSettingDefinitions())
+        additional_settings = appender.getAdditionalSettingDefinitions()
+        plugin_id_settings = prependIdToSettings("PLUGIN", appender.getId(), appender.getVersion(), additional_settings)
         self._additional_setting_definitions_list.append(plugin_id_settings)
 
     def findDefinitionContainers(self, **kwargs: Any) -> List[DefinitionContainerInterface]:

--- a/UM/Settings/DefinitionContainer.py
+++ b/UM/Settings/DefinitionContainer.py
@@ -359,7 +359,10 @@ class DefinitionContainer(QObject, DefinitionContainerInterface, PluginObject):
     def appendAdditionalSettingDefinitions(self, additional_settings: Dict[str, Dict[str, Any]]) -> None:
         """
         Appends setting-definitions not defined for/by the main program (for example, a plugin) to this container.
+
+        Additional settings are always assumed to come in the form of categories with child-settings.
         See also the Settings.AdditionalSettingDefinitionAppender class.
+
         :param additional_settings: A dictionary of category-name to categories, each containing setting-definitions.
         """
         try:

--- a/UM/Settings/DefinitionContainer.py
+++ b/UM/Settings/DefinitionContainer.py
@@ -344,8 +344,6 @@ class DefinitionContainer(QObject, DefinitionContainerInterface, PluginObject):
             category_parent = category_parent[0] if len(category_parent) > 0 else None
 
         for key, value in settings_dict.items():
-            if key in self._definition_cache:
-                continue
             definition = SettingDefinition(key, self, category_parent, self._i18n_catalog)
             self._definition_cache[key] = definition
             definition.deserialize(value)

--- a/UM/Settings/DefinitionContainer.py
+++ b/UM/Settings/DefinitionContainer.py
@@ -332,16 +332,54 @@ class DefinitionContainer(QObject, DefinitionContainerInterface, PluginObject):
         self._metadata["version"] = self.Version #Guaranteed to be equal to what's in the parsed data by the validation.
         self._metadata["container_type"] = DefinitionContainer
 
-        for key, value in parsed["settings"].items():
-            definition = SettingDefinition(key, self, None, self._i18n_catalog)
+        self._deserializeDefinitions(parsed["settings"])
+        return serialized
+
+    def _deserializeDefinitions(self, settings_dict: Dict[str, Any], force_category: Optional[str] = None) -> None:
+
+        # When there is a forced category (= parent) present, find the category parent, create it if it doesn't exist.
+        category_parent = None
+        if force_category:
+            category_parent = self.findDefinitions(key=force_category)
+            category_parent = category_parent[0] if len(category_parent) > 0 else None
+
+        for key, value in settings_dict.items():
+            if key in self._definition_cache:
+                continue
+            definition = SettingDefinition(key, self, category_parent, self._i18n_catalog)
             self._definition_cache[key] = definition
             definition.deserialize(value)
-            self._definitions.append(definition)
+            if category_parent:
+                # Forced category; these are then children of that category, instead of full categories on their own.
+                category_parent.children.append(definition)
+            else:
+                self._definitions.append(definition)
 
         for definition in self._definitions:
             self._updateRelations(definition)
 
-        return serialized
+    def appendAdditionalSettingDefinitions(self, additional_settings: Dict[str, Dict[str, Any]]) -> None:
+        try:
+            merge_with_existing_categories = {}
+            create_new_categories = {}
+
+            for category, values in additional_settings.items():
+                if len(self.findDefinitions(key=category)) > 0:
+                    merge_with_existing_categories[category] = values
+                else:
+                    create_new_categories[category] = values
+
+            if len(create_new_categories) > 0:
+                self._deserializeDefinitions(create_new_categories)
+            for category, values in merge_with_existing_categories.items():
+                if "children" in values:
+                    for key, value in values["children"].items():
+                        self._deserializeDefinitions({key: value}, category)
+                else:
+                    self._deserializeDefinitions(values, category)
+
+        except Exception as ex:
+            Logger.error(f"Failed to append additional settings from external source because: {str(ex)}")
 
     @classmethod
     def deserializeMetadata(cls, serialized: str, container_id: str) -> List[Dict[str, Any]]:
@@ -429,6 +467,7 @@ class DefinitionContainer(QObject, DefinitionContainerInterface, PluginObject):
         json_dict = self._loadFile(file_name)
 
         if "inherits" in json_dict:
+            # NOTE: Since load-file isn't cached, this will load base definitions multiple times!
             inherited = self._resolveInheritance(json_dict["inherits"])
             json_dict = self._mergeDicts(inherited, json_dict)
 

--- a/UM/Settings/DefinitionContainer.py
+++ b/UM/Settings/DefinitionContainer.py
@@ -340,7 +340,7 @@ class DefinitionContainer(QObject, DefinitionContainerInterface, PluginObject):
         # When there is a forced category (= parent) present, find the category parent, create it if it doesn't exist.
         category_parent = None
         if force_category:
-            category_parent = self.findDefinitions(key=force_category)
+            category_parent = self.findDefinitions(key = force_category)
             category_parent = category_parent[0] if len(category_parent) > 0 else None
 
         for key, value in settings_dict.items():
@@ -362,7 +362,7 @@ class DefinitionContainer(QObject, DefinitionContainerInterface, PluginObject):
             create_new_categories = {}
 
             for category, values in additional_settings.items():
-                if len(self.findDefinitions(key=category)) > 0:
+                if len(self.findDefinitions(key = category)) > 0:
                     merge_with_existing_categories[category] = values
                 else:
                     create_new_categories[category] = values

--- a/UM/Settings/DefinitionContainer.py
+++ b/UM/Settings/DefinitionContainer.py
@@ -357,6 +357,11 @@ class DefinitionContainer(QObject, DefinitionContainerInterface, PluginObject):
             self._updateRelations(definition)
 
     def appendAdditionalSettingDefinitions(self, additional_settings: Dict[str, Dict[str, Any]]) -> None:
+        """
+        Appends setting-definitions not defined for/by the main program (for example, a plugin) to this container.
+        See also the Settings.AdditionalSettingDefinitionAppender class.
+        :param additional_settings: A dictionary of category-name to categories, each containing setting-definitions.
+        """
         try:
             merge_with_existing_categories = {}
             create_new_categories = {}

--- a/tests/Settings/TestAppendAdditionalSettings.py
+++ b/tests/Settings/TestAppendAdditionalSettings.py
@@ -16,7 +16,7 @@ class PluginTestClass(AdditionalSettingDefinitionsAppender):
         self._plugin_id = "RealityPerforator"
         self._version = "7.8.9"
         self.appender_type = "CLOWNS"
-        self.definition_file_paths = [os.path.join(os.path.dirname(os.path.abspath(__file__)), "definitions", "append_extra_settings.def.json")]
+        self.definition_file_paths = [os.path.join(os.path.dirname(os.path.abspath(__file__)), "additional_settings", "append_extra_settings.def.json")]
 
 
 def test_AdditionalSettingNames():

--- a/tests/Settings/TestAppendAdditionalSettings.py
+++ b/tests/Settings/TestAppendAdditionalSettings.py
@@ -1,0 +1,52 @@
+# Copyright (c) 2023 UltiMaker
+# Uranium is released under the terms of the LGPLv3 or higher.
+
+import os
+import pytest
+from unittest.mock import MagicMock, patch
+
+from UM.Settings.AdditionalSettingDefinitionAppender import AdditionalSettingDefinitionsAppender
+from UM.Settings.DefinitionContainer import DefinitionContainer
+from UM.VersionUpgradeManager import VersionUpgradeManager
+
+
+class PluginTestClass(AdditionalSettingDefinitionsAppender):
+    def __init__(self) -> None:
+        super().__init__()
+        self._plugin_id = "RealityPerforator"
+        self._version = "7.8.9"
+        self.appender_type = "CLOWNS"
+        self.definition_file_paths = [os.path.join(os.path.dirname(os.path.abspath(__file__)), "definitions", "append_extra_settings.def.json")]
+
+
+def test_AdditionalSettingNames():
+    plugin = PluginTestClass()
+    settings = plugin.getAdditionalSettingDefinitions()
+
+    assert "test_setting" in settings
+    assert "category_too" in settings
+    assert "children" in settings["test_setting"]
+    assert "children" in settings["category_too"]
+
+    assert "_clowns__realityperforator__7_8_9__glombump" in settings["test_setting"]["children"]
+    assert "_clowns__realityperforator__7_8_9__zharbler" in settings["category_too"]["children"]
+
+
+def test_AdditionalSettingContainer(upgrade_manager: VersionUpgradeManager):
+    plugin = PluginTestClass()
+    settings = plugin.getAdditionalSettingDefinitions()
+
+    definition_container = DefinitionContainer("TheSunIsADeadlyLazer")
+    with open(os.path.join(os.path.dirname(os.path.abspath(__file__)), "definitions", "children.def.json"), encoding = "utf-8") as data:
+        definition_container.deserialize(data.read())
+    definition_container.appendAdditionalSettingDefinitions(settings)
+
+    # 'merged' setting-categories should definitely be in the relevant container (as well as the original ones):
+    assert len(definition_container.findDefinitions(key="test_setting")) == 1
+    kid_keys = [x.key for x in definition_container.findDefinitions(key="test_setting")[0].children]
+    assert "test_child_0" in kid_keys
+    assert "test_child_1" in kid_keys
+    assert "_clowns__realityperforator__7_8_9__glombump" in kid_keys
+
+    # other settings (from new categories) are added 'dry' to the container:
+    assert "_clowns__realityperforator__7_8_9__zharbler" in definition_container.getAllKeys()

--- a/tests/Settings/additional_settings/append_extra_settings.def.json
+++ b/tests/Settings/additional_settings/append_extra_settings.def.json
@@ -17,7 +17,7 @@
       }
     }
   },
-  "spoot":
+  "category_too":
   {
     "label": "Warble!",
     "type": "category",

--- a/tests/Settings/definitions/append_extra_settings.def.json
+++ b/tests/Settings/definitions/append_extra_settings.def.json
@@ -1,0 +1,44 @@
+{
+  "test_setting":
+  {
+    "children":
+    {
+      "glombump":
+      {
+        "label": "Snosmozea",
+        "description": "Sudoriferous.",
+        "unit": "mm/s",
+        "type": "float",
+        "minimum_value": "0.1",
+        "maximum_value_warning": "150",
+        "maximum_value": "500",
+        "default_value": 60,
+        "settable_per_mesh": true
+      }
+    }
+  },
+  "spoot":
+  {
+    "label": "Warble!",
+    "type": "category",
+    "description": "Blomblimg",
+    "icon": "Printer",
+    "children":
+    {
+      "zharbler":
+      {
+        "label": "Frumg",
+        "description": "Pleonastic Pellerator.",
+        "unit": "mm/s",
+        "type": "float",
+        "minimum_value": "0.1",
+        "maximum_value_warning": "150",
+        "maximum_value": "500",
+        "default_value": 60,
+        "value": "glombump * 1.2",
+        "settable_per_mesh": false
+      }
+    }
+  }
+}
+

--- a/tests/TestTrust.py
+++ b/tests/TestTrust.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2023 UltiMaker
+# Uranium is released under the terms of the LGPLv3 or higher.
+
 import copy
 import json
 from unittest.mock import MagicMock, patch


### PR DESCRIPTION
Plugins should now be able to add settings. (But not append enum-values to existing ones, that's another ticket.)

- (De)serialization works, including load/save.
- Keys are tagged/'namespaced' with provider type (just a plugin for now), unique id, version.
- Will be sent to engine (except you have to demangle the tagged/namespaced name a bit).
- Setting-formulas work (except for taking values of another plugin).
- Can add to an existing category, or create a new one.

See (now) also the accompanying front-end PR here: https://github.com/Ultimaker/Cura/pull/16305