### PR TITLE
Fix duplicated file reloading

### DIFF
--- a/UM/Mesh/MeshBuilder.py
+++ b/UM/Mesh/MeshBuilder.py
@@ -37,6 +37,7 @@ class MeshBuilder:
         self._face_count = 0
         self._type = MeshType.faces
         self._file_name = None  # type: Optional[str]
+        self._mesh_id: Optional[str] = None
         # original center position
         self._center_position = None  # type: Optional[Vector]
 
@@ -48,7 +49,7 @@ class MeshBuilder:
 
         return MeshData(vertices = self.getVertices(), normals = self.getNormals(), indices = self.getIndices(),
                         colors = self.getColors(), uvs = self.getUVCoordinates(), file_name = self.getFileName(),
-                        center_position = self.getCenterPosition())
+                        center_position = self.getCenterPosition(), mesh_id = self.getMeshId())
 
     def setCenterPosition(self, position: Optional[Vector]) -> None:
         self._center_position = position
@@ -165,6 +166,12 @@ class MeshBuilder:
 
     def setFileName(self, file_name: Optional[str]) -> None:
         self._file_name = file_name
+
+    def getMeshId(self) -> Optional[str]:
+        return self._mesh_id
+
+    def setMeshId(self, mesh_id: Optional[str]) -> None:
+        self._mesh_id = mesh_id
 
     def reserveFaceCount(self, num_faces: int) -> None:
         """Set the amount of faces before loading data to the mesh.

--- a/UM/Mesh/MeshData.py
+++ b/UM/Mesh/MeshData.py
@@ -48,7 +48,7 @@ class MeshData:
     """
 
     def __init__(self, vertices=None, normals=None, indices=None, colors=None, uvs=None, file_name=None,
-                 center_position=None, zero_position=None, type = MeshType.faces, attributes=None) -> None:
+                 center_position=None, zero_position=None, type = MeshType.faces, attributes=None, mesh_id=None) -> None:
         self._application = None  # Initialize this later otherwise unit tests break
 
         self._vertices = NumPyUtil.immutableNDArray(vertices)
@@ -60,6 +60,7 @@ class MeshData:
         self._face_count = len(self._indices) if self._indices is not None else 0
         self._type = type
         self._file_name = file_name  # type: Optional[str]
+        self._mesh_id: Optional[str] = mesh_id
         # original center position
         self._center_position = center_position
         # original zero position, is changed after transformation
@@ -93,7 +94,7 @@ class MeshData:
                 self._application.getController().getScene().removeWatchedFile(self._file_name)
 
     def set(self, vertices=Reuse, normals=Reuse, indices=Reuse, colors=Reuse, uvs=Reuse, file_name=Reuse,
-            center_position=Reuse, zero_position=Reuse, attributes=Reuse) -> "MeshData":
+            center_position=Reuse, zero_position=Reuse, attributes=Reuse, mesh_id=Reuse) -> "MeshData":
         """Create a new MeshData with specified changes
 
         :return: :type{MeshData}
@@ -105,12 +106,14 @@ class MeshData:
         colors = colors if colors is not Reuse else self._colors
         uvs = uvs if uvs is not Reuse else self._uvs
         file_name = file_name if file_name is not Reuse else self._file_name
+        mesh_id = mesh_id if mesh_id is not Reuse else self._mesh_id
         center_position = center_position if center_position is not Reuse else self._center_position
         zero_position = zero_position if zero_position is not Reuse else self._zero_position
         attributes = attributes if attributes is not Reuse else self._attributes
 
         return MeshData(vertices=vertices, normals=normals, indices=indices, colors=colors, uvs=uvs,
-                        file_name=file_name, center_position=center_position, zero_position=zero_position, attributes=attributes)
+                        file_name=file_name, center_position=center_position, zero_position=zero_position,
+                        attributes=attributes, mesh_id=mesh_id)
 
     def getHash(self):
         m = hashlib.sha256()
@@ -183,6 +186,9 @@ class MeshData:
 
     def getFileName(self) -> Optional[str]:
         return self._file_name
+
+    def getMeshId(self) -> Optional[str]:
+        return self._mesh_id
 
     def getTransformed(self, transformation: Matrix) -> "MeshData":
         """Transform the meshdata, center and zero position by given Matrix

--- a/UM/Scene/Scene.py
+++ b/UM/Scene/Scene.py
@@ -253,15 +253,14 @@ class Scene:
                 renamed_nodes[node.getName()] = 0
 
             # Find the matching scene node to replace
-            scene_node = None
+            mesh_replaced = False
             for replaced_node in replaced_nodes:
-                if replaced_node.getName() == node_name:
-                    scene_node = replaced_node
-                    break
+                mesh_id = replaced_node.getMeshData().getMeshId()
+                if mesh_id is None or mesh_id == mesh_data.getMeshId():
+                    replaced_node.setMeshData(mesh_data)
+                    mesh_replaced = True
 
-            if scene_node:
-                scene_node.setMeshData(mesh_data)
-            else:
-                # Current node is a new one in the file, or it's name has changed
+            if not mesh_replaced:
+                # Current node is a new one in the file, or it's ID has changed
                 # TODO: Load this mesh into the scene. Also alter the "ReloadAll" action in CuraApplication.
                 Logger.log("w", "Could not find matching node for object '{0}' in the scene.", node_name)


### PR DESCRIPTION
Instead of using the object name for reloading meshes inside a 3MF file, use a dedicated mesh ID property that is only stored internally, doesn't have to be unique (because the combination filename+ID will be) and can't be changed by the user. This should improve 3MF file reloading, and also fixes reloading of duplicated instances, because multiple meshes can now have the same mesh ID.

CURA-11905