### PR TITLE
CURA-11984 Fix some models not supporting "align to buildplate"

### DIFF
--- a/UM/View/SelectionPass.py
+++ b/UM/View/SelectionPass.py
@@ -65,7 +65,6 @@ class SelectionPass(RenderPass):
 
         self._mode = SelectionPass.SelectionMode.OBJECTS
         Selection.selectedFaceChanged.connect(self._onSelectedFaceChanged)
-        self._face_mode_max_objects = 1  # Needed when selecting a face for (a) grouped or merged object(s).
 
         self._output = None
 
@@ -124,9 +123,7 @@ class SelectionPass(RenderPass):
 
     def _renderFacesMode(self):
         batch = RenderBatch(self._face_shader)
-        self._face_mode_max_objects = 1
         self._face_shader.setUniformValue("u_modelId", 0)
-        self._face_shader.setUniformValue("u_maxModelId", self._face_mode_max_objects)
         self._face_mode_selection_map = []
 
         selectable_objects = False
@@ -141,7 +138,6 @@ class SelectionPass(RenderPass):
             elif node.hasChildren():
                 # Drill down to see if we're in a group or merged meshes type situation.
                 # This should be OK, as we should get both the mesh-id _and_ face-id from the rendering mesh.
-                self._face_mode_max_objects = sum([1 if (node.isSelectable() and node.getMeshData()) else 0 for node in node.getChildren()])
                 current_model_id = 0
                 node_list = [node]
                 while len(node_list) > 0:
@@ -151,7 +147,7 @@ class SelectionPass(RenderPass):
                             batch.addItem(
                                 transformation = node.getWorldTransformation(copy = False),
                                 mesh = node.getMeshData(),
-                                uniforms = {"model_id": current_model_id, "max_model_id": self._face_mode_max_objects},
+                                uniforms = {"model_id": current_model_id},
                                 normal_transformation = node.getCachedNormalMatrix())
                             self._face_mode_selection_map.append(node)
                             current_model_id += 1
@@ -196,13 +192,12 @@ class SelectionPass(RenderPass):
         if px < 0 or px > (output.width() - 1) or py < 0 or py > (output.height() - 1):
             return None
 
-        blue_channel = int(Color.fromARGB(output.pixel(px, py)).b * 255.)
-        if blue_channel % 2 == 0:  # check signal (any selected object here) bit
+        alpha_channel = int(Color.fromARGB(output.pixel(px, py)).a * 255.)
+        if alpha_channel == 0:  # check if there is any selected object here
             return None
 
-        max_objects_mask = int(math.pow(2, int(math.ceil(math.log2(self._face_mode_max_objects))) + 1)) - 1
-        index = (blue_channel & max_objects_mask) >> 1
-        if 0 <= index < len(self._face_mode_selection_map):
+        index = 255 - alpha_channel
+        if index < len(self._face_mode_selection_map):
             return self._face_mode_selection_map[index]
         else:
             return None
@@ -220,14 +215,13 @@ class SelectionPass(RenderPass):
             return -1
 
         face_color = Color.fromARGB(output.pixel(px, py))
-        if int(face_color.b * 255) % 2 == 0:
+        if int(face_color.a * 255) == 0:
             return -1
 
-        max_objects_adjusted = int(math.ceil(math.log2(self._face_mode_max_objects))) + 1
         return (
-            ((int(face_color.b * 255.) >> max_objects_adjusted) << 15) |
-            (int(face_color.g * 255.) << 8) |
-            int(face_color.r * 255.)
+            ((int(face_color.b * 255.) << 16) & 0xff0000) |
+            ((int(face_color.g * 255.) << 8) & 0x00ff00) |
+            (int(face_color.r * 255.) & 0x0000ff)
         )
 
     def _getNodeColor(self, node):

--- a/resources/shaders/select_face.shader
+++ b/resources/shaders/select_face.shader
@@ -15,7 +15,6 @@ vertex =
 
 fragment =
     // NOTE: These legacy shaders are compiled, but not used. Select-by-face isn't possible in legacy-render-mode.
-    uniform highp int u_maxModelId;  // So the output can still be up to ~8M faces for an ungrouped object.
 
     void main()
     {
@@ -46,23 +45,16 @@ vertex41core =
 fragment41core =
     #version 410
 
-    uniform highp int u_maxModelId;  // So the output can still be up to ~8M faces for an ungrouped object.
     flat in highp int v_modelId;
 
     out vec4 frag_color;
 
     void main()
     {
-        int max_model_adjusted = int(exp2(int(ceil(log2(u_maxModelId))) + 1));
-        int blue_part_face_id = (gl_PrimitiveID / 0x10000) % 0x80;
-
-        frag_color = vec4(0., 0., 0., 1.);
-        frag_color.r = (gl_PrimitiveID % 0x100) / 255.;
-        frag_color.g = ((gl_PrimitiveID / 0x100) % 0x100) / 255.;
-        frag_color.b = (0x1 + 2 * v_modelId + max_model_adjusted * blue_part_face_id) / 255.;
-
-        // Don't use alpha for anything, as some faces may be behind others, an only the front one's value is desired.
-        // There isn't any control over the background color, so a signal-bit is put into the blue byte.
+        frag_color.r = (gl_PrimitiveID & 0xff) / 255.;
+        frag_color.g = ((gl_PrimitiveID >> 8) & 0xff) / 255.;
+        frag_color.b = ((gl_PrimitiveID >> 16) & 0xff) / 255.;
+        frag_color.a = (255 - v_modelId) / 255.; // Invert to ease visualization in images, and so that 0 means no object
     }
 
 [defaults]
@@ -72,7 +64,6 @@ u_modelMatrix = model_matrix
 u_viewMatrix = view_matrix
 u_projectionMatrix = projection_matrix
 u_modelId = model_id
-u_maxModelId = max_model_id
 
 [attributes]
 a_vertex = vertex


### PR DESCRIPTION
Instead of using a dynamic number of bits for the face index, store the object ID in the alpha channel, which was previously unused. This way we have the full 24 bits of the RGB channels to store the face index.

OpenGL blending is disabled for this pass, so the alpha channel is just stored as an extra channel but no calculation is performed based on it.

CURA-11984