### PR TITLE
Fix numpy exception with polygon scaling

### DIFF
--- a/UM/Math/Polygon.py
+++ b/UM/Math/Polygon.py
@@ -160,6 +160,9 @@ class Polygon:
         point. If `None`, the 0,0 coordinate will be used.
         :return: A transformed polygon.
         """
+        if not self.isValid():
+            return self
+
         if origin is None:
             origin = [0, 0]
 


### PR DESCRIPTION
Add an extra check to ensure that calling `scale()` on an empty `Polygon` will not generate an exception.

CURA-10004