### PR TITLE
Better handling of inconsistent property values

### DIFF
--- a/UM/Qt/Bindings/ActiveToolProxy.py
+++ b/UM/Qt/Bindings/ActiveToolProxy.py
@@ -88,8 +88,11 @@ class ActiveToolProxy(QObject):
             return
         if hasattr(self._active_tool, "set" + property):
             option_setter = getattr(self._active_tool, "set" + property)
-            if option_setter and value != '':
-                option_setter(value)
+            if option_setter:
+                try:
+                    option_setter(value)
+                except Exception as e:
+                    Logger.logException("e", f"Unable to set value '{value}' to property '{property}'.")
 
         if hasattr(self._active_tool, property):
             setattr(self._active_tool, property, value)


### PR DESCRIPTION
Commit https://github.com/Ultimaker/Uranium/commit/4f328198c4cca4b3f0f7af82f7b81faa5e8479a1 fixes exceptions where an empty string would be set to a floating-point property value. However, in some cases it prevents the values being intentionally set to an empty string (for properties that are actual string). This fix introduces an other way of handling this issue.

CURA-11215