### PR TITLE
CURA-7812-decrease-Qml-singletons

### DIFF
--- a/UM/Qt/Bindings/ActiveToolProxy.py
+++ b/UM/Qt/Bindings/ActiveToolProxy.py
@@ -14,8 +14,7 @@ import os.path
 
 from ...Decorators import deprecated
 
-
-@deprecated("ActiveToolProxy is depricated and will be removed in major SDK release")
+# Class Active Tool Proxy is deprecated and will be removed in next major SDK release
 class ActiveToolProxy(QObject):
     def __init__(self, parent = None):
         super().__init__(parent)
@@ -125,6 +124,6 @@ class ActiveToolProxy(QObject):
 
         self.propertiesChanged.emit()
 
-@deprecated("createActiveToolProxy is depricated and will be removed in major SDK release")
+@deprecated("UM.ActiveTool is depricated and will be removed in major SDK release, Use UM.Controller instead", since = "5.7.0")
 def createActiveToolProxy(engine, script_engine):
     return ActiveToolProxy()

--- a/UM/Qt/Bindings/ActiveToolProxy.py
+++ b/UM/Qt/Bindings/ActiveToolProxy.py
@@ -124,6 +124,6 @@ class ActiveToolProxy(QObject):
 
         self.propertiesChanged.emit()
 
-@deprecated("UM.ActiveTool is depricated and will be removed in major SDK release, Use UM.Controller instead", since = "5.7.0")
+@deprecated("UM.ActiveTool is deprecated and will be removed in major SDK release, Use UM.Controller instead", since = "5.7.0")
 def createActiveToolProxy(engine, script_engine):
     return ActiveToolProxy()

--- a/UM/Qt/Bindings/ActiveToolProxy.py
+++ b/UM/Qt/Bindings/ActiveToolProxy.py
@@ -12,7 +12,10 @@ from . import ContainerProxy
 
 import os.path
 
+from ...Decorators import deprecated
 
+
+@deprecated("ActiveToolProxy is depricated and will be removed in major SDK release")
 class ActiveToolProxy(QObject):
     def __init__(self, parent = None):
         super().__init__(parent)
@@ -21,8 +24,6 @@ class ActiveToolProxy(QObject):
         self._properties = {}
         Application.getInstance().getController().activeToolChanged.connect(self._onActiveToolChanged)
         self._onActiveToolChanged()
-
-
         self._properties_proxy = ContainerProxy.ContainerProxy(self._properties)
 
     activeToolChanged = pyqtSignal()
@@ -124,5 +125,6 @@ class ActiveToolProxy(QObject):
 
         self.propertiesChanged.emit()
 
+@deprecated("createActiveToolProxy is depricated and will be removed in major SDK release")
 def createActiveToolProxy(engine, script_engine):
     return ActiveToolProxy()

--- a/UM/Qt/Bindings/ApplicationProxy.py
+++ b/UM/Qt/Bindings/ApplicationProxy.py
@@ -4,9 +4,8 @@
 from PyQt6.QtCore import QObject, pyqtSlot, pyqtProperty, pyqtSignal
 
 from UM.Application import Application
-from UM.Decorators import deprecated
 
-@deprecated("ApplicationProxy is deprecated and will be removed in major SDK release")
+#ApplicationProxy is deprecated and will be removed in major SDK release, use CuraApplication.version() in place of UM.Application.version
 class ApplicationProxy(QObject):
     def __init__(self, parent = None):
         super().__init__(parent)

--- a/UM/Qt/Bindings/ApplicationProxy.py
+++ b/UM/Qt/Bindings/ApplicationProxy.py
@@ -6,7 +6,7 @@ from PyQt6.QtCore import QObject, pyqtSlot, pyqtProperty, pyqtSignal
 from UM.Application import Application
 from UM.Decorators import deprecated
 
-@deprecated
+@deprecated("ApplicationProxy is deprecated and will be removed in major SDK release")
 class ApplicationProxy(QObject):
     def __init__(self, parent = None):
         super().__init__(parent)

--- a/UM/Qt/Bindings/ApplicationProxy.py
+++ b/UM/Qt/Bindings/ApplicationProxy.py
@@ -4,8 +4,9 @@
 from PyQt6.QtCore import QObject, pyqtSlot, pyqtProperty, pyqtSignal
 
 from UM.Application import Application
+from UM.Decorators import deprecated
 
-
+@deprecated
 class ApplicationProxy(QObject):
     def __init__(self, parent = None):
         super().__init__(parent)

--- a/UM/Qt/Bindings/Bindings.py
+++ b/UM/Qt/Bindings/Bindings.py
@@ -9,9 +9,11 @@ from UM.Qt.Duration import Duration, DurationFormat
 from . import MainWindow
 from . import ViewModel
 from . import ToolModel
+from . import ApplicationProxy
 from . import ControllerProxy
 from . import BackendProxy
 from . import ResourcesProxy
+from . import OperationStackProxy
 from . import Window
 from UM.Mesh.MeshFileHandler import MeshFileHandler
 from UM.Workspace.WorkspaceFileHandler import WorkspaceFileHandler
@@ -20,6 +22,7 @@ from . import Theme
 from . import OpenGLContextProxy
 from . import PointingRectangle
 from UM.ColorImage import ColorImage
+from . import ActiveToolProxy
 from . import OutputDevicesModel
 from . import SelectionProxy
 from . import OutputDeviceManagerProxy
@@ -36,11 +39,18 @@ from UM.Settings.Models.ContainerStacksModel import ContainerStacksModel
 from UM.Settings.Models.SettingPropertyProvider import SettingPropertyProvider
 from UM.Settings.Models.SettingPreferenceVisibilityHandler import SettingPreferenceVisibilityHandler
 from UM.Settings.Models.ContainerPropertyProvider import ContainerPropertyProvider
+from ...Decorators import deprecated
+
 
 class Bindings:
     @classmethod
     def createControllerProxy(self, engine, script_engine):
         return ControllerProxy.ControllerProxy()
+
+    @classmethod
+    @deprecated("UM.Application is depricated and will be removed in major SDK release, Use CuraApplication instead", since = "5.7.0")
+    def createApplicationProxy(self, engine, script_engine):
+        return ApplicationProxy.ApplicationProxy()
 
     @classmethod
     def createBackendProxy(self, engine, script_engine):
@@ -49,6 +59,11 @@ class Bindings:
     @classmethod
     def createResourcesProxy(cls, engine, script_engine):
         return ResourcesProxy.ResourcesProxy()
+
+    @classmethod
+    @deprecated("UM.OperationStack is depricated and will be removed in major SDK release, Use CuraActions instead", since = "5.7.0")
+    def createOperationStackProxy(cls, engine, script_engine):
+        return OperationStackProxy.OperationStackProxy()
 
     @classmethod
     def createOpenGLContextProxy(cls, engine, script_engine):
@@ -66,11 +81,14 @@ class Bindings:
 
         # Singleton proxy objects
         qmlRegisterSingletonType(ControllerProxy.ControllerProxy, "UM", 1, 0, Bindings.createControllerProxy, "Controller")
+        qmlRegisterSingletonType(ApplicationProxy.ApplicationProxy, "UM", 1, 0, Bindings.createApplicationProxy, "Application")
         qmlRegisterSingletonType(BackendProxy.BackendProxy, "UM", 1, 0, Bindings.createBackendProxy, "Backend")
         qmlRegisterSingletonType(ResourcesProxy.ResourcesProxy, "UM", 1, 0, Bindings.createResourcesProxy, "Resources")
+        qmlRegisterSingletonType(OperationStackProxy.OperationStackProxy, "UM", 1, 0, Bindings.createOperationStackProxy, "OperationStack")
         qmlRegisterSingletonType(MeshFileHandler, "UM", 1, 0, MeshFileHandler.getInstance, "MeshFileHandler")
         qmlRegisterSingletonType(PreferencesProxy.PreferencesProxy, "UM", 1, 0, PreferencesProxy.createPreferencesProxy, "Preferences")
         qmlRegisterSingletonType(Theme.Theme, "UM", 1, 0, Theme.createTheme, "Theme")
+        qmlRegisterSingletonType(ActiveToolProxy.ActiveToolProxy, "UM", 1, 0, ActiveToolProxy.createActiveToolProxy, "ActiveTool")
         qmlRegisterSingletonType(SelectionProxy.SelectionProxy, "UM", 1, 0, SelectionProxy.createSelectionProxy, "Selection")
 
         qmlRegisterUncreatableType(Duration, "UM", 1, 0, "", "Duration")

--- a/UM/Qt/Bindings/Bindings.py
+++ b/UM/Qt/Bindings/Bindings.py
@@ -12,7 +12,6 @@ from . import ToolModel
 from . import ControllerProxy
 from . import BackendProxy
 from . import ResourcesProxy
-from . import OperationStackProxy
 from . import Window
 from UM.Mesh.MeshFileHandler import MeshFileHandler
 from UM.Workspace.WorkspaceFileHandler import WorkspaceFileHandler
@@ -21,7 +20,6 @@ from . import Theme
 from . import OpenGLContextProxy
 from . import PointingRectangle
 from UM.ColorImage import ColorImage
-from . import ActiveToolProxy
 from . import OutputDevicesModel
 from . import SelectionProxy
 from . import OutputDeviceManagerProxy
@@ -39,12 +37,10 @@ from UM.Settings.Models.SettingPropertyProvider import SettingPropertyProvider
 from UM.Settings.Models.SettingPreferenceVisibilityHandler import SettingPreferenceVisibilityHandler
 from UM.Settings.Models.ContainerPropertyProvider import ContainerPropertyProvider
 
-
 class Bindings:
     @classmethod
     def createControllerProxy(self, engine, script_engine):
         return ControllerProxy.ControllerProxy()
-
 
     @classmethod
     def createBackendProxy(self, engine, script_engine):
@@ -53,10 +49,6 @@ class Bindings:
     @classmethod
     def createResourcesProxy(cls, engine, script_engine):
         return ResourcesProxy.ResourcesProxy()
-
-    @classmethod
-    def createOperationStackProxy(cls, engine, script_engine):
-        return OperationStackProxy.OperationStackProxy()
 
     @classmethod
     def createOpenGLContextProxy(cls, engine, script_engine):
@@ -76,11 +68,9 @@ class Bindings:
         qmlRegisterSingletonType(ControllerProxy.ControllerProxy, "UM", 1, 0, Bindings.createControllerProxy, "Controller")
         qmlRegisterSingletonType(BackendProxy.BackendProxy, "UM", 1, 0, Bindings.createBackendProxy, "Backend")
         qmlRegisterSingletonType(ResourcesProxy.ResourcesProxy, "UM", 1, 0, Bindings.createResourcesProxy, "Resources")
-        qmlRegisterSingletonType(OperationStackProxy.OperationStackProxy, "UM", 1, 0, Bindings.createOperationStackProxy, "OperationStack")
         qmlRegisterSingletonType(MeshFileHandler, "UM", 1, 0, MeshFileHandler.getInstance, "MeshFileHandler")
         qmlRegisterSingletonType(PreferencesProxy.PreferencesProxy, "UM", 1, 0, PreferencesProxy.createPreferencesProxy, "Preferences")
         qmlRegisterSingletonType(Theme.Theme, "UM", 1, 0, Theme.createTheme, "Theme")
-        qmlRegisterSingletonType(ActiveToolProxy.ActiveToolProxy, "UM", 1, 0, ActiveToolProxy.createActiveToolProxy, "ActiveTool")
         qmlRegisterSingletonType(SelectionProxy.SelectionProxy, "UM", 1, 0, SelectionProxy.createSelectionProxy, "Selection")
 
         qmlRegisterUncreatableType(Duration, "UM", 1, 0, "", "Duration")

--- a/UM/Qt/Bindings/Bindings.py
+++ b/UM/Qt/Bindings/Bindings.py
@@ -48,7 +48,7 @@ class Bindings:
         return ControllerProxy.ControllerProxy()
 
     @classmethod
-    @deprecated("UM.Application is depricated and will be removed in major SDK release, Use CuraApplication instead", since = "5.7.0")
+    @deprecated("UM.Application is deprecated and will be removed in major SDK release, Use CuraApplication instead", since = "5.7.0")
     def createApplicationProxy(self, engine, script_engine):
         return ApplicationProxy.ApplicationProxy()
 
@@ -61,7 +61,7 @@ class Bindings:
         return ResourcesProxy.ResourcesProxy()
 
     @classmethod
-    @deprecated("UM.OperationStack is depricated and will be removed in major SDK release, Use CuraActions instead", since = "5.7.0")
+    @deprecated("UM.OperationStack is deprecated and will be removed in major SDK release, Use CuraActions instead", since = "5.7.0")
     def createOperationStackProxy(cls, engine, script_engine):
         return OperationStackProxy.OperationStackProxy()
 

--- a/UM/Qt/Bindings/Bindings.py
+++ b/UM/Qt/Bindings/Bindings.py
@@ -9,7 +9,6 @@ from UM.Qt.Duration import Duration, DurationFormat
 from . import MainWindow
 from . import ViewModel
 from . import ToolModel
-from . import ApplicationProxy
 from . import ControllerProxy
 from . import BackendProxy
 from . import ResourcesProxy
@@ -46,9 +45,6 @@ class Bindings:
     def createControllerProxy(self, engine, script_engine):
         return ControllerProxy.ControllerProxy()
 
-    @classmethod
-    def createApplicationProxy(self, engine, script_engine):
-        return ApplicationProxy.ApplicationProxy()
 
     @classmethod
     def createBackendProxy(self, engine, script_engine):
@@ -78,7 +74,6 @@ class Bindings:
 
         # Singleton proxy objects
         qmlRegisterSingletonType(ControllerProxy.ControllerProxy, "UM", 1, 0, Bindings.createControllerProxy, "Controller")
-        qmlRegisterSingletonType(ApplicationProxy.ApplicationProxy, "UM", 1, 0, Bindings.createApplicationProxy, "Application")
         qmlRegisterSingletonType(BackendProxy.BackendProxy, "UM", 1, 0, Bindings.createBackendProxy, "Backend")
         qmlRegisterSingletonType(ResourcesProxy.ResourcesProxy, "UM", 1, 0, Bindings.createResourcesProxy, "Resources")
         qmlRegisterSingletonType(OperationStackProxy.OperationStackProxy, "UM", 1, 0, Bindings.createOperationStackProxy, "OperationStack")

--- a/UM/Qt/Bindings/ControllerProxy.py
+++ b/UM/Qt/Bindings/ControllerProxy.py
@@ -1,12 +1,18 @@
 # Copyright (c) 2022 Ultimaker B.V.
 # Uranium is released under the terms of the LGPLv3 or higher.
+import os
+from typing import Any
 
-from PyQt6.QtCore import QObject, pyqtSlot, pyqtSignal, pyqtProperty
+from PyQt6.QtCore import QObject, pyqtSlot, pyqtSignal, pyqtProperty, QUrl, QVariant
 
 from UM.Application import Application
 from UM.Scene.Selection import Selection
 from UM.Operations.RemoveSceneNodeOperation import RemoveSceneNodeOperation
 from UM.Operations.GroupedOperation import GroupedOperation
+
+from . import ContainerProxy
+from ...Logger import Logger
+from ...PluginRegistry import PluginRegistry
 
 
 class ControllerProxy(QObject):
@@ -17,6 +23,14 @@ class ControllerProxy(QObject):
         self._selection_pass = None
         self._tools_enabled = True
 
+        self._active_tool = None
+        self._properties = {}
+        Application.getInstance().getController().activeToolChanged.connect(self._onActiveToolChanged)
+        self._onActiveToolChanged()
+
+
+        self._properties_proxy = ContainerProxy.ContainerProxy(self._properties)
+
         # bind needed signals
         self._controller.toolOperationStarted.connect(self._onToolOperationStarted)
         self._controller.toolOperationStopped.connect(self._onToolOperationStopped)
@@ -26,6 +40,7 @@ class ControllerProxy(QObject):
     toolsEnabledChanged = pyqtSignal()
     activeStageChanged = pyqtSignal()
     activeViewChanged = pyqtSignal()
+    activeToolChanged = pyqtSignal()
 
     @pyqtProperty(bool, notify = toolsEnabledChanged)
     def toolsEnabled(self):
@@ -116,3 +131,101 @@ class ControllerProxy(QObject):
 
     def _onActiveViewChanged(self):
         self.activeViewChanged.emit()
+
+
+    @pyqtProperty(bool, notify = activeToolChanged)
+    def valid(self):
+        return self._active_tool != None
+
+    @pyqtProperty(QUrl, notify = activeToolChanged)
+    def activeToolPanel(self):
+        if not self._active_tool:
+            return QUrl()
+        try:
+            panel_file = self._active_tool.getMetaData()["tool_panel"]
+        except KeyError:
+            return QUrl()
+
+        return QUrl.fromLocalFile(os.path.join(PluginRegistry.getInstance().getPluginPath(self._active_tool.getPluginId()), panel_file))
+
+    @pyqtSlot(str)
+    def triggerAction(self, action):
+        if not self._active_tool:
+            return
+        if not hasattr(self._active_tool, action):
+            Logger.log("w", "Trying to call non-existing action {action} of tool {tool}.".format(action = action, tool = self._active_tool.getPluginId()))
+            return
+
+        action = getattr(self._active_tool, action)
+        if action:
+            action()
+
+    @pyqtSlot(str, QVariant)
+    def triggerActionWithData(self, action: str, data: Any):
+        """Triggers one of the tools' actions and provides additional parameters to the action.
+
+        The additional data is passed as a parameter to the function call of the
+        action.
+        :param action: The action to trigger.
+        :param data: The additional data to call
+        """
+
+        if not self._active_tool:
+            return
+        if not hasattr(self._active_tool, action):
+            Logger.log("w", "Trying to call non-existing action {action} of tool {tool}.".format(action = action, tool = self._active_tool.getPluginId()))
+            return
+
+        if hasattr(self._active_tool, action):
+            getattr(self._active_tool, action)(data)
+
+    propertiesChanged = pyqtSignal()
+    @pyqtProperty(QObject, notify = propertiesChanged)
+    def properties(self):
+        return self._properties_proxy
+
+    @pyqtSlot()
+    def forceUpdate(self):
+        self._updateProperties()
+
+    @pyqtSlot(str, "QVariant")
+    def setProperty(self, property, value):
+        if not self._active_tool:
+            return
+        if hasattr(self._active_tool, "set" + property):
+            option_setter = getattr(self._active_tool, "set" + property)
+            if option_setter:
+                try:
+                    option_setter(value)
+                except Exception as e:
+                    Logger.logException("e", f"Unable to set value '{value}' to property '{property}'.")
+
+        if hasattr(self._active_tool, property):
+            setattr(self._active_tool, property, value)
+
+    def _onPropertyChanged(self):
+        self._updateProperties()
+
+    def _onActiveToolChanged(self):
+        if self._active_tool:
+            self._active_tool.propertyChanged.disconnect(self._onPropertyChanged)
+
+        self._active_tool = Application.getInstance().getController().getActiveTool()
+        if self._active_tool is not None:
+            self._active_tool.propertyChanged.connect(self._onPropertyChanged)
+            self._updateProperties()
+
+        self.activeToolChanged.emit()
+
+    def _updateProperties(self):
+        self._properties.clear()
+
+        for name in self._active_tool.getExposedProperties():
+            property_getter = getattr(self._active_tool, "get" + name)
+            if property_getter:
+                self._properties[name] = property_getter()
+
+            if hasattr(self._active_tool, name):
+                self._properties[name] = getattr(self._active_tool, name)
+
+        self.propertiesChanged.emit()

--- a/UM/Qt/Bindings/OperationStackProxy.py
+++ b/UM/Qt/Bindings/OperationStackProxy.py
@@ -4,8 +4,10 @@
 from PyQt6.QtCore import QObject, pyqtSlot, pyqtProperty, pyqtSignal
 
 from UM.Application import Application
+from UM.Decorators import deprecated
 
 
+@deprecated("OperationStackProxy is deprecated and will be removed in major SDK release")
 class OperationStackProxy(QObject):
     def __init__(self, parent = None):
         super().__init__(parent)

--- a/UM/Qt/Bindings/OperationStackProxy.py
+++ b/UM/Qt/Bindings/OperationStackProxy.py
@@ -4,10 +4,9 @@
 from PyQt6.QtCore import QObject, pyqtSlot, pyqtProperty, pyqtSignal
 
 from UM.Application import Application
-from UM.Decorators import deprecated
 
 
-@deprecated("OperationStackProxy is deprecated and will be removed in major SDK release")
+#"OperationStackProxy is deprecated and will be removed in major SDK release"
 class OperationStackProxy(QObject):
     def __init__(self, parent = None):
         super().__init__(parent)

--- a/UM/Qt/QtApplication.py
+++ b/UM/Qt/QtApplication.py
@@ -343,6 +343,10 @@ class QtApplication(QApplication, Application):
 
     recentFilesChanged = pyqtSignal()
 
+    @pyqtSlot(result = str)
+    def applicationVersion(self) -> str:
+        return Application.getInstance().getVersion()
+
     @pyqtProperty("QVariantList", notify=recentFilesChanged)
     def recentFiles(self) -> List[QUrl]:
         return self._recent_files

--- a/UM/Qt/QtApplication.py
+++ b/UM/Qt/QtApplication.py
@@ -344,7 +344,7 @@ class QtApplication(QApplication, Application):
     recentFilesChanged = pyqtSignal()
 
     @pyqtSlot(result = str)
-    def applicationVersion(self) -> str:
+    def version(self) -> str:
         return Application.getInstance().getVersion()
 
     @pyqtProperty("QVariantList", notify=recentFilesChanged)

--- a/plugins/Tools/RotateTool/RotateTool.qml
+++ b/plugins/Tools/RotateTool/RotateTool.qml
@@ -26,7 +26,7 @@ Item
 
         z: 2
 
-        onClicked: UM.ActiveTool.triggerAction("resetRotation")
+        onClicked: UM.Controller.triggerAction("resetRotation")
     }
 
     UM.ToolbarButton
@@ -47,10 +47,10 @@ Item
 
         z: 1
 
-        onClicked: UM.ActiveTool.triggerAction("layFlat");
+        onClicked: UM.Controller.triggerAction("layFlat");
 
         // (Not yet:) Alternative 'lay flat' when legacy OpenGL makes selection of a face in an indexed model impossible.
-        // visible: ! UM.ActiveTool.properties.getValue("SelectFaceSupported");
+        // visible: ! UM.Controller.properties.getValue("SelectFaceSupported");
     }
 
     UM.ToolbarButton{
@@ -71,10 +71,10 @@ Item
         checkable: true
 
         enabled: UM.Selection.selectionCount == 1
-        checked: UM.ActiveTool.properties.getValue("SelectFaceToLayFlatMode")
-        onClicked: UM.ActiveTool.setProperty("SelectFaceToLayFlatMode", checked)
+        checked: UM.Controller.properties.getValue("SelectFaceToLayFlatMode")
+        onClicked: UM.Controller.setProperty("SelectFaceToLayFlatMode", checked)
 
-        visible: UM.ActiveTool.properties.getValue("SelectFaceSupported") == true //Might be undefined if we're switching away from the RotateTool!
+        visible: UM.Controller.properties.getValue("SelectFaceSupported") == true //Might be undefined if we're switching away from the RotateTool!
     }
 
     UM.CheckBox
@@ -86,21 +86,21 @@ Item
         //: Snap Rotation checkbox
         text: catalog.i18nc("@action:checkbox","Snap Rotation")
 
-        checked: UM.ActiveTool.properties.getValue("RotationSnap")
-        onClicked: UM.ActiveTool.setProperty("RotationSnap", checked)
+        checked: UM.Controller.properties.getValue("RotationSnap")
+        onClicked: UM.Controller.setProperty("RotationSnap", checked)
     }
 
     Binding
     {
         target: snapRotationCheckbox
         property: "checked"
-        value: UM.ActiveTool.properties.getValue("RotationSnap")
+        value: UM.Controller.properties.getValue("RotationSnap")
     }
 
     Binding
     {
         target: alignFaceButton
         property: "checked"
-        value: UM.ActiveTool.properties.getValue("SelectFaceToLayFlatMode")
+        value: UM.Controller.properties.getValue("SelectFaceToLayFlatMode")
     }
 }

--- a/plugins/Tools/ScaleTool/ScaleTool.qml
+++ b/plugins/Tools/ScaleTool/ScaleTool.qml
@@ -72,7 +72,7 @@ Item
             color: UM.Theme.getColor("icon")
         }
 
-        onClicked: UM.ActiveTool.triggerAction("resetScale")
+        onClicked: UM.Controller.triggerAction("resetScale")
     }
 
 
@@ -92,15 +92,15 @@ Item
             width: parent.width //Use a width instead of anchors to allow the flow layout to resolve positioning.
             text: catalog.i18nc("@option:check", "Snap Scaling")
 
-            checked: UM.ActiveTool.properties.getValue("ScaleSnap")
+            checked: UM.Controller.properties.getValue("ScaleSnap")
             onClicked:
             {
-                UM.ActiveTool.setProperty("ScaleSnap", checked)
+                UM.Controller.setProperty("ScaleSnap", checked)
                 if (snapScalingCheckbox.checked)
                 {
-                    UM.ActiveTool.setProperty("ScaleX", parseFloat(xPercentage.text) / 100)
-                    UM.ActiveTool.setProperty("ScaleY", parseFloat(yPercentage.text) / 100)
-                    UM.ActiveTool.setProperty("ScaleZ", parseFloat(zPercentage.text) / 100)
+                    UM.Controller.setProperty("ScaleX", parseFloat(xPercentage.text) / 100)
+                    UM.Controller.setProperty("ScaleY", parseFloat(yPercentage.text) / 100)
+                    UM.Controller.setProperty("ScaleZ", parseFloat(zPercentage.text) / 100)
                 }
             }
         }
@@ -109,7 +109,7 @@ Item
         {
             target: snapScalingCheckbox
             property: "checked"
-            value: UM.ActiveTool.properties.getValue("ScaleSnap")
+            value: UM.Controller.properties.getValue("ScaleSnap")
         }
 
         UM.CheckBox
@@ -119,15 +119,15 @@ Item
             width: parent.width //Use a width instead of anchors to allow the flow layout to resolve positioning.
             text: catalog.i18nc("@option:check", "Uniform Scaling")
 
-            checked: !UM.ActiveTool.properties.getValue("NonUniformScale")
-            onClicked: UM.ActiveTool.setProperty("NonUniformScale", !checked)
+            checked: !UM.Controller.properties.getValue("NonUniformScale")
+            onClicked: UM.Controller.setProperty("NonUniformScale", !checked)
         }
 
         Binding
         {
             target: uniformScalingCheckbox
             property: "checked"
-            value: !UM.ActiveTool.properties.getValue("NonUniformScale")
+            value: !UM.Controller.properties.getValue("NonUniformScale")
         }
     }
 
@@ -181,7 +181,7 @@ Item
             onEditingFinished:
             {
                 var modified_text = text.replace(",", ".") // User convenience. We use dots for decimal values
-                UM.ActiveTool.setProperty("ObjectWidth", modified_text)
+                UM.Controller.setProperty("ObjectWidth", modified_text)
             }
             Keys.onBacktabPressed: selectTextInTextfield(yPercentage)
             Keys.onTabPressed: selectTextInTextfield(xPercentage)
@@ -203,7 +203,7 @@ Item
             onEditingFinished:
             {
                 var modified_text = text.replace(",", ".") // User convenience. We use dots for decimal values
-                UM.ActiveTool.setProperty("ObjectDepth", modified_text)
+                UM.Controller.setProperty("ObjectDepth", modified_text)
             }
             Keys.onBacktabPressed: selectTextInTextfield(xPercentage)
             Keys.onTabPressed: selectTextInTextfield(zPercentage)
@@ -225,7 +225,7 @@ Item
             onEditingFinished:
             {
                 var modified_text = text.replace(",", ".") // User convenience. We use dots for decimal values
-                UM.ActiveTool.setProperty("ObjectHeight", modified_text)
+                UM.Controller.setProperty("ObjectHeight", modified_text)
             }
             Keys.onBacktabPressed: selectTextInTextfield(zPercentage)
             Keys.onTabPressed: selectTextInTextfield(yPercentage)
@@ -252,20 +252,20 @@ Item
 
         function evaluateTextChange(text, lastEnteredValue, valueName, scaleName)
         {
-            var currentModelSize = UM.ActiveTool.properties.getValue(valueName)
+            var currentModelSize = UM.Controller.properties.getValue(valueName)
             var parsedValue = textfields.validateMinimumSize(text, lastEnteredValue, currentModelSize)
-            if (parsedValue > 0 && ! UM.ActiveTool.properties.getValue("NonUniformScale"))
+            if (parsedValue > 0 && ! UM.Controller.properties.getValue("NonUniformScale"))
             {
                 var scale = parsedValue / lastEnteredValue
-                var x = UM.ActiveTool.properties.getValue("ScaleX") * 100
-                var y = UM.ActiveTool.properties.getValue("ScaleY") * 100
-                var z = UM.ActiveTool.properties.getValue("ScaleZ") * 100
+                var x = UM.Controller.properties.getValue("ScaleX") * 100
+                var y = UM.Controller.properties.getValue("ScaleY") * 100
+                var z = UM.Controller.properties.getValue("ScaleZ") * 100
                 var newX = textfields.validateMinimumSize(
-                    (x * scale).toString(), x, UM.ActiveTool.properties.getValue("ObjectWidth"))
+                    (x * scale).toString(), x, UM.Controller.properties.getValue("ObjectWidth"))
                 var newY = textfields.validateMinimumSize(
-                    (y * scale).toString(), y, UM.ActiveTool.properties.getValue("ObjectHeight"))
+                    (y * scale).toString(), y, UM.Controller.properties.getValue("ObjectHeight"))
                 var newZ = textfields.validateMinimumSize(
-                    (z * scale).toString(), z, UM.ActiveTool.properties.getValue("ObjectDepth"))
+                    (z * scale).toString(), z, UM.Controller.properties.getValue("ObjectDepth"))
                 if (newX <= 0 || newY <= 0 || newZ <= 0)
                 {
                     parsedValue = -1
@@ -273,7 +273,7 @@ Item
             }
             if (parsedValue > 0)
             {
-                UM.ActiveTool.setProperty(scaleName, parsedValue / 100)
+                UM.Controller.setProperty(scaleName, parsedValue / 100)
                 lastEnteredValue = parsedValue
             } // 'else' the value is not valid (the object will become too small)
             return lastEnteredValue
@@ -344,42 +344,42 @@ Item
         {
             target: base
             property: "heightText"
-            value: base.roundFloat(UM.ActiveTool.properties.getValue("ObjectHeight"), 4)
+            value: base.roundFloat(UM.Controller.properties.getValue("ObjectHeight"), 4)
         }
 
         Binding
         {
             target: base
             property: "widthText"
-            value: base.roundFloat(UM.ActiveTool.properties.getValue("ObjectWidth"), 4)
+            value: base.roundFloat(UM.Controller.properties.getValue("ObjectWidth"), 4)
         }
 
         Binding
         {
             target: base
             property: "depthText"
-            value:base.roundFloat(UM.ActiveTool.properties.getValue("ObjectDepth"), 4)
+            value:base.roundFloat(UM.Controller.properties.getValue("ObjectDepth"), 4)
         }
 
         Binding
         {
             target: base
             property: "xPercentageText"
-            value: base.roundFloat(100 * UM.ActiveTool.properties.getValue("ScaleX"), 4)
+            value: base.roundFloat(100 * UM.Controller.properties.getValue("ScaleX"), 4)
         }
 
         Binding
         {
             target: base
             property: "yPercentageText"
-            value: base.roundFloat(100 * UM.ActiveTool.properties.getValue("ScaleY"), 4)
+            value: base.roundFloat(100 * UM.Controller.properties.getValue("ScaleY"), 4)
         }
 
         Binding
         {
             target: base
             property: "zPercentageText"
-            value: base.roundFloat(100 * UM.ActiveTool.properties.getValue("ScaleZ"), 4)
+            value: base.roundFloat(100 * UM.Controller.properties.getValue("ScaleZ"), 4)
         }
     }
 }

--- a/plugins/Tools/TranslateTool/TranslateTool.qml
+++ b/plugins/Tools/TranslateTool/TranslateTool.qml
@@ -94,7 +94,7 @@ Item
             onEditingFinished:
             {
                 var modified_text = text.replace(",", ".") // User convenience. We use dots for decimal values
-                UM.ActiveTool.setProperty("X", modified_text)
+                UM.Controller.setProperty("X", modified_text)
             }
             onActiveFocusChanged:
             {
@@ -123,7 +123,7 @@ Item
             onEditingFinished:
             {
                 var modified_text = text.replace(",", ".") // User convenience. We use dots for decimal values
-                UM.ActiveTool.setProperty("Y", modified_text)
+                UM.Controller.setProperty("Y", modified_text)
             }
 
             onActiveFocusChanged:
@@ -152,7 +152,7 @@ Item
             onEditingFinished:
             {
                 var modified_text = text.replace(",", ".") // User convenience. We use dots for decimal values
-                UM.ActiveTool.setProperty("Z", modified_text)
+                UM.Controller.setProperty("Z", modified_text)
             }
 
             onActiveFocusChanged:
@@ -187,7 +187,7 @@ Item
             tristate: true
             nextCheckState: function() {
                 const new_state = checkState !== Qt.Checked;
-                UM.ActiveTool.setProperty("LockPosition", new_state)
+                UM.Controller.setProperty("LockPosition", new_state)
                 return new_state ? Qt.Checked : Qt.Unchecked
             }
 
@@ -202,7 +202,7 @@ Item
             tristate: true
             nextCheckState: function() {
                 const new_state = checkState !== Qt.Checked;
-                UM.ActiveTool.setProperty("AutoDropDown", new_state)
+                UM.Controller.setProperty("AutoDropDown", new_state)
                 return new_state ? Qt.Checked : Qt.Unchecked
             }
 
@@ -210,7 +210,7 @@ Item
         }
 
         function getCheckBoxState(property) {
-            const value = UM.ActiveTool.properties.getValue(property)
+            const value = UM.Controller.properties.getValue(property)
             if (value) {
                 return Qt.Checked
             }
@@ -244,20 +244,20 @@ Item
     {
         target: base
         property: "xText"
-        value: base.roundFloat(UM.ActiveTool.properties.getValue("X"), 4)
+        value: base.roundFloat(UM.Controller.properties.getValue("X"), 4)
     }
 
     Binding
     {
         target: base
         property: "yText"
-        value: base.roundFloat(UM.ActiveTool.properties.getValue("Y"), 4)
+        value: base.roundFloat(UM.Controller.properties.getValue("Y"), 4)
     }
 
     Binding
     {
         target: base
         property: "zText"
-        value:base.roundFloat(UM.ActiveTool.properties.getValue("Z"), 4)
+        value:base.roundFloat(UM.Controller.properties.getValue("Z"), 4)
     }
 }


### PR DESCRIPTION
CURA-7812
Delete and refactor a number of singletons in QML to clean up the code. Document the refactor decisions made in the SDK documentation. 
Deleted: (Deprecated)
QualityManagementModel
MaterialManagementModel
QualityProfilesDropDownMenuModel 
SimpleModeSettingsManager
MachineActionManager
UM.Application 
CustomQualityProfilesDropDownMenuModel

Merged: (also deprecated)
WorkspaceFileHandler (merged with meshfile )
OperationStack (merge with actions)
ActiveTool (merge with Controller)