### PR TITLE
[CURA-12050] For cross-stack relations, signal changed properties globally.

### DIFF
--- a/UM/Settings/DefinitionContainer.py
+++ b/UM/Settings/DefinitionContainer.py
@@ -554,7 +554,7 @@ class DefinitionContainer(QObject, DefinitionContainerInterface, PluginObject):
             settings_dependencies.update(function.getUsedSettingKeys())
 
         try:
-            settings_dependencies.update(definition.depends_on_settings)
+            settings_dependencies.update(definition.force_depends_on_settings)
         except AttributeError:
             pass
 

--- a/UM/Settings/SettingDefinition.py
+++ b/UM/Settings/SettingDefinition.py
@@ -761,7 +761,7 @@ class SettingDefinition:
         # For bool type: if the value is the same as the error value, the setting will be in the error state.
         "error_value": {"type": DefinitionPropertyType.Function, "required": False, "read_only": True, "default": None, "depends_on": None},
         # Optional list of settings that a setting explicitely depends on, which is useful when this can not be fully calculated from the formula.
-        "depends_on_settings": {"type": DefinitionPropertyType.Any, "required": False, "read_only": True, "default": [], "depends_on": None},
+        "force_depends_on_settings": {"type": DefinitionPropertyType.Any, "required": False, "read_only": True, "default": [], "depends_on": None},
     }   # type: Dict[str, Dict[str, Any]]
 
     __type_definitions = {

--- a/examples/definition_query/query.py
+++ b/examples/definition_query/query.py
@@ -28,6 +28,7 @@ SettingDefinition.addSupportedProperty("settable_per_mesh", DefinitionPropertyTy
 SettingDefinition.addSupportedProperty("settable_per_extruder", DefinitionPropertyType.Any, default = True, read_only = True)
 SettingDefinition.addSupportedProperty("settable_per_meshgroup", DefinitionPropertyType.Any, default = True, read_only = True)
 SettingDefinition.addSupportedProperty("settable_globally", DefinitionPropertyType.Any, default = True, read_only = True)
+SettingDefinition.addSupportedProperty("force_depends_on_settings", DefinitionPropertyType.Any, default = [], read_only = True)
 SettingDefinition.addSupportedProperty("limit_to_extruder", DefinitionPropertyType.Function, default = "-1")
 SettingDefinition.addSupportedProperty("resolve", DefinitionPropertyType.Function, default = None)
 SettingDefinition.addSettingType("extruder", None, str, Validator)


### PR DESCRIPTION
If a setting depends on a setting that is somehow in another stack (or another part of the global tree), as signalled by 'force_depends_on_settings' (renamed from 'depends_on_settings', as that'd imply you should _always_ add it), use the global container stack instead of the 'local' one (which'd only contain the setting-instances for that stack, not the actual relation _should_ it reside in another part of the currently active machine containers).

This can happen for instance in a dependee like Cura, which has machines with different extruders, and if a setting is locked to an extruder with 'limit_to_extruder', a setting using a formula using such a setting should be updated from what may potentially be the an other extruders' stack.