### PR TITLE
[CURA-10870] If last we crashed, don't restore the previous window.

### DIFF
--- a/UM/Application.py
+++ b/UM/Application.py
@@ -38,6 +38,11 @@ if TYPE_CHECKING:
 
 @signalemitter
 class Application:
+    class ShutdownSeverity:
+        HardCrash = "hard_crash"
+        CrashHandler = "crash_handler"
+        NormalShutdown = "normal_shutdown"
+
     """Central object responsible for running the main event loop and creating other central objects.
 
     The Application object is a central object for accessing other important objects. It is also
@@ -207,6 +212,7 @@ class Application:
         self._preferences.addPreference("general/visible_settings", "")
         self._preferences.addPreference("general/plugins_to_remove", "")
         self._preferences.addPreference("general/disabled_plugins", "")
+        self._preferences.addPreference("general/last_shutdown_severity", Application.ShutdownSeverity.NormalShutdown)
 
         self._controller = Controller(self)
         self._output_device_manager = OutputDeviceManager()

--- a/UM/Qt/Bindings/MainWindow.py
+++ b/UM/Qt/Bindings/MainWindow.py
@@ -57,19 +57,26 @@ class MainWindow(QQuickWindow):
         self._preferences.addPreference("general/window_top", self.DEFAULT_WINDOW_TOP)
         self._preferences.addPreference("general/window_state", Qt.WindowState.WindowNoState.value)
         self._preferences.addPreference("general/restore_window_geometry", True)
+        self._preferences.addPreference("general/last_shutdown_normal", True)
 
         restored_geometry = QRect(int(self._preferences.getValue("general/window_left")),
                                   int(self._preferences.getValue("general/window_top")),
                                   int(self._preferences.getValue("general/window_width")),
                                   int(self._preferences.getValue("general/window_height")))
 
-        if not self._preferences.getValue("general/restore_window_geometry"):
+        if (not self._preferences.getValue("general/restore_window_geometry") or
+                not self._preferences.getValue("general/last_shutdown_normal")):
             # Ignore whatever the preferences said.
             Logger.log("i", "Not restoring window geometry from preferences because 'restore_window_geometry' is false")
             restored_geometry = QRect(self.DEFAULT_WINDOW_LEFT,
                                       self.DEFAULT_WINDOW_TOP,
                                       self.DEFAULT_WINDOW_WIDTH,
                                       self.DEFAULT_WINDOW_HEIGHT)
+
+        # Now set the 'last shutdown normal' to False, then, when the app closes normally, set it back to True.
+        self._preferences.setValue("general/last_shutdown_normal", False)
+        Application.getInstance().applicationShuttingDown.connect(
+            lambda: self._preferences.setValue("general/last_shutdown_normal", True))
 
         # Make sure restored geometry is not outside the currently available screens
         screen_found = False


### PR DESCRIPTION
Should work around certain multiple-monitor crashes.

_Update_: Now this also a little bit of frontend magic, see Ultimaker/Cura#16683