### PR TITLE
CURA-11904 Fix crash when slicing with first extruder disabled

### DIFF
--- a/UM/Job.py
+++ b/UM/Job.py
@@ -23,7 +23,6 @@ class Job:
         self._running = False   # type: bool
         self._finished = False  # type: bool
         self._result = None     # type: Any
-        self._message = None    # type: Any
         self._error = None      # type: Optional[Exception]
 
     def run(self) -> None:


### PR DESCRIPTION
Following the removal of the get/setMessage methods in the Job class, the StartSliceJob has not been updated and still used them. We now use a specific variable for storing the disabled extruders and properly display them.

CURA-11904
Associated PR https://github.com/Ultimaker/Cura/pull/19076