### PR TITLE
Cura 9374 make long messages scrollable

### DIFF
--- a/UM/Qt/qml/UM/MessageStack.qml
+++ b/UM/Qt/qml/UM/MessageStack.qml
@@ -219,6 +219,8 @@ ListView
             textArea.textFormat: Text.RichText
             textArea.readOnly: true
             textArea.onLinkActivated: Qt.openUrlExternally(link)
+            textArea.background: null
+            textArea.padding: 0
         }
 
         UM.CheckBox
@@ -226,7 +228,7 @@ ListView
             id: optionToggle
             anchors
             {
-                top: scrollableMessage.bottom
+                top: scrollableMessageLabel.bottom
                 topMargin: visible ? UM.Theme.getSize("narrow_margin").height: 0
                 left: parent.left
                 leftMargin: UM.Theme.getSize("default_margin").width

--- a/UM/Qt/qml/UM/MessageStack.qml
+++ b/UM/Qt/qml/UM/MessageStack.qml
@@ -208,7 +208,7 @@ ListView
                 topMargin: UM.Theme.getSize("default_margin").height
             }
 
-            height: textArea.text == "" ? 0 : Math.min(200, contentHeight)
+            height: textArea.text === "" ? 0 : Math.min(UM.Theme.getSize("message").height * 3, contentHeight)
 
             function getProgressText()
             {

--- a/UM/Qt/qml/UM/MessageStack.qml
+++ b/UM/Qt/qml/UM/MessageStack.qml
@@ -5,7 +5,7 @@ import QtQuick 2.3
 import QtQuick.Controls 2.1
 import QtQuick.Layouts 1.1
 
-import UM 1.5 as UM
+import UM 1.7 as UM
 
 ListView
 {
@@ -192,9 +192,10 @@ ListView
             }
         }
 
-        UM.Label
+        UM.ScrollableTextArea
         {
-            id: messageLabel
+            id: scrollableMessageLabel
+
             anchors
             {
                 left: parent.left
@@ -207,15 +208,17 @@ ListView
                 topMargin: UM.Theme.getSize("default_margin").height
             }
 
-            height: text == "" ? 0 : contentHeight
+            height: textArea.text == "" ? 0 : Math.min(200, contentHeight)
 
             function getProgressText()
             {
                 return "%1 %2%".arg(model.text).arg(Math.floor(model.progress))
             }
 
-            text: model.progress > 0 ? messageLabel.getProgressText() : model.text == undefined ? "" : model.text
-            onLinkActivated: Qt.openUrlExternally(link)
+            textArea.text: model.progress > 0 ? getProgressText() : (model.text == undefined ? "" : model.text)
+            textArea.textFormat: Text.RichText
+            textArea.readOnly: true
+            textArea.onLinkActivated: Qt.openUrlExternally(link)
         }
 
         UM.CheckBox
@@ -223,7 +226,7 @@ ListView
             id: optionToggle
             anchors
             {
-                top: messageLabel.bottom
+                top: scrollableMessage.bottom
                 topMargin: visible ? UM.Theme.getSize("narrow_margin").height: 0
                 left: parent.left
                 leftMargin: UM.Theme.getSize("default_margin").width

--- a/UM/Qt/qml/UM/ScrollableTextArea.qml
+++ b/UM/Qt/qml/UM/ScrollableTextArea.qml
@@ -3,13 +3,9 @@
 
 import QtQuick 2.10
 import QtQuick.Controls 2.3
+import UM 1.7 as UM
 
-import UM 1.5 as UM
-
-
-//
-// Cura-style TextArea with scrolls
-//
+//TextArea with scrolls that uses our own theme.
 Flickable
 {
     id: scrollableTextAreaBase

--- a/UM/Qt/qml/UM/ScrollableTextArea.qml
+++ b/UM/Qt/qml/UM/ScrollableTextArea.qml
@@ -1,0 +1,43 @@
+// Copyright (c) 2022 Ultimaker B.V.
+// Uranium is released under the terms of the LGPLv3 or higher.
+
+import QtQuick 2.10
+import QtQuick.Controls 2.3
+
+import UM 1.5 as UM
+
+
+//
+// Cura-style TextArea with scrolls
+//
+Flickable
+{
+    id: scrollableTextAreaBase
+    property bool do_borders: true
+    property var back_color: UM.Theme.getColor("main_background")
+    property alias textArea: flickableTextArea
+
+    ScrollBar.vertical: UM.ScrollBar {}
+
+    TextArea.flickable: TextArea
+    {
+        id: flickableTextArea
+
+        background: Rectangle //Providing the background color and border.
+        {
+            anchors.fill: parent
+            anchors.margins: -border.width
+
+            color: scrollableTextAreaBase.back_color
+            border.color: UM.Theme.getColor("thick_lining")
+            border.width: scrollableTextAreaBase.do_borders ? UM.Theme.getSize("default_lining").width : 0
+        }
+
+        font: UM.Theme.getFont("default")
+        color: UM.Theme.getColor("text")
+        textFormat: TextEdit.PlainText
+        renderType: Text.NativeRendering
+        wrapMode: Text.Wrap
+        selectByMouse: true
+    }
+}

--- a/UM/Qt/qml/UM/qmldir
+++ b/UM/Qt/qml/UM/qmldir
@@ -21,6 +21,7 @@ TooltipArea             1.1 TooltipArea.qml
 
 ProgressBar             1.3 ProgressBar.qml
 ScrollBar               1.5 ScrollBar.qml
+ScrollableTextArea      1.7 ScrollableTextArea.qml
 SimpleButton            1.1 SimpleButton.qml
 TabRow                  1.3 TabRow.qml
 TabRowButton            1.3 TabRowButton.qml


### PR DESCRIPTION
Long messages are now scrollable. I reused the existing ScrollableTextArea, which has moved from Cura to Uranium, and changes the behavior of the user interactions :
* :+1: The text can now be selected, so the user may easily Google it in case of an error 
* :+1: The scrollbar only appears if the text is too high (fixed max size, to be discussed)
* :-1: When scrolling quickly, the last wheels moves actually zoom in/out on the 3d view

Maybe we should also consider making the dialog box a bit larger ?