### PR TITLE
Fix removing watching for file modifications

### DIFF
--- a/UM/Mesh/MeshData.py
+++ b/UM/Mesh/MeshData.py
@@ -49,7 +49,6 @@ class MeshData:
 
     def __init__(self, vertices=None, normals=None, indices=None, colors=None, uvs=None, file_name=None,
                  center_position=None, zero_position=None, type = MeshType.faces, attributes=None) -> None:
-        self._application = None  # Initialize this later otherwise unit tests break
 
         self._vertices = NumPyUtil.immutableNDArray(vertices)
         self._normals = NumPyUtil.immutableNDArray(normals)
@@ -81,16 +80,6 @@ class MeshData:
                     else:
                         new_value[attribute_key] = attribute_value
                 self._attributes[key] = new_value
-
-    def __del__(self):
-        """Triggered when this file is deleted.
-
-        The file will then no longer be watched for changes.
-        """
-
-        if self._file_name:
-            if self._application:
-                self._application.getController().getScene().removeWatchedFile(self._file_name)
 
     def set(self, vertices=Reuse, normals=Reuse, indices=Reuse, colors=Reuse, uvs=Reuse, file_name=Reuse,
             center_position=Reuse, zero_position=Reuse, attributes=Reuse) -> "MeshData":

--- a/UM/Mesh/MeshReader.py
+++ b/UM/Mesh/MeshReader.py
@@ -3,7 +3,6 @@
 
 from typing import Union, List
 
-import UM.Application
 from UM.FileHandler.FileReader import FileReader
 from UM.FileHandler.FileHandler import resolveAnySymlink
 from UM.Logger import Logger
@@ -24,7 +23,6 @@ class MeshReader(FileReader):
 
         file_name = resolveAnySymlink(file_name)
         result = self._read(file_name)
-        UM.Application.Application.getInstance().getController().getScene().addWatchedFile(file_name)
 
         # The mesh reader may set a MIME type itself if it knows a more specific MIME type than just going by extension.
         # If not, automatically generate one from our MIME type database, going by the file extension.

--- a/UM/Scene/SceneNode.py
+++ b/UM/Scene/SceneNode.py
@@ -429,7 +429,10 @@ class SceneNode:
         self.meshDataChanged.emit(self)
 
     meshDataChanged = Signal()
-    """Emitted whenever the attached mesh data object changes."""
+    """Emitted whenever the attached mesh data object changes.
+
+    :param object: The SceneNode that had the changed mesh data object.
+    """
 
     def _onMeshDataChanged(self) -> None:
         self.meshDataChanged.emit(self)
@@ -517,7 +520,7 @@ class SceneNode:
     childrenChanged = Signal()
     """Emitted whenever the list of children of this object or any child object changes.
 
-    :param object: The object that triggered the change.
+    :param object: The SceneNode that triggered the change.
     """
 
     def _updateCachedNormalMatrix(self) -> None:
@@ -716,7 +719,8 @@ class SceneNode:
 
     transformationChanged = Signal()
     """Signal. Emitted whenever the transformation of this object or any child object changes.
-    :param object: The object that caused the change.
+
+    :param object: The SceneNode that triggered the change.
     """
 
     def lookAt(self, target: Vector, up: Vector = Vector.Unit_Y) -> None:


### PR DESCRIPTION
# Description

This depends on (and contains the commits) for pull request Ultimaker/Urandium#964.

If the file is no longer part of the scene graph no longer watch it
for file modifications.  This had been triggered from MeshData when it
was deleted, but _application was no longer populated so it was not
being called.

_application could be replaced by querying the current instance.
```
from UM.Application import Application
Application.getInstance().getController().getScene().removeWatchedFile(self._file_name)
```

The problem with calling removeWatchedFile from MeshData __del__, is
Cura 5.8.1 is creating three MeshData objects with the file name
populated, when the file is loaded, two are deleted, the last stays
around.  If it were to call from the first two objects being deleted,
it would remove the watch even though it is loaded as part of the
scene.  Further I'm seeing that the last object isn't getting deleted,
even when it is removed from the scene graph.  I don't know if this is
a memory leak or if there would still be an issue with undo/redo.

Instead listen for the scene graph meshDataChanged signal, collect the
files in the scene graph and add or remove based on that list.  This
does not listen to sceneChanged signal as that includes transform
changes, which won't change the set of files listened for.


<!-- Please include a summary of which issue is fixed or feature was added. Please also include relevant motivation and context. 
If this pull request adds settings definitions for machines/materials, list them here. 

This fixes... OR This improves... -->

## Type of change

<!-- Please delete options that are not relevant. -->

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [X] Tested with multiple models loaded, being deleted, undo/redo, and added debugging to print the list of files that are watched for in _updateWatchedFiles, to verify they match the file list and what is loaded in the scene graph.

**Test Configuration**:
* Operating System: Debian Linux

# Checklist:
<!-- Check if relevant -->

- [X] My code follows the style guidelines of this project as described in [UltiMaker Meta](https://github.com/Ultimaker/Meta) and [Cura QML best practices](https://github.com/Ultimaker/Cura/wiki/QML-Best-Practices)
- [X] I have read the [Contribution guide](https://github.com/Ultimaker/Cura/blob/main/CONTRIBUTING.md) 
- [X] I have commented my code, particularly in hard-to-understand areas