### PR TITLE
Cura 11617 print manually

### DIFF
--- a/UM/Scene/Iterator/DepthFirstIterator.py
+++ b/UM/Scene/Iterator/DepthFirstIterator.py
@@ -10,7 +10,7 @@ class DepthFirstIterator(Iterator.Iterator):
 
     def _fillStack(self) -> None:
         self._addNodesToStack()
-        self._set_print_order_for_sliceable_nodes()
+        self._setPrintOrderForSliceableNodes()
 
     def _addNodesToStack(self) -> None:
         self._node_stack.append(self._scene_node)

--- a/UM/Scene/Iterator/DepthFirstIterator.py
+++ b/UM/Scene/Iterator/DepthFirstIterator.py
@@ -9,5 +9,16 @@ class DepthFirstIterator(Iterator.Iterator):
         super().__init__(scene_node)
 
     def _fillStack(self) -> None:
+        self._addNodesToStack()
+        self._set_print_order_for_sliceable_nodes()
+
+    def _addNodesToStack(self) -> None:
         self._node_stack.append(self._scene_node)
         self._node_stack.extend(self._scene_node.getAllChildren())
+
+    def _setPrintOrderForSliceableNodes(self) -> None:
+        order_counter = 1
+        for node in self._node_stack:
+            if node.callDecoration("isSliceable"):
+                node.printOrder = order_counter
+                order_counter += 1


### PR DESCRIPTION
Duplicating a model (copy paste or multiply) breaks the ordering logic (print before/after) of UI as all the models generated from the original instance will take the same order index. As a result, you cannot print before/after if you use the multiply function. I added a simple solution to organize the models in the print sequence when copy paste or multiply operation is called when user defined sequence is switched on.

follow up of: https://github.com/Ultimaker/Cura/pull/17893