### PR TITLE
CURA-12138 export for support option

### DIFF
--- a/UM/FileHandler/WriteFileJob.py
+++ b/UM/FileHandler/WriteFileJob.py
@@ -10,7 +10,7 @@ from UM.Message import Message
 import io
 import time
 
-from typing import Any, Optional, Union
+from typing import Any, Optional, Union, Dict
 
 
 class WriteFileJob(Job):
@@ -19,7 +19,7 @@ class WriteFileJob(Job):
     The writer defines what the result of this job is.
     """
 
-    def __init__(self, writer: Optional[FileWriter], stream: Union[io.BytesIO, io.StringIO], data: Any, mode: int) -> None:
+    def __init__(self, writer: Optional[FileWriter], stream: Union[io.BytesIO, io.StringIO], data: Any, mode: int, writer_args: dict = {}) -> None:
         """Creates a new job for writing.
 
         :param writer: The file writer to use, with the correct MIME type.
@@ -37,6 +37,7 @@ class WriteFileJob(Job):
         self._mode = mode
         self._add_to_recent_files = False  # If this file should be added to the "recent files" list upon success
         self._message = None  # type: Optional[Message]
+        self._writer_args = writer_args
         self.progress.connect(self._onProgress)
         self.finished.connect(self._onFinished)
 
@@ -73,7 +74,7 @@ class WriteFileJob(Job):
     def run(self) -> None:
         Job.yieldThread()
         begin_time = time.time()
-        self.setResult(None if not self._writer else self._writer.write(self._stream, self._data, self._mode))
+        self.setResult(None if not self._writer else self._writer.write(self._stream, self._data, self._mode, **self._writer_args))
         if not self.getResult():
             self.setError(Exception("No writer in WriteFileJob" if not self._writer else self._writer.getInformation()))
         end_time = time.time()

--- a/UM/Qt/Bindings/OutputDeviceManagerProxy.py
+++ b/UM/Qt/Bindings/OutputDeviceManagerProxy.py
@@ -90,10 +90,19 @@ class OutputDeviceManagerProxy(QObject):
         file_type = kwargs.get("file_type", "mesh")
         preferred_mimetypes = kwargs.get("preferred_mimetypes", None)
         silent_save = kwargs.get("silent_save", False)
+        writer_args = kwargs.get("writer_args", {})
         # On Windows, calling requestWrite() on LocalFileOutputDevice crashes when called from a signal
         # handler attached to a QML MenuItem. So instead, defer the call to the next run of the event
         # loop, since that does work.
-        Application.getInstance().callLater(self._writeToDevice, [Application.getInstance().getController().getScene().getRoot()], device_id, file_name, limit_mimetypes, file_type, preferred_mimetypes = preferred_mimetypes, silent_save = silent_save)
+        Application.getInstance().callLater(self._writeToDevice,
+                                            [Application.getInstance().getController().getScene().getRoot()],
+                                            device_id,
+                                            file_name,
+                                            limit_mimetypes,
+                                            file_type,
+                                            preferred_mimetypes = preferred_mimetypes,
+                                            silent_save = silent_save,
+                                            writer_args = writer_args)
 
     @pyqtSlot(str, str, "QVariantMap")
     def requestWriteSelectionToDevice(self, device_id: str, file_name: str, kwargs: Mapping[str, str]) -> None:

--- a/UM/Qt/Bindings/OutputDeviceManagerProxy.py
+++ b/UM/Qt/Bindings/OutputDeviceManagerProxy.py
@@ -89,10 +89,11 @@ class OutputDeviceManagerProxy(QObject):
         limit_mimetypes = kwargs.get("limit_mimetypes", None)
         file_type = kwargs.get("file_type", "mesh")
         preferred_mimetypes = kwargs.get("preferred_mimetypes", None)
+        silent_save = kwargs.get("silent_save", False)
         # On Windows, calling requestWrite() on LocalFileOutputDevice crashes when called from a signal
         # handler attached to a QML MenuItem. So instead, defer the call to the next run of the event
         # loop, since that does work.
-        Application.getInstance().callLater(self._writeToDevice, [Application.getInstance().getController().getScene().getRoot()], device_id, file_name, limit_mimetypes, file_type, preferred_mimetypes = preferred_mimetypes)
+        Application.getInstance().callLater(self._writeToDevice, [Application.getInstance().getController().getScene().getRoot()], device_id, file_name, limit_mimetypes, file_type, preferred_mimetypes = preferred_mimetypes, silent_save = silent_save)
 
     @pyqtSlot(str, str, "QVariantMap")
     def requestWriteSelectionToDevice(self, device_id: str, file_name: str, kwargs: Mapping[str, str]) -> None:

--- a/UM/Workspace/WorkspaceWriter.py
+++ b/UM/Workspace/WorkspaceWriter.py
@@ -8,5 +8,5 @@ class WorkspaceWriter(FileWriter):
     def __init__(self, add_to_recent_files: bool = True) -> None:
         super().__init__(add_to_recent_files)
 
-    def write(self, stream, node, mode = FileWriter.OutputMode.BinaryMode):
+    def write(self, stream, node, mode = FileWriter.OutputMode.BinaryMode, **kwargs):
         raise NotImplementedError("WorkspaceWriter plugin was not correctly implemented, no write was specified")

--- a/plugins/FileLogger/FileLogger.py
+++ b/plugins/FileLogger/FileLogger.py
@@ -5,6 +5,8 @@ import logging
 import logging.handlers
 from typing import Set
 
+from logging import StreamHandler, FileHandler
+
 from UM.Logger import LogOutput
 from UM.Resources import Resources
 from UM.VersionUpgradeManager import VersionUpgradeManager
@@ -33,6 +35,20 @@ class FileLogger(LogOutput):
             self._logger.addHandler(file_handler)
         else:
             pass  # TODO, add handling
+
+    def flush(self) -> None:
+        for handler in self._logger.handlers:
+            if isinstance(handler, StreamHandler):
+                handler.flush()
+
+    def getFilesPaths(self):
+        files_paths = []
+
+        for handler in self._logger.handlers:
+            if isinstance(handler, FileHandler):
+                files_paths.append(handler.baseFilename)
+
+        return files_paths
 
     def log(self, log_type: str, message: str) -> None:
         """Log message to file. 

--- a/plugins/LocalFileOutputDevice/LocalFileOutputDevice.py
+++ b/plugins/LocalFileOutputDevice/LocalFileOutputDevice.py
@@ -138,9 +138,10 @@ class LocalFileOutputDevice(ProjectOutputDevice):
                 raise OutputDeviceError.UserCanceledError()
 
         silent_save = kwargs.get("silent_save", False)
-        self._performWrite(file_name, selected_type, file_handler, nodes, silent_save)
+        writer_args = kwargs.get("writer_args", {})
+        self._performWrite(file_name, selected_type, file_handler, nodes, silent_save, writer_args)
 
-    def _performWrite(self, file_name, selected_type, file_handler, nodes, silent_save):
+    def _performWrite(self, file_name, selected_type, file_handler, nodes, silent_save, writer_args):
         """Writes the specified nodes to a file. This is split from requestWrite to allow interception
         in other plugins. See Ultimaker/Cura#10917.
 
@@ -149,6 +150,7 @@ class LocalFileOutputDevice(ProjectOutputDevice):
         :param file_handler: File handler for writing to the file.
         :param nodes: A collection of scene nodes that should be written to the
         :param silent_save: When true, ignore all side effects (set project name, add recent file, ...)
+        :param writer_args: Extra list of arguments to be given to the writer
         file.
         """
 
@@ -174,7 +176,7 @@ class LocalFileOutputDevice(ProjectOutputDevice):
                 Logger.log("e", "Unrecognised OutputMode.")
                 return None
 
-            job = WriteFileJob(file_writer, stream, nodes, mode)
+            job = WriteFileJob(file_writer, stream, nodes, mode, writer_args)
             job.setFileName(file_name)
             if not silent_save:
                 job.setAddToRecentFiles(True)  # The file will be added into the "recent files" list upon success


### PR DESCRIPTION
CURA-12138

* Allow saving a project file without setting the name as the project name
* Allow giving extra arguments to a file writer
* Allow FileLogger to flush the current file and returns the list of used files paths