### PR TITLE
Cura 11511

### DIFF
--- a/UM/Qt/qml/UM/MessageStack.qml
+++ b/UM/Qt/qml/UM/MessageStack.qml
@@ -435,7 +435,7 @@ ListView
 
     add: Transition
     {
-        NumberAnimation { property: "opacity"; from: 0; to: 1; duration: 200; }
+        NumberAnimation { property: "opacity"; from: 0; to: 1; duration: 100; }
     }
 
     displaced: Transition
@@ -445,7 +445,7 @@ ListView
 
     remove: Transition
     {
-        NumberAnimation { property: "opacity"; to: 0; duration: 200; }
+        NumberAnimation { property: "opacity"; to: 0; duration: 100; }
     }
 
 }

--- a/UM/Qt/qml/UM/MessageStack.qml
+++ b/UM/Qt/qml/UM/MessageStack.qml
@@ -76,6 +76,16 @@ ListView
         border.color: UM.Theme.getColor("message_border")
         radius: UM.Theme.getSize("message_radius").width
 
+        MouseArea {
+            anchors.fill: message
+
+            hoverEnabled: true
+            onEntered: {
+                message.opacity= 1;
+                hoverEnabled = false;
+            }
+        }
+
         RowLayout
         {
             id: titleBar


### PR DESCRIPTION
Opacity of message
It seems like root cause is 2 messages getting added and their simulation time overlapping.

I tried making the simulation time smaller and now it works.
Also, added mouse area, if hovered the opacity will become 1 if not already