### PR TITLE
Fix checkbox tooltip

### DIFF
--- a/UM/Qt/qml/UM/CheckBox.qml
+++ b/UM/Qt/qml/UM/CheckBox.qml
@@ -99,7 +99,7 @@ CheckBox
         verticalAlignment: Text.AlignVCenter
         leftPadding: control.indicator.width
     }
-    ToolTip
+    UM.ToolTip
     {
         id: tooltip
         text: ""


### PR DESCRIPTION
Fix tooltip in the checkbox component, previously we were using Qt's "native" tooltop. Swapped it for the UM.ToolTip for consistency with the whole application.

CURA-11697