### PR TITLE
[CURA-11102] qml warnings

### DIFF
--- a/UM/Qt/qml/UM/Menu.qml
+++ b/UM/Qt/qml/UM/Menu.qml
@@ -23,6 +23,7 @@ Menu
 
     Component.onCompleted: handleVisibility()
     onShouldBeVisibleChanged: handleVisibility()
+    onAboutToShow: handleVisibility()
 
     // Automatically set the width to fit the widest MenuItem
     // Based on https://martin.rpdev.net/2018/03/13/qt-quick-controls-2-automatically-set-the-width-of-menus.html

--- a/UM/Qt/qml/UM/MenuItem.qml
+++ b/UM/Qt/qml/UM/MenuItem.qml
@@ -84,7 +84,8 @@ MenuItem
         {
             // Middle margin
             id: middleSpacer
-            width: (_shortcut.nativeText != "" || root.subMenu) ? UM.Theme.getSize("default_margin").width : 0
+            width: visible ? UM.Theme.getSize("default_margin").width : 0
+            visible: _shortcut.nativeText != "" || root.subMenu
         }
 
         UM.Label

--- a/UM/Qt/qml/UM/MenuItem.qml
+++ b/UM/Qt/qml/UM/MenuItem.qml
@@ -84,8 +84,7 @@ MenuItem
         {
             // Middle margin
             id: middleSpacer
-            width: visible ? UM.Theme.getSize("default_margin").width : 0
-            visible: _shortcut.nativeText != "" || root.subMenu
+            width: (_shortcut.nativeText != "" || root.subMenu) ? UM.Theme.getSize("default_margin").width : 0
         }
 
         UM.Label


### PR DESCRIPTION
Removing the binding to `setWidth()` prevented the generic materials sub-menu to show up. I added a call just before the menu is displayed so that the proper width is calculated.