### PR TITLE
CURA-12009 add setting depends on

### DIFF
--- a/UM/Settings/DefinitionContainer.py
+++ b/UM/Settings/DefinitionContainer.py
@@ -548,10 +548,17 @@ class DefinitionContainer(QObject, DefinitionContainerInterface, PluginObject):
         except AttributeError:
             return
 
-        if not isinstance(function, SettingFunction):
-            return
+        settings_dependencies = set()
 
-        for setting in function.getUsedSettingKeys():
+        if isinstance(function, SettingFunction):
+            settings_dependencies.update(function.getUsedSettingKeys())
+
+        try:
+            settings_dependencies.update(definition.depends_on_settings)
+        except AttributeError:
+            pass
+
+        for setting in settings_dependencies:
             # Prevent circular relations between the same setting and the same property
             # Note that the only property used by SettingFunction is the "value" property, which
             # is why this is hard coded here.

--- a/UM/Settings/SettingDefinition.py
+++ b/UM/Settings/SettingDefinition.py
@@ -760,6 +760,8 @@ class SettingDefinition:
         "warning_value": {"type": DefinitionPropertyType.Function, "required": False, "read_only": True, "default": None, "depends_on": None},
         # For bool type: if the value is the same as the error value, the setting will be in the error state.
         "error_value": {"type": DefinitionPropertyType.Function, "required": False, "read_only": True, "default": None, "depends_on": None},
+        # Optional list of settings that a setting explicitely depends on, which is useful when this can not be fully calculated from the formula.
+        "depends_on_settings": {"type": DefinitionPropertyType.Any, "required": False, "read_only": True, "default": [], "depends_on": None},
     }   # type: Dict[str, Dict[str, Any]]
 
     __type_definitions = {


### PR DESCRIPTION
This is a workaround for a case where it is not possible to know in advance what settings a setting depends on, e.g. if the function is overridden by a material profile. This way we can explicitely specify an extra list of dependencies. 