### PR TITLE
[CURA-11102] qml warnings

### DIFF
--- a/UM/Qt/qml/UM/Menu.qml
+++ b/UM/Qt/qml/UM/Menu.qml
@@ -17,7 +17,7 @@ Menu
         {
             root.parent.visible = shouldBeVisible
             root.parent.height = shouldBeVisible ? UM.Theme.getSize("menu").height : 0
-            root.width = shouldBeVisible ? Qt.binding(setWidth) : 0
+            root.width = shouldBeVisible ? setWidth() : 0
         }
     }
 

--- a/UM/Qt/qml/UM/MenuItem.qml
+++ b/UM/Qt/qml/UM/MenuItem.qml
@@ -84,8 +84,7 @@ MenuItem
         {
             // Middle margin
             id: middleSpacer
-            width: visible ? UM.Theme.getSize("default_margin").width : 0
-            visible: _shortcut.nativeText != "" || root.subMenu
+            width: (_shortcut.nativeText != "" || root.subMenu) ? UM.Theme.getSize("default_margin").width : 0
         }
 
         UM.Label


### PR DESCRIPTION
* The first mentioned QML warning has been fixed already with commit 1f67452346a5eda0c37c71a746d4a5cd44d33563
* Fixed two other QML binding loop warnings.
  * The one in `Menu.qml` implies that the width of the menu will not automatically change if any of the menu item changes. It will be updated only when the menu is opened again. In practice, this does not happen because it would be very user-unfriendly to have a menu that changes its width while the mouse cursor is over it.