### PR TITLE
[CURA-12067] Unless scope is overridden, always send a user-agent with HTTP(S) get/put.

### DIFF
--- a/UM/TaskManagement/HttpRequestManager.py
+++ b/UM/TaskManagement/HttpRequestManager.py
@@ -286,8 +286,11 @@ class HttpRequestManager(TaskManager):
             for key, value in headers_dict.items():
                 request.setRawHeader(key.encode("utf-8"), value.encode("utf-8"))
 
-        if scope is not None:
-            scope.requestHook(request)
+        if scope is None:
+            from UM.TaskManagement.HttpRequestScope import DefaultUserAgentScope
+            from UM.Application import Application
+            scope = DefaultUserAgentScope(Application.getInstance())
+        scope.requestHook(request)
 
         # Generate a unique request ID
         request_id = uuid.uuid4().hex


### PR DESCRIPTION
Now we can't forget to do that anymore -- previously we could, since a 'None' 'scope' would just not make headers, so each time we didn't set a scope (which we don't have to, since it's an optional parameter) no user-agent would get sent.

