### PR TITLE
Handle message too big error when sending model data to engine

### DIFF
--- a/UM/Backend/Backend.py
+++ b/UM/Backend/Backend.py
@@ -263,6 +263,9 @@ class Backend(PluginObject):
         elif error.getErrorCode() == Arcus.ErrorCode.Debug:
             Logger.log("d", "Socket debug: %s", str(error))
             return
+        elif error.getErrorCode() == Arcus.ErrorCode.MessageTooBigError:
+            Logger.log("w", "Message was too big to be sent", str(error))
+            return
         else:
             Logger.log("w", "Unhandled socket error %s", str(error.getErrorCode()))
 

--- a/conandata.yml
+++ b/conandata.yml
@@ -1,3 +1,3 @@
 version: "5.9.0-alpha.0"
 requirements:
-  - "pyarcus/5.3.1"
+  - "pyarcus/5.4.1"


### PR DESCRIPTION
The 'message too big' error is just logged by the Backend, and the actual handling is done in the `CuraEngineBackend` child class.

CURA-11103