### PR TITLE
[CURA-12067] The json-decorator-scope didn't set the user-agent yet.

### DIFF
--- a/UM/TaskManagement/HttpRequestScope.py
+++ b/UM/TaskManagement/HttpRequestScope.py
@@ -51,6 +51,10 @@ class JsonDecoratorScope(HttpRequestScope):
             "Content-Type": "application/json",
             "Accept": "application/json"
         }
+        # JsonDecorator probably _should_ have inherited from DefaultUserAgentScope in the first place.
+        # In order to prevent a break in the API by forcing that, just check if there are extra header specs needed.
+        if hasattr(self.base, "header_dict"):
+            self.header_dict.update(self.base.header_dict)
 
     def requestHook(self, request: QNetworkRequest) -> None:
         # not calling super().request_hook() because base will do that.


### PR DESCRIPTION
Add the header-dictionaries from base (which should've got the User-Agent set, at the very least in case we wrap around something that inherits from DefaultUserAgentScope, which is the only use-case I encountered) with the json-specific settings that are already in there. In order to prevent breaking the API, don't directly change the inheritance of the JsonDecoratorScope, but instead check for the existence of the header-dict in the base.

