### PR TITLE
[CURA-11761] Cache results of class-member methods

### DIFF
--- a/UM/Decorators.py
+++ b/UM/Decorators.py
@@ -142,19 +142,24 @@ def timeit(method):
 
 
 class CachedMemberFunctions:
+    """Helper class to handle instance-cache w.r.t. results of member-functions decorated with '@cachePerInstance'."""
+
     __cache = {}
 
     @classmethod
     def clearInstanceCache(cls, instance):
+        """Clear all the cache-entries for the specified instance."""
         cls.__cache[instance] = {}
 
     @classmethod
     def deleteInstanceCache(cls, instance):
+        """Completely delete the entry of the specified instance."""
         if instance in cls.__cache:
             del cls.__cache[instance]
 
     @classmethod
     def callMemberFunction(cls, instance, function, *args, **kwargs):
+        """Call the specified member function, make use of (results) cache if available, and create if not."""
         if kwargs is not None and len(kwargs) > 0:
             # NOTE The `lru_cache` can't handle keyword-arguments (because it's a dict).
             # We could make a frozendict, but that's probably a lot more hassle than it's worth, so just call normally.

--- a/UM/Decorators.py
+++ b/UM/Decorators.py
@@ -154,6 +154,10 @@ class CachedMemberFunctions:
     def clearInstanceCache(cls, instance):
         cls.getInstance()._cache[instance] = {}
 
+    @classmethod
+    def deleteInstanceCache(cls, instance):
+        del cls.getInstance()._cache[instance]
+
     def __init__(self):
         if CachedMemberFunctions.__instance is not None:
             raise RuntimeError(f"Attempt to instantiate singleton '{self.__class__.__name__}' more than once.")

--- a/UM/Decorators.py
+++ b/UM/Decorators.py
@@ -156,7 +156,8 @@ class CachedMemberFunctions:
 
     @classmethod
     def deleteInstanceCache(cls, instance):
-        del cls.getInstance()._cache[instance]
+        if instance in cls.getInstance()._cache:
+            del cls.getInstance()._cache[instance]
 
     def __init__(self):
         if CachedMemberFunctions.__instance is not None:

--- a/UM/Settings/ContainerStack.py
+++ b/UM/Settings/ContainerStack.py
@@ -409,7 +409,6 @@ class ContainerStack(QObject, ContainerInterface, PluginObject):
             Logger.log("d", "Could not get version from serialized: %s", e)
         return version
 
-    @cachePerInstance
     def deserialize(self, serialized: str, file_name: Optional[str] = None) -> str:
         """:copydoc ContainerInterface::deserialize
 
@@ -417,6 +416,8 @@ class ContainerStack(QObject, ContainerInterface, PluginObject):
 
         TODO: Expand documentation here, include the fact that this should _not_ include all containers
         """
+
+        CachedMemberFunctions.clearInstanceCache(self)
 
         # Update the serialized data first
         serialized = super().deserialize(serialized, file_name)
@@ -839,6 +840,8 @@ class ContainerStack(QObject, ContainerInterface, PluginObject):
     # In addition, it allows us to emit a single signal that reports all properties that
     # have changed.
     def _collectPropertyChanges(self, key: str, property_name: str) -> None:
+        CachedMemberFunctions.clearInstanceCache(self)
+
         if key not in self._property_changes:
             self._property_changes[key] = set()
 

--- a/UM/Settings/ContainerStack.py
+++ b/UM/Settings/ContainerStack.py
@@ -867,6 +867,11 @@ class ContainerStack(QObject, ContainerInterface, PluginObject):
     def __repr__(self) -> str:
         return str(self)
 
+    def __del__(self) -> None:
+        # None of the 'parents' seem to have __dell__, so OK not to call `super.del` here.
+        CachedMemberFunctions.deleteInstanceCache(self)
+
+
 _containerRegistry = ContainerRegistryInterface()  # type: ContainerRegistryInterface
 
 

--- a/UM/Settings/ContainerStack.py
+++ b/UM/Settings/ContainerStack.py
@@ -872,7 +872,7 @@ class ContainerStack(QObject, ContainerInterface, PluginObject):
         return str(self)
 
     def __del__(self) -> None:
-        # None of the 'parents' seem to have __dell__, so OK not to call `super.del` here.
+        # None of the 'parents' seem to have __del__, so OK not to call `super.del` here.
         CachedMemberFunctions.deleteInstanceCache(self)
 
 

--- a/UM/Settings/ContainerStack.py
+++ b/UM/Settings/ContainerStack.py
@@ -194,6 +194,7 @@ class ContainerStack(QObject, ContainerInterface, PluginObject):
 
         return value
 
+    # Note that '_getRawMetaDataEntry' is cached, not this one, because default may be a list and that's unhashable.
     def getMetaDataEntry(self, entry: str, default: Any = None) -> Any:
         """:copydoc ContainerInterface::getMetaDataEntry
 

--- a/UM/Settings/InstanceContainer.py
+++ b/UM/Settings/InstanceContainer.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2022 Ultimaker B.V.
+# Copyright (c) 2024 UltiMaker
 # Uranium is released under the terms of the LGPLv3 or higher.
 
 import configparser

--- a/UM/Settings/InstanceContainer.py
+++ b/UM/Settings/InstanceContainer.py
@@ -10,6 +10,7 @@ from typing import Any, cast, Dict, List, Optional, Set, Tuple
 from PyQt6.QtCore import QObject, pyqtProperty, pyqtSignal
 from PyQt6.QtQml import QQmlEngine #To take ownership of this class ourselves.
 
+from UM.Decorators import CachedMemberFunctions, cachePerInstance
 from UM.FastConfigParser import FastConfigParser
 from UM.Trust import Trust
 from UM.Decorators import override
@@ -143,6 +144,7 @@ class InstanceContainer(QObject, ContainerInterface, PluginObject):
     def __setstate__(self, state: Dict[str, Any]) -> None:
         """For pickle support"""
 
+        CachedMemberFunctions.clearInstanceCache(self)
         self.__dict__.update(state)
 
     @classmethod
@@ -178,6 +180,7 @@ class InstanceContainer(QObject, ContainerInterface, PluginObject):
 
     def setCachedValues(self, cached_values: Dict[str, Any]) -> None:
         if not self._instances:
+            CachedMemberFunctions.clearInstanceCache(self)
             self._cached_values = cached_values
         else:
             Logger.log("w", "Unable set values to be lazy loaded when values are already loaded ")
@@ -200,6 +203,7 @@ class InstanceContainer(QObject, ContainerInterface, PluginObject):
         Reimplemented from ContainerInterface
         """
 
+        CachedMemberFunctions.clearInstanceCache(self)
         self._path = path
 
     def getName(self) -> str:
@@ -212,6 +216,7 @@ class InstanceContainer(QObject, ContainerInterface, PluginObject):
 
     def setName(self, name: str) -> None:
         if name != self.getName():
+            CachedMemberFunctions.clearInstanceCache(self)
             self._metadata["name"] = name
             self._dirty = True
             self.nameChanged.emit()
@@ -251,6 +256,7 @@ class InstanceContainer(QObject, ContainerInterface, PluginObject):
         if metadata == self._metadata:
             return #No need to do anything or even emit the signal.
 
+        CachedMemberFunctions.clearInstanceCache(self)
         #We'll fill a temporary dictionary with all the required metadata and overwrite it with the new metadata.
         #This way it is ensured that at least the required metadata is still there.
         self._metadata = {
@@ -285,6 +291,7 @@ class InstanceContainer(QObject, ContainerInterface, PluginObject):
         """
 
         if key not in self._metadata or self._metadata[key] != value:
+            CachedMemberFunctions.clearInstanceCache(self)
             self._metadata[key] = value
             self._dirty = True
             self.metaDataChanged.emit(self)
@@ -298,8 +305,10 @@ class InstanceContainer(QObject, ContainerInterface, PluginObject):
         if self._read_only:
             Logger.log("w", "Tried to set dirty on read-only object.")
         else:
+            CachedMemberFunctions.clearInstanceCache(self)
             self._dirty = dirty
 
+    @cachePerInstance
     def getProperty(self, key: str, property_name: str, context: PropertyEvaluationContext = None) -> Any:
         """:copydoc ContainerInterface::getProperty
 
@@ -318,6 +327,7 @@ class InstanceContainer(QObject, ContainerInterface, PluginObject):
 
         return None
 
+    @cachePerInstance
     def hasProperty(self, key: str, property_name: str) -> bool:
         """:copydoc ContainerInterface::hasProperty
 
@@ -345,6 +355,8 @@ class InstanceContainer(QObject, ContainerInterface, PluginObject):
 
         if not self._cached_values:
             return
+
+        CachedMemberFunctions.clearInstanceCache(self)
 
         for key, value in self._cached_values.items():
             if key not in self._instances:
@@ -387,6 +399,8 @@ class InstanceContainer(QObject, ContainerInterface, PluginObject):
                     property_name, property_value, key, self.id))
             return
 
+        CachedMemberFunctions.clearInstanceCache(self)
+
         if key not in self._instances:
             try:
                 definition = self.getDefinition()
@@ -414,12 +428,14 @@ class InstanceContainer(QObject, ContainerInterface, PluginObject):
     def clear(self) -> None:
         """Remove all instances from this container."""
 
+        CachedMemberFunctions.clearInstanceCache(self)
         self._instantiateCachedValues()
         all_keys = self._instances.copy()
         for key in all_keys:
             self.removeInstance(key, postpone_emit=True)
         self.sendPostponedEmits()
 
+    @cachePerInstance
     def getAllKeys(self) -> Set[str]:
         """Get all the keys of the instances of this container
         :returns: list of keys
@@ -588,6 +604,8 @@ class InstanceContainer(QObject, ContainerInterface, PluginObject):
         Reimplemented from ContainerInterface
         """
 
+        CachedMemberFunctions.clearInstanceCache(self)
+
         # update the serialized data first
         serialized = super().deserialize(serialized, file_name)
         parser = self._readAndValidateSerialized(serialized)
@@ -656,6 +674,7 @@ class InstanceContainer(QObject, ContainerInterface, PluginObject):
         """Instance containers are lazy loaded. This function ensures that it happened."""
         if not self._cached_values:
             return
+        CachedMemberFunctions.clearInstanceCache(self)
         definition = self.getDefinition()
         try:
             for key, value in self._cached_values.items():
@@ -665,6 +684,7 @@ class InstanceContainer(QObject, ContainerInterface, PluginObject):
 
         self._cached_values = None
 
+    # TODO: Deal with cacheing kwargs type arguments, as that is passed as an 'unhashable' dict.
     def findInstances(self, **kwargs: Any) -> List[SettingInstance]:
         """Find instances matching certain criteria.
 
@@ -682,6 +702,7 @@ class InstanceContainer(QObject, ContainerInterface, PluginObject):
 
         return result
 
+    @cachePerInstance
     def getInstance(self, key: str) -> Optional[SettingInstance]:
         """Get an instance by key"""
 
@@ -699,6 +720,8 @@ class InstanceContainer(QObject, ContainerInterface, PluginObject):
         if key in self._instances:
             return
 
+        CachedMemberFunctions.clearInstanceCache(self)
+
         instance.propertyChanged.connect(self.propertyChanged)
         instance.propertyChanged.emit(key, "value")
         self._instances[key] = instance
@@ -712,6 +735,8 @@ class InstanceContainer(QObject, ContainerInterface, PluginObject):
         self._instantiateCachedValues()
         if key not in self._instances:
             return
+
+        CachedMemberFunctions.clearInstanceCache(self)
 
         instance = self._instances[key]
         del self._instances[key]
@@ -739,6 +764,8 @@ class InstanceContainer(QObject, ContainerInterface, PluginObject):
     def update(self) -> None:
         """Update all instances from this container."""
 
+        CachedMemberFunctions.clearInstanceCache(self)
+
         self._instantiateCachedValues()
         for key, instance in self._instances.items():
             instance.propertyChanged.emit(key, "value")
@@ -749,6 +776,7 @@ class InstanceContainer(QObject, ContainerInterface, PluginObject):
                     self.propertyChanged.emit(key, property_name)
         self._dirty = True
 
+    @cachePerInstance
     def getDefinition(self) -> DefinitionContainerInterface:
         """Get the DefinitionContainer used for new instance creation."""
 
@@ -766,6 +794,7 @@ class InstanceContainer(QObject, ContainerInterface, PluginObject):
         way of figuring out what SettingDefinition to use when creating a new SettingInstance.
         """
 
+        CachedMemberFunctions.clearInstanceCache(self)
         self._metadata["definition"] = definition_id
         self._definition = None
 
@@ -798,6 +827,7 @@ class InstanceContainer(QObject, ContainerInterface, PluginObject):
             signal, signal_arg = self._postponed_emits.pop(0)
             signal.emit(*signal_arg)
             
+    @cachePerInstance
     def getAllKeysWithUserState(self)-> Set[str]:
         """Get the keys of all the setting having a User state"""
         self._instantiateCachedValues()

--- a/UM/Settings/InstanceContainer.py
+++ b/UM/Settings/InstanceContainer.py
@@ -816,6 +816,10 @@ class InstanceContainer(QObject, ContainerInterface, PluginObject):
     def __repr__(self) -> str:
         return str(self)
 
+    def __del__(self) -> None:
+        # None of the 'parents' seem to have __del__, so OK not to call `super.del` here.
+        CachedMemberFunctions.deleteInstanceCache(self)
+
     def sendPostponedEmits(self) -> None:
         """Send the postponed emits
 

--- a/UM/Settings/Models/SettingPropertyProvider.py
+++ b/UM/Settings/Models/SettingPropertyProvider.py
@@ -470,3 +470,7 @@ class SettingPropertyProvider(QObject):
             return options_map
 
         return str(property_value)
+
+    def __del__(self) -> None:
+        # None of the 'parents' seem to have __del__, so OK not to call `super.del` here.
+        CachedMemberFunctions.deleteInstanceCache(self)

--- a/UM/Settings/SettingDefinition.py
+++ b/UM/Settings/SettingDefinition.py
@@ -189,6 +189,10 @@ class SettingDefinition:
         if not hasattr(self, "_all_keys"):
             self._all_keys = set()
 
+    def __del__(self) -> None:
+        # None of the 'parents' seem to have __del__, so OK not to call `super.del` here.
+        CachedMemberFunctions.deleteInstanceCache(self)
+
     @property
     def key(self) -> str:
         """The key of this setting.

--- a/UM/Settings/SettingInstance.py
+++ b/UM/Settings/SettingInstance.py
@@ -157,6 +157,10 @@ class SettingInstance:
 
         raise AttributeError("'SettingInstance' object has no attribute '{0}'".format(name))
 
+    def __del__(self) -> None:
+        # None of the 'parents' seem to have __del__, so OK not to call `super.del` here.
+        CachedMemberFunctions.deleteInstanceCache(self)
+
     @call_if_enabled(_traceSetProperty, _isTraceEnabled())
     def setProperty(self, name: str, value: Any, container: Optional[ContainerInterface] = None, emit_signals: bool = True) -> None:
         if SettingDefinition.hasProperty(name):

--- a/UM/Settings/SettingInstance.py
+++ b/UM/Settings/SettingInstance.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2018 Ultimaker B.V.
+# Copyright (c) 2024 UltiMaker
 # Uranium is released under the terms of the LGPLv3 or higher.
 
 import copy #To implement deepcopy.

--- a/tests/Settings/TestContainerStack.py
+++ b/tests/Settings/TestContainerStack.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2018 Ultimaker B.V.
+# Copyright (c) 2024 UltiMaker
 # Uranium is released under the terms of the LGPLv3 or higher.
 
 from typing import Optional

--- a/tests/Settings/TestContainerStack.py
+++ b/tests/Settings/TestContainerStack.py
@@ -8,6 +8,7 @@ from unittest.mock import MagicMock
 
 import pytest
 
+from UM.Decorators import CachedMemberFunctions
 from UM.Settings.ContainerRegistry import ContainerRegistry
 from UM.Settings.ContainerStack import ContainerStack
 from UM.Settings.ContainerStack import IncorrectVersionError
@@ -814,6 +815,9 @@ def test_getHasErrors(container_stack):
 
     # We won't get any wrong validation states, so it shouldn't have errors.
     assert not container_stack.hasErrors()
+
+    # Clear the cache (so 'hasErrors' recalculates, as from the perspective of the container-stack, it hasn't changed).
+    CachedMemberFunctions.clearInstanceCache(container_stack)
 
     # Fake the property so it does return validation state
     container_stack.getProperty = MagicMock(return_value = ValidatorState.MaximumError)

--- a/tests/Settings/conftest.py
+++ b/tests/Settings/conftest.py
@@ -50,6 +50,9 @@ def container_registry(application, test_containers_provider, plugin_registry: P
         )
     )
 
+    if ContainerRegistry._ContainerRegistry__instance is not None and ContainerRegistry._ContainerRegistry__instance._db_connection is not None:
+        ContainerRegistry._ContainerRegistry__instance._db_connection.close()
+        ContainerRegistry._ContainerRegistry__instance._db_connection = None
     ContainerRegistry._ContainerRegistry__instance = None # Reset the private instance variable every time
     registry = ContainerRegistry(application)
 


### PR DESCRIPTION
Be able to cache results from member-functions of classes (as well as just plain using `lru_cache` for class- and static- methods) and use that to cache a lot of the results from the Container/Settings stacks.

Depending on the situation (such as with a printer with multiple extruders in Cura for example) -- this can speed up the interface quite noticibly.

(There's also a small PR in the front-end to make extra sure that objects inheriting from the cached classes play fair. -- )