### PR TITLE
Rotation by input & snap angle input

### DIFF
--- a/UM/Math/Quaternion.py
+++ b/UM/Math/Quaternion.py
@@ -285,48 +285,7 @@ class Quaternion:
         q.setByAngleAxis(angle, axis)
         return q
 
-    def getAngleOnAxis(self, axis: Vector) -> float:
-        """
-        Retrieve the angle of rotation around a specific axis.
 
-        :param axis: :type{Vector} The axis to compute the rotation angle around.
-        :return: The angle of rotation in radians.
-        """
-        normalized_axis = axis.normalized()
-        axis_quaternion = Quaternion(normalized_axis.x, normalized_axis.y, normalized_axis.z, 0)
-
-        # Extract the quaternion's rotational component along the specified axis.
-        projected_quaternion = self * axis_quaternion * self.getInverse()
-        projected_vector = Vector(projected_quaternion.x, projected_quaternion.y, projected_quaternion.z)
-
-        # Compute the angle of rotation using the projected vector.
-        sin_angle = projected_vector.dot(normalized_axis)
-        cos_angle = self.w
-        calculated_angle = 2 * math.atan2(sin_angle, cos_angle)
-
-        return calculated_angle
-
-    def euler_from_quaternion(self):
-        """
-        Convert a quaternion into euler angles (roll, pitch, yaw)
-        roll is rotation around x in radians (counterclockwise)
-        pitch is rotation around y in radians (counterclockwise)
-        yaw is rotation around z in radians (counterclockwise)
-        """
-        t0 = +2.0 * (self.w * self.x + self.y * self.z)
-        t1 = +1.0 - 2.0 * (self.x * self.x + self.y * self.y)
-        roll_x = math.atan2(t0, t1)
-
-        t2 = +2.0 * (self.w * self.y - self.z * self.x)
-        t2 = +1.0 if t2 > +1.0 else t2
-        t2 = -1.0 if t2 < -1.0 else t2
-        pitch_y = math.asin(t2)
-
-        t3 = +2.0 * (self.w * self.z + self.x * self.y)
-        t4 = +1.0 - 2.0 * (self.y * self.y + self.z * self.z)
-        yaw_z = math.atan2(t3, t4)
-
-        return roll_x, pitch_y, yaw_z  # in radians
     def __repr__(self):
         return "Quaternion(x={0}, y={1}, z={2}, w={3})".format(self.x, self.y, self.z, self.w)
 

--- a/UM/Math/Quaternion.py
+++ b/UM/Math/Quaternion.py
@@ -285,7 +285,6 @@ class Quaternion:
         q.setByAngleAxis(angle, axis)
         return q
 
-
     def __repr__(self):
         return "Quaternion(x={0}, y={1}, z={2}, w={3})".format(self.x, self.y, self.z, self.w)
 

--- a/UM/Math/Quaternion.py
+++ b/UM/Math/Quaternion.py
@@ -293,16 +293,40 @@ class Quaternion:
         :return: The angle of rotation in radians.
         """
         normalized_axis = axis.normalized()
+        axis_quaternion = Quaternion(normalized_axis.x, normalized_axis.y, normalized_axis.z, 0)
 
-        # Project the quaternion's axis onto the given axis.
-        axis_dot = normalized_axis.x * self.x + normalized_axis.y * self.y + normalized_axis.z * self.z
-        rotation_length = math.sqrt(axis_dot ** 2 + self.w ** 2)
+        # Extract the quaternion's rotational component along the specified axis.
+        projected_quaternion = self * axis_quaternion * self.getInverse()
+        projected_vector = Vector(projected_quaternion.x, projected_quaternion.y, projected_quaternion.z)
 
-        # Compute the angle of rotation (half-angle is stored in w).
-        calculated_angle = 2 * math.atan2(axis_dot, self.w)
+        # Compute the angle of rotation using the projected vector.
+        sin_angle = projected_vector.dot(normalized_axis)
+        cos_angle = self.w
+        calculated_angle = 2 * math.atan2(sin_angle, cos_angle)
 
         return calculated_angle
 
+    def euler_from_quaternion(self):
+        """
+        Convert a quaternion into euler angles (roll, pitch, yaw)
+        roll is rotation around x in radians (counterclockwise)
+        pitch is rotation around y in radians (counterclockwise)
+        yaw is rotation around z in radians (counterclockwise)
+        """
+        t0 = +2.0 * (self.w * self.x + self.y * self.z)
+        t1 = +1.0 - 2.0 * (self.x * self.x + self.y * self.y)
+        roll_x = math.atan2(t0, t1)
+
+        t2 = +2.0 * (self.w * self.y - self.z * self.x)
+        t2 = +1.0 if t2 > +1.0 else t2
+        t2 = -1.0 if t2 < -1.0 else t2
+        pitch_y = math.asin(t2)
+
+        t3 = +2.0 * (self.w * self.z + self.x * self.y)
+        t4 = +1.0 - 2.0 * (self.y * self.y + self.z * self.z)
+        yaw_z = math.atan2(t3, t4)
+
+        return roll_x, pitch_y, yaw_z  # in radians
     def __repr__(self):
         return "Quaternion(x={0}, y={1}, z={2}, w={3})".format(self.x, self.y, self.z, self.w)
 

--- a/UM/Math/Quaternion.py
+++ b/UM/Math/Quaternion.py
@@ -285,6 +285,24 @@ class Quaternion:
         q.setByAngleAxis(angle, axis)
         return q
 
+    def getAngleOnAxis(self, axis: Vector) -> float:
+        """
+        Retrieve the angle of rotation around a specific axis.
+
+        :param axis: :type{Vector} The axis to compute the rotation angle around.
+        :return: The angle of rotation in radians.
+        """
+        normalized_axis = axis.normalized()
+
+        # Project the quaternion's axis onto the given axis.
+        axis_dot = normalized_axis.x * self.x + normalized_axis.y * self.y + normalized_axis.z * self.z
+        rotation_length = math.sqrt(axis_dot ** 2 + self.w ** 2)
+
+        # Compute the angle of rotation (half-angle is stored in w).
+        calculated_angle = 2 * math.atan2(axis_dot, self.w)
+
+        return calculated_angle
+
     def __repr__(self):
         return "Quaternion(x={0}, y={1}, z={2}, w={3})".format(self.x, self.y, self.z, self.w)
 

--- a/plugins/Tools/RotateTool/RotateTool.py
+++ b/plugins/Tools/RotateTool/RotateTool.py
@@ -244,6 +244,15 @@ class RotateTool(Tool):
         self._rotateModel(angle, Vector.Unit_Z)
         self.propertyChanged.emit()
 
+    def getRX(self) -> float:
+        return 0
+
+    def getRY(self) -> float:
+        return 0
+
+    def getRZ(self) -> float:
+        return 0
+
     def _onSelectedFaceChanged(self):
         if not self._select_face_mode:
             return
@@ -422,7 +431,7 @@ class RotateTool(Tool):
         for node in self._getSelectedObjectsWithoutSelectedAncestors():
             self._saved_node_positions.append((node, node.getPosition()))
 
-        # Rotate around the saved centeres of all selected nodes
+        # Rotate around the saved centers of all selected nodes
         if len(self._saved_node_positions) > 1:
             op = GroupedOperation()
             for node, position in self._saved_node_positions:

--- a/plugins/Tools/RotateTool/RotateTool.py
+++ b/plugins/Tools/RotateTool/RotateTool.py
@@ -48,6 +48,9 @@ class RotateTool(Tool):
         self._snap_angle = math.radians(15)
 
         self._angle = None
+        self._x_angle = 0
+        self._y_angle = 0
+        self._z_angle = 0
         self._angle_update_time = None
 
         self._shortcut_key = Qt.Key.Key_R
@@ -232,44 +235,56 @@ class RotateTool(Tool):
     def setRX(self, rx: str) -> None:
         angle = float(rx)
         _angle = math.radians(angle)
-        if self._angle == math.radians(angle):
-            return True
-        elif self._angle:
-            angle = angle - float(math.degrees(self._angle))
+        if self._x_angle == math.radians(angle):
+            return
+        elif self._x_angle:
+            angle = angle - float(math.degrees(self._x_angle))
         self._rotateModel(angle, Vector.Unit_X)
-        self._angle = _angle
+        self._x_angle = _angle
         self.propertyChanged.emit()
 
     def setRY(self, ry: str) -> None:
         angle = float(ry)
         _angle = math.radians(angle)
-        if self._angle == math.radians(angle):
-            return True
-        elif self._angle:
-            angle = angle - float(math.degrees(self._angle))
+        if self._y_angle == math.radians(angle):
+            return
+        elif self._y_angle:
+            angle = angle - float(math.degrees(self._y_angle))
         self._rotateModel(angle, Vector.Unit_Y)
-        self._angle = _angle
+        self._y_angle = _angle
         self.propertyChanged.emit()
 
     def setRZ(self, rz: str) -> None:
         angle = float(rz)
         _angle = math.radians(angle)
-        if self._angle == math.radians(angle):
-            return True
-        elif self._angle:
-            angle = angle - float(math.degrees(self._angle))
+        if self._z_angle == math.radians(angle):
+            return
+        elif self._z_angle:
+            angle = angle - float(math.degrees(self._z_angle))
         self._rotateModel(angle, Vector.Unit_Z)
-        self._angle = _angle
+        self._z_angle = _angle
         self.propertyChanged.emit()
 
     def getRX(self) -> float:
-        return 0.0
+        nodelist = self._getSelectedObjectsWithoutSelectedAncestors()
+        for node in nodelist:
+            q = node.getOrientation()
+            self._x_angle = math.ceil(q.getAngleOnAxis(Vector.Unit_X) * 90)
+            return self._x_angle
 
     def getRY(self) -> float:
-        return 0.0
+        nodelist = self._getSelectedObjectsWithoutSelectedAncestors()
+        for node in nodelist:
+            q = node.getOrientation()
+            self._y_angle = math.ceil(q.getAngleOnAxis(Vector.Unit_Y) * 90)
+            return self._y_angle
 
     def getRZ(self) -> float:
-        return 0.0
+        nodelist = self._getSelectedObjectsWithoutSelectedAncestors()
+        for node in nodelist:
+            q = node.getOrientation()
+            self._z_angle = math.ceil(q.getAngleOnAxis(Vector.Unit_Z) * 90)
+            return self._z_angle
 
     def _onSelectedFaceChanged(self):
         if not self._select_face_mode:

--- a/plugins/Tools/RotateTool/RotateTool.py
+++ b/plugins/Tools/RotateTool/RotateTool.py
@@ -235,7 +235,7 @@ class RotateTool(Tool):
     def setRX(self, rx: str) -> None:
         angle = float(rx)
         _angle = math.radians(angle)
-        if self._x_angle == math.radians(angle):
+        if self._x_angle == _angle:
             return
         elif self._x_angle:
             angle = angle - float(math.degrees(self._x_angle))
@@ -246,7 +246,7 @@ class RotateTool(Tool):
     def setRY(self, ry: str) -> None:
         angle = float(ry)
         _angle = math.radians(angle)
-        if self._y_angle == math.radians(angle):
+        if self._y_angle == _angle:
             return
         elif self._y_angle:
             angle = angle - float(math.degrees(self._y_angle))
@@ -257,7 +257,7 @@ class RotateTool(Tool):
     def setRZ(self, rz: str) -> None:
         angle = float(rz)
         _angle = math.radians(angle)
-        if self._z_angle == math.radians(angle):
+        if self._z_angle == _angle:
             return
         elif self._z_angle:
             angle = angle - float(math.degrees(self._z_angle))
@@ -269,22 +269,22 @@ class RotateTool(Tool):
         nodelist = self._getSelectedObjectsWithoutSelectedAncestors()
         for node in nodelist:
             q = node.getOrientation()
-            self._x_angle = math.ceil(q.getAngleOnAxis(Vector.Unit_X) * 90)
-            return self._x_angle
+            self._x_angle, self._y_angle, self._z_angle = q.euler_from_quaternion()
+            return math.degrees(self._x_angle)
 
     def getRY(self) -> float:
         nodelist = self._getSelectedObjectsWithoutSelectedAncestors()
         for node in nodelist:
             q = node.getOrientation()
-            self._y_angle = math.ceil(q.getAngleOnAxis(Vector.Unit_Y) * 90)
-            return self._y_angle
+            self._x_angle, self._y_angle, self._z_angle = q.euler_from_quaternion()
+            return math.degrees(self._y_angle)
 
     def getRZ(self) -> float:
         nodelist = self._getSelectedObjectsWithoutSelectedAncestors()
         for node in nodelist:
             q = node.getOrientation()
-            self._z_angle = math.ceil(q.getAngleOnAxis(Vector.Unit_Z) * 90)
-            return self._z_angle
+            self._x_angle, self._y_angle, self._z_angle = q.euler_from_quaternion()
+            return math.degrees(self._z_angle)
 
     def _onSelectedFaceChanged(self):
         if not self._select_face_mode:

--- a/plugins/Tools/RotateTool/RotateTool.py
+++ b/plugins/Tools/RotateTool/RotateTool.py
@@ -230,17 +230,17 @@ class RotateTool(Tool):
                 return True
 
     def setRotationX(self, rotation_x: str) -> None:
-        angle = float(rotation_x)
+        angle = math.radians(float(rotation_x))
         self._rotateModel(angle, Vector.Unit_X)
         self.propertyChanged.emit()
 
     def setRotationY(self, rotation_y: str) -> None:
-        angle = float(rotation_y)
+        angle = math.radians(float(rotation_y))
         self._rotateModel(angle, Vector.Unit_Y)
         self.propertyChanged.emit()
 
     def setRotationZ(self, rotation_z: str) -> None:
-        angle = float(rotation_z)
+        angle = math.radians(float(rotation_z))
         self._rotateModel(angle, Vector.Unit_Z)
         self.propertyChanged.emit()
 
@@ -426,7 +426,7 @@ class RotateTool(Tool):
         self.operationStopped.emit(self)
 
     def _rotateModel(self, angle, vector_unit) -> None:
-        rotation = Quaternion.fromAngleAxis(angle / 90, vector_unit)
+        rotation = Quaternion.fromAngleAxis(angle, vector_unit)
         self._saved_node_positions = []
         for node in self._getSelectedObjectsWithoutSelectedAncestors():
             self._saved_node_positions.append((node, node.getPosition()))

--- a/plugins/Tools/RotateTool/RotateTool.py
+++ b/plugins/Tools/RotateTool/RotateTool.py
@@ -48,10 +48,6 @@ class RotateTool(Tool):
         self._snap_angle = math.radians(15)
 
         self._angle = None
-        self._x_angle = 0
-        self._y_angle = 0
-        self._z_angle = 0
-        self._rotation_axis = None
         self._angle_update_time = None
 
         self._shortcut_key = Qt.Key.Key_R
@@ -163,15 +159,12 @@ class RotateTool(Tool):
             if self.getLockedAxis() == ToolHandle.XAxis:
                 direction = 1 if Vector.Unit_X.dot(drag_start.cross(drag_end)) > 0 else -1
                 rotation = Quaternion.fromAngleAxis(direction * angle, Vector.Unit_X)
-                self._rotation_axis = Vector.Unit_X
             elif self.getLockedAxis() == ToolHandle.YAxis:
                 direction = 1 if Vector.Unit_Y.dot(drag_start.cross(drag_end)) > 0 else -1
                 rotation = Quaternion.fromAngleAxis(direction * angle, Vector.Unit_Y)
-                self._rotation_axis = Vector.Unit_Y
             elif self.getLockedAxis() == ToolHandle.ZAxis:
                 direction = 1 if Vector.Unit_Z.dot(drag_start.cross(drag_end)) > 0 else -1
                 rotation = Quaternion.fromAngleAxis(direction * angle, Vector.Unit_Z)
-                self._rotation_axis = Vector.Unit_Z
             else:
                 direction = -1
 
@@ -182,15 +175,6 @@ class RotateTool(Tool):
             if not self._angle_update_time or new_time - self._angle_update_time > 0.1:
                 self._angle_update_time = new_time
                 self._angle += direction * angle
-                match self._rotation_axis:
-                    case Vector.Unit_X:
-                        self._x_angle = self._angle
-                    case Vector.Unit_Y:
-                        self._y_angle = self._angle
-                    case Vector.Unit_Z:
-                        self._z_angle = self._angle
-                    case _:
-                        pass
                 self.propertyChanged.emit()
 
                 # Rotate around the saved centeres of all selected nodes
@@ -217,13 +201,10 @@ class RotateTool(Tool):
                     axis += self._handle.XAxis
                     if axis == ToolHandle.XAxis:
                         rotation = Quaternion.fromAngleAxis(angle, Vector.Unit_X)
-                        self._x_angle += angle
                     elif axis == ToolHandle.YAxis:
                         rotation = Quaternion.fromAngleAxis(angle, Vector.Unit_Y)
-                        self._y_angle += angle
                     else:
                         rotation = Quaternion.fromAngleAxis(angle, Vector.Unit_Z)
-                        self._z_angle += angle
 
 
                     # Rotate around the saved centeres of all selected nodes
@@ -250,50 +231,17 @@ class RotateTool(Tool):
 
     def setRX(self, rx: str) -> None:
         angle = float(rx)
-        _angle = math.radians(angle)
-        if self._x_angle == _angle:
-            return
-        elif self._x_angle:
-            angle = angle - float(math.degrees(self._x_angle))
         self._rotateModel(angle, Vector.Unit_X)
-        self._x_angle = _angle
         self.propertyChanged.emit()
 
     def setRY(self, ry: str) -> None:
         angle = float(ry)
-        _angle = math.radians(angle)
-        if self._y_angle == _angle:
-            return
-        elif self._y_angle:
-            angle = angle - float(math.degrees(self._y_angle))
         self._rotateModel(angle, Vector.Unit_Y)
-        self._y_angle = _angle
         self.propertyChanged.emit()
 
     def setRZ(self, rz: str) -> None:
         angle = float(rz)
-        _angle = math.radians(angle)
-        if self._z_angle == _angle:
-            return
-        elif self._z_angle:
-            angle = angle - float(math.degrees(self._z_angle))
         self._rotateModel(angle, Vector.Unit_Z)
-        self._z_angle = _angle
-        self.propertyChanged.emit()
-
-    def getRX(self) -> float:
-        return math.degrees(self._x_angle)
-
-    def getRY(self) -> float:
-        return math.degrees(self._y_angle)
-
-    def getRZ(self) -> float:
-        return math.degrees(self._z_angle)
-
-    def _resetXYZRotation(self) -> None:
-        self._x_angle = 0
-        self._y_angle = 0
-        self._z_angle = 0
         self.propertyChanged.emit()
 
     def _onSelectedFaceChanged(self):
@@ -404,7 +352,6 @@ class RotateTool(Tool):
     def resetRotation(self):
         """Reset the orientation of the mesh(es) to their original orientation(s)"""
 
-        self._resetXYZRotation()
         for node in self._getSelectedObjectsWithoutSelectedAncestors():
             node.setMirror(Vector(1, 1, 1))
 

--- a/plugins/Tools/RotateTool/RotateTool.py
+++ b/plugins/Tools/RotateTool/RotateTool.py
@@ -56,7 +56,7 @@ class RotateTool(Tool):
         self._iterations = 0
         self._total_iterations = 0
         self._rotating = False
-        self.setExposedProperties("ToolHint", "RotationSnap", "RotationSnapAngle", "SelectFaceSupported", "SelectFaceToLayFlatMode", "RX", "RY", "RZ")
+        self.setExposedProperties("ToolHint", "RotationSnap", "RotationSnapAngle", "SelectFaceSupported", "SelectFaceToLayFlatMode", "RotationX", "RotationY", "RotationZ")
         self._saved_node_positions = []
 
         self._active_widget = None  # type: Optional[RotateToolHandle.ExtraWidgets]
@@ -229,28 +229,28 @@ class RotateTool(Tool):
                     self.operationStopped.emit(self)
                 return True
 
-    def setRX(self, rx: str) -> None:
-        angle = float(rx)
+    def setRotationX(self, rotation_x: str) -> None:
+        angle = float(rotation_x)
         self._rotateModel(angle, Vector.Unit_X)
         self.propertyChanged.emit()
 
-    def setRY(self, ry: str) -> None:
-        angle = float(ry)
+    def setRotationY(self, rotation_y: str) -> None:
+        angle = float(rotation_y)
         self._rotateModel(angle, Vector.Unit_Y)
         self.propertyChanged.emit()
 
-    def setRZ(self, rz: str) -> None:
-        angle = float(rz)
+    def setRotationZ(self, rotation_z: str) -> None:
+        angle = float(rotation_z)
         self._rotateModel(angle, Vector.Unit_Z)
         self.propertyChanged.emit()
 
-    def getRX(self) -> float:
+    def getRotationX(self) -> float:
         return 0
 
-    def getRY(self) -> float:
+    def getRotationY(self) -> float:
         return 0
 
-    def getRZ(self) -> float:
+    def getRotationZ(self) -> float:
         return 0
 
     def _onSelectedFaceChanged(self):

--- a/plugins/Tools/RotateTool/RotateTool.qml
+++ b/plugins/Tools/RotateTool/RotateTool.qml
@@ -125,12 +125,12 @@ Item
             width: Math.ceil(contentWidth) //Make sure that the grid cells have an integer width.
         }
 
-		UM.TextFieldWithUnit
+        UM.TextFieldWithUnit
         {
             id: angleTextField
             width: UM.Theme.getSize("setting_control").width
             height: UM.Theme.getSize("setting_control").height
-            unit: "degrees"
+            unit: "°"
             text: snapText
 
             validator: UM.FloatValidator
@@ -141,14 +141,14 @@ Item
             onEditingFinished:
             {
                 var modified_text = text.replace(",", ".") // User convenience. We use dots for decimal values
-                if(text !="")
+                if(text != "")
                 {
                     UM.Controller.setProperty("RotationSnapAngle", modified_text)
                 }
             }
             onActiveFocusChanged:
             {
-                if(!activeFocus && text =="")
+                if(!activeFocus && text == "")
                 {
                     snapText = 0.1; // Need to change it to something else so we can force it to getvalue
                     snapText = UM.Controller.properties.getValue("RotationSnapAngle")
@@ -206,12 +206,12 @@ Item
             width: Math.ceil(contentWidth) //Make sure that the grid cells have an integer width.
         }
 
-		UM.TextFieldWithUnit
+        UM.TextFieldWithUnit
         {
             id: xangleTextField
             width: UM.Theme.getSize("setting_control").width
             height: UM.Theme.getSize("setting_control").height
-            unit: "degrees"
+            unit: "°"
             text: xText
 
             validator: UM.FloatValidator
@@ -222,15 +222,15 @@ Item
             onEditingFinished:
             {
                 var modified_text = text.replace(",", ".") // User convenience. We use dots for decimal values
-                if(text !="")
+                if(text != "")
                 {
-                    UM.Controller.setProperty("RX", modified_text)
+                    UM.Controller.setProperty("RotationX", modified_text)
                     text = "0"
                 }
             }
             onActiveFocusChanged:
             {
-                if(!activeFocus && text =="")
+                if(!activeFocus && text == "")
                 {
                     xText = 0.1; // Need to change it to something else so we can force it to getvalue
                     xText = 0
@@ -243,7 +243,7 @@ Item
             id: yangleTextField
             width: UM.Theme.getSize("setting_control").width
             height: UM.Theme.getSize("setting_control").height
-            unit: "degrees"
+            unit: "°"
             text: yText
 
             validator: UM.FloatValidator
@@ -254,16 +254,16 @@ Item
             onEditingFinished:
             {
                 var modified_text = text.replace(",", ".") // User convenience. We use dots for decimal values
-                if(text !="")
+                if(text != "")
                 {
                     // Yes this is intentional. Y & Z are flipped between model axes and build plate axes
-                    UM.Controller.setProperty("RZ", modified_text)
+                    UM.Controller.setProperty("RotationZ", modified_text)
                     text = "0"
                 }
             }
             onActiveFocusChanged:
             {
-                if(!activeFocus && text =="")
+                if(!activeFocus && text == "")
                 {
                     yText = 0.1; // Need to change it to something else so we can force it to getvalue
                     // Yes this is intentional. Y & Z are flipped between model axes and build plate axes
@@ -277,7 +277,7 @@ Item
             id: zangleTextField
             width: UM.Theme.getSize("setting_control").width
             height: UM.Theme.getSize("setting_control").height
-            unit: "degrees"
+            unit: "°"
             text: zText
 
             validator: UM.FloatValidator
@@ -288,16 +288,16 @@ Item
             onEditingFinished:
             {
                 var modified_text = text.replace(",", ".") // User convenience. We use dots for decimal values
-                if(text !="")
+                if(text != "")
                 {
                     // Yes this is intentional. Y & Z are flipped between model axes and build plate axes
-                    UM.Controller.setProperty("RY", modified_text)
+                    UM.Controller.setProperty("RotationY", modified_text)
                     text = "0"
                 }
             }
             onActiveFocusChanged:
             {
-                if(!activeFocus && text =="")
+                if(!activeFocus && text == "")
                 {
                     zText = 0.1; // Need to change it to something else so we can force it to getvalue
                     // Yes this is intentional. Y & Z are flipped between model axes and build plate axes
@@ -333,20 +333,20 @@ Item
     {
         target: base
         property: "xText"
-        value: base.roundFloat(UM.Controller.properties.getValue("RX"), 2)
+        value: base.roundFloat(UM.Controller.properties.getValue("RotationX"), 2)
     }
 
     Binding
     {
         target: base
         property: "zText"
-        value: base.roundFloat(UM.Controller.properties.getValue("RY"), 2)
+        value: base.roundFloat(UM.Controller.properties.getValue("RotationY"), 2)
     }
 
     Binding
     {
         target: base
         property: "yText"
-        value: base.roundFloat(UM.Controller.properties.getValue("RZ"), 2)
+        value: base.roundFloat(UM.Controller.properties.getValue("RotationZ"), 2)
     }
 }

--- a/plugins/Tools/RotateTool/RotateTool.qml
+++ b/plugins/Tools/RotateTool/RotateTool.qml
@@ -150,12 +150,13 @@ Item
             {
                 if(!activeFocus && text =="")
                 {
-                    snapText = 0.1; // Yeaaah i know. We need to change it to something else so we can force it to 0
+                    snapText = 0.1; // Need to change it to something else so we can force it to getvalue
                     snapText = UM.Controller.properties.getValue("RotationSnapAngle")
                 }
             }
         }
     }
+
     UM.CheckBox
     {
         id: snapRotationCheckbox
@@ -230,11 +231,12 @@ Item
             {
                 if(!activeFocus && text =="")
                 {
-                    xText = 0.1; // Yeaaah i know. We need to change it to something else so we can force it to 0
+                    xText = 0.1; // Need to change it to something else so we can force it to getvalue
                     xText = UM.Controller.properties.getValue("RX")
                 }
             }
         }
+
         UM.TextFieldWithUnit
         {
             id: yangleTextField
@@ -253,18 +255,21 @@ Item
                 var modified_text = text.replace(",", ".") // User convenience. We use dots for decimal values
                 if(text !="")
                 {
-                    UM.Controller.setProperty("RY", modified_text)
+                    // Yes this is intentional. Y & Z are flipped between model axes and build plate axes
+                    UM.Controller.setProperty("RZ", modified_text)
                 }
             }
             onActiveFocusChanged:
             {
                 if(!activeFocus && text =="")
                 {
-                    yText = 0.1; // Yeaaah i know. We need to change it to something else so we can force it to 0
-                    yText = UM.Controller.properties.getValue("RY")
+                    yText = 0.1; // Need to change it to something else so we can force it to getvalue
+                    // Yes this is intentional. Y & Z are flipped between model axes and build plate axes
+                    yText = UM.Controller.properties.getValue("RZ")
                 }
             }
         }
+
         UM.TextFieldWithUnit
         {
             id: zangleTextField
@@ -283,15 +288,17 @@ Item
                 var modified_text = text.replace(",", ".") // User convenience. We use dots for decimal values
                 if(text !="")
                 {
-                    UM.Controller.setProperty("RZ", modified_text)
+                    // Yes this is intentional. Y & Z are flipped between model axes and build plate axes
+                    UM.Controller.setProperty("RY", modified_text)
                 }
             }
             onActiveFocusChanged:
             {
                 if(!activeFocus && text =="")
                 {
-                    zText = 0.1; // Yeaaah i know. We need to change it to something else so we can force it to 0
-                    zText = UM.Controller.properties.getValue("RZ")
+                    zText = 0.1; // Need to change it to something else so we can force it to getvalue
+                    // Yes this is intentional. Y & Z are flipped between model axes and build plate axes
+                    zText = UM.Controller.properties.getValue("RY")
                 }
             }
         }
@@ -329,14 +336,14 @@ Item
     Binding
     {
         target: base
-        property: "yText"
+        property: "zText"
         value: base.roundFloat(UM.Controller.properties.getValue("RY"), 2)
     }
 
     Binding
     {
         target: base
-        property: "zText"
+        property: "yText"
         value: base.roundFloat(UM.Controller.properties.getValue("RZ"), 2)
     }
 }

--- a/plugins/Tools/RotateTool/RotateTool.qml
+++ b/plugins/Tools/RotateTool/RotateTool.qml
@@ -11,9 +11,6 @@ Item
     height: childrenRect.height
     UM.I18nCatalog { id: catalog; name: "uranium"}
 
-    property string xText
-    property string yText
-    property string zText
     property string snapText
 
     //Rounds a floating point number to 4 decimals. This prevents floating
@@ -212,27 +209,15 @@ Item
             width: UM.Theme.getSize("setting_control").width
             height: UM.Theme.getSize("setting_control").height
             unit: "degrees"
-            text: xText
+            text: ""
 
-            validator: UM.FloatValidator
-            {
-                maxBeforeDecimal: 3
-                maxAfterDecimal: 2
-            }
             onEditingFinished:
             {
                 var modified_text = text.replace(",", ".") // User convenience. We use dots for decimal values
                 if(text !="")
                 {
                     UM.Controller.setProperty("RX", modified_text)
-                }
-            }
-            onActiveFocusChanged:
-            {
-                if(!activeFocus && text =="")
-                {
-                    xText = 0.1; // Need to change it to something else so we can force it to getvalue
-                    xText = UM.Controller.properties.getValue("RX")
+                    text =""
                 }
             }
         }
@@ -243,13 +228,8 @@ Item
             width: UM.Theme.getSize("setting_control").width
             height: UM.Theme.getSize("setting_control").height
             unit: "degrees"
-            text: yText
+            text: ""
 
-            validator: UM.FloatValidator
-            {
-                maxBeforeDecimal: 3
-                maxAfterDecimal: 2
-            }
             onEditingFinished:
             {
                 var modified_text = text.replace(",", ".") // User convenience. We use dots for decimal values
@@ -257,15 +237,7 @@ Item
                 {
                     // Yes this is intentional. Y & Z are flipped between model axes and build plate axes
                     UM.Controller.setProperty("RZ", modified_text)
-                }
-            }
-            onActiveFocusChanged:
-            {
-                if(!activeFocus && text =="")
-                {
-                    yText = 0.1; // Need to change it to something else so we can force it to getvalue
-                    // Yes this is intentional. Y & Z are flipped between model axes and build plate axes
-                    yText = UM.Controller.properties.getValue("RZ")
+                    text =""
                 }
             }
         }
@@ -276,13 +248,8 @@ Item
             width: UM.Theme.getSize("setting_control").width
             height: UM.Theme.getSize("setting_control").height
             unit: "degrees"
-            text: zText
+            text: ""
 
-            validator: UM.FloatValidator
-            {
-                maxBeforeDecimal: 3
-                maxAfterDecimal: 2
-            }
             onEditingFinished:
             {
                 var modified_text = text.replace(",", ".") // User convenience. We use dots for decimal values
@@ -290,15 +257,7 @@ Item
                 {
                     // Yes this is intentional. Y & Z are flipped between model axes and build plate axes
                     UM.Controller.setProperty("RY", modified_text)
-                }
-            }
-            onActiveFocusChanged:
-            {
-                if(!activeFocus && text =="")
-                {
-                    zText = 0.1; // Need to change it to something else so we can force it to getvalue
-                    // Yes this is intentional. Y & Z are flipped between model axes and build plate axes
-                    zText = UM.Controller.properties.getValue("RY")
+                    text = ""
                 }
             }
         }
@@ -324,26 +283,5 @@ Item
         target: base
         property: "snapText"
         value: base.roundFloat(UM.Controller.properties.getValue("RotationSnapAngle"), 2)
-    }
-
-    Binding
-    {
-        target: base
-        property: "xText"
-        value: base.roundFloat(UM.Controller.properties.getValue("RX"), 2)
-    }
-
-    Binding
-    {
-        target: base
-        property: "zText"
-        value: base.roundFloat(UM.Controller.properties.getValue("RY"), 2)
-    }
-
-    Binding
-    {
-        target: base
-        property: "yText"
-        value: base.roundFloat(UM.Controller.properties.getValue("RZ"), 2)
     }
 }

--- a/plugins/Tools/RotateTool/RotateTool.qml
+++ b/plugins/Tools/RotateTool/RotateTool.qml
@@ -11,6 +11,9 @@ Item
     height: childrenRect.height
     UM.I18nCatalog { id: catalog; name: "uranium"}
 
+    property string xText
+    property string yText
+    property string zText
     property string snapText
 
     //Rounds a floating point number to 4 decimals. This prevents floating
@@ -209,15 +212,28 @@ Item
             width: UM.Theme.getSize("setting_control").width
             height: UM.Theme.getSize("setting_control").height
             unit: "degrees"
-            text: ""
+            text: xText
 
+            validator: UM.FloatValidator
+            {
+                maxBeforeDecimal: 3
+                maxAfterDecimal: 2
+            }
             onEditingFinished:
             {
                 var modified_text = text.replace(",", ".") // User convenience. We use dots for decimal values
                 if(text !="")
                 {
                     UM.Controller.setProperty("RX", modified_text)
-                    text =""
+                    text = "0"
+                }
+            }
+            onActiveFocusChanged:
+            {
+                if(!activeFocus && text =="")
+                {
+                    xText = 0.1; // Need to change it to something else so we can force it to getvalue
+                    xText = 0
                 }
             }
         }
@@ -228,8 +244,13 @@ Item
             width: UM.Theme.getSize("setting_control").width
             height: UM.Theme.getSize("setting_control").height
             unit: "degrees"
-            text: ""
+            text: yText
 
+            validator: UM.FloatValidator
+            {
+                maxBeforeDecimal: 3
+                maxAfterDecimal: 2
+            }
             onEditingFinished:
             {
                 var modified_text = text.replace(",", ".") // User convenience. We use dots for decimal values
@@ -237,7 +258,16 @@ Item
                 {
                     // Yes this is intentional. Y & Z are flipped between model axes and build plate axes
                     UM.Controller.setProperty("RZ", modified_text)
-                    text =""
+                    text = "0"
+                }
+            }
+            onActiveFocusChanged:
+            {
+                if(!activeFocus && text =="")
+                {
+                    yText = 0.1; // Need to change it to something else so we can force it to getvalue
+                    // Yes this is intentional. Y & Z are flipped between model axes and build plate axes
+                    yText = 0
                 }
             }
         }
@@ -248,8 +278,13 @@ Item
             width: UM.Theme.getSize("setting_control").width
             height: UM.Theme.getSize("setting_control").height
             unit: "degrees"
-            text: ""
+            text: zText
 
+            validator: UM.FloatValidator
+            {
+                maxBeforeDecimal: 3
+                maxAfterDecimal: 2
+            }
             onEditingFinished:
             {
                 var modified_text = text.replace(",", ".") // User convenience. We use dots for decimal values
@@ -257,7 +292,16 @@ Item
                 {
                     // Yes this is intentional. Y & Z are flipped between model axes and build plate axes
                     UM.Controller.setProperty("RY", modified_text)
-                    text = ""
+                    text = "0"
+                }
+            }
+            onActiveFocusChanged:
+            {
+                if(!activeFocus && text =="")
+                {
+                    zText = 0.1; // Need to change it to something else so we can force it to getvalue
+                    // Yes this is intentional. Y & Z are flipped between model axes and build plate axes
+                    zText = 0
                 }
             }
         }
@@ -283,5 +327,26 @@ Item
         target: base
         property: "snapText"
         value: base.roundFloat(UM.Controller.properties.getValue("RotationSnapAngle"), 2)
+    }
+
+    Binding
+    {
+        target: base
+        property: "xText"
+        value: base.roundFloat(UM.Controller.properties.getValue("RX"), 2)
+    }
+
+    Binding
+    {
+        target: base
+        property: "zText"
+        value: base.roundFloat(UM.Controller.properties.getValue("RY"), 2)
+    }
+
+    Binding
+    {
+        target: base
+        property: "yText"
+        value: base.roundFloat(UM.Controller.properties.getValue("RZ"), 2)
     }
 }

--- a/plugins/Tools/RotateTool/RotateTool.qml
+++ b/plugins/Tools/RotateTool/RotateTool.qml
@@ -2,13 +2,17 @@
 // Uranium is released under the terms of the LGPLv3 or higher.
 
 import QtQuick 2.2
-import UM 1.5 as UM
+import UM 1.7 as UM
 
 Item
 {
     width: childrenRect.width
     height: childrenRect.height
     UM.I18nCatalog { id: catalog; name: "uranium"}
+
+    property string xText
+    property string yText
+    property string zText
 
     UM.ToolbarButton
     {
@@ -89,6 +93,110 @@ Item
         checked: UM.Controller.properties.getValue("RotationSnap")
         onClicked: UM.Controller.setProperty("RotationSnap", checked)
     }
+
+    Grid
+    {
+        id: textfields
+
+        anchors.leftMargin: UM.Theme.getSize("default_margin").width
+        anchors.top: snapRotationCheckbox.bottom
+
+        columns: 2
+        flow: Grid.TopToBottom
+        spacing: Math.round(UM.Theme.getSize("default_margin").width / 2)
+
+        UM.Label
+        {
+            height: UM.Theme.getSize("setting_control").height
+            text: "X"
+            color: UM.Theme.getColor("x_axis")
+            width: Math.ceil(contentWidth) //Make sure that the grid cells have an integer width.
+        }
+
+        UM.Label
+        {
+            height: UM.Theme.getSize("setting_control").height
+            text: "Y"
+            color: UM.Theme.getColor("z_axis"); // This is intentional. The internal axis are switched.
+            width: Math.ceil(contentWidth) //Make sure that the grid cells have an integer width.
+        }
+
+        UM.Label
+        {
+            height: UM.Theme.getSize("setting_control").height
+            text: "Z"
+            color: UM.Theme.getColor("y_axis"); // This is intentional. The internal axis are switched.
+            width: Math.ceil(contentWidth) //Make sure that the grid cells have an integer width.
+        }
+
+		UM.TextFieldWithUnit
+        {
+            id: xangleTextField
+            width: UM.Theme.getSize("setting_control").width
+            height: UM.Theme.getSize("setting_control").height
+            unit: "degrees"
+            text: xText
+
+            onEditingFinished:
+            {
+                var modified_text = text.replace(",", ".") // User convenience. We use dots for decimal values
+                UM.Controller.setProperty("RX", modified_text)
+            }
+            onActiveFocusChanged:
+            {
+                if(!activeFocus && text =="")
+                {
+                    xText = 0.1; // Yeaaah i know. We need to change it to something else so we can force it to 0
+                    xText = 0
+                }
+            }
+        }
+        UM.TextFieldWithUnit
+        {
+            id: yangleTextField
+            width: UM.Theme.getSize("setting_control").width
+            height: UM.Theme.getSize("setting_control").height
+            unit: "degrees"
+            text: yText
+
+            onEditingFinished:
+            {
+                var modified_text = text.replace(",", ".") // User convenience. We use dots for decimal values
+                UM.Controller.setProperty("RY", modified_text)
+            }
+            onActiveFocusChanged:
+            {
+                if(!activeFocus && text =="")
+                {
+                    yText = 0.1; // Yeaaah i know. We need to change it to something else so we can force it to 0
+                    yText = 0
+                }
+            }
+        }
+        UM.TextFieldWithUnit
+        {
+            id: zangleTextField
+            width: UM.Theme.getSize("setting_control").width
+            height: UM.Theme.getSize("setting_control").height
+            unit: "degrees"
+            text: zText
+
+            onEditingFinished:
+            {
+                var modified_text = text.replace(",", ".") // User convenience. We use dots for decimal values
+                UM.Controller.setProperty("RZ", modified_text)
+            }
+            onActiveFocusChanged:
+            {
+                if(!activeFocus && text =="")
+                {
+                    zText = 0.1; // Yeaaah i know. We need to change it to something else so we can force it to 0
+                    zText = 0
+                }
+            }
+        }
+
+	}
 
     Binding
     {

--- a/plugins/Tools/RotateTool/RotateTool.qml
+++ b/plugins/Tools/RotateTool/RotateTool.qml
@@ -135,7 +135,7 @@ Item
             width: UM.Theme.getSize("setting_control").width
             height: UM.Theme.getSize("setting_control").height
             unit: "degrees"
-            text: xText
+            text: UM.Controller.properties.getValue("RX")
 
             onEditingFinished:
             {
@@ -157,7 +157,7 @@ Item
             width: UM.Theme.getSize("setting_control").width
             height: UM.Theme.getSize("setting_control").height
             unit: "degrees"
-            text: yText
+            text: UM.Controller.properties.getValue("RY")
 
             onEditingFinished:
             {
@@ -179,7 +179,7 @@ Item
             width: UM.Theme.getSize("setting_control").width
             height: UM.Theme.getSize("setting_control").height
             unit: "degrees"
-            text: zText
+            text: UM.Controller.properties.getValue("RZ")
 
             onEditingFinished:
             {

--- a/plugins/Tools/RotateTool/RotateTool.qml
+++ b/plugins/Tools/RotateTool/RotateTool.qml
@@ -112,6 +112,7 @@ Item
 
         anchors.leftMargin: UM.Theme.getSize("default_margin").width
         anchors.top: snapRotationCheckbox.bottom
+        visible: snapRotationCheckbox.checked
 
         columns: 2
         flow: Grid.TopToBottom
@@ -122,7 +123,6 @@ Item
             height: UM.Theme.getSize("setting_control").height
             text: "Snap Angle"
             width: Math.ceil(contentWidth) //Make sure that the grid cells have an integer width.
-			visible: snapRotationCheckbox.checked
         }
 
 		UM.TextFieldWithUnit
@@ -132,7 +132,7 @@ Item
             height: UM.Theme.getSize("setting_control").height
             unit: "degrees"
             text: snapText
-			visible: snapRotationCheckbox.checked
+
             validator: UM.FloatValidator
             {
                 maxBeforeDecimal: 3
@@ -146,7 +146,6 @@ Item
                     UM.Controller.setProperty("RotationSnapAngle", modified_text)
                 }
             }
-
             onActiveFocusChanged:
             {
                 if(!activeFocus && text =="")
@@ -172,7 +171,7 @@ Item
 
     Grid
     {
-        id: textfields
+        id: manualInputTextFields
 
         anchors.leftMargin: UM.Theme.getSize("default_margin").width
         anchors.top: snapRotationCheckbox.bottom
@@ -180,6 +179,7 @@ Item
         columns: 2
         flow: Grid.TopToBottom
         spacing: Math.round(UM.Theme.getSize("default_margin").width / 2)
+        visible: !snapRotationCheckbox.checked
 
         UM.Label
         {
@@ -211,19 +211,27 @@ Item
             width: UM.Theme.getSize("setting_control").width
             height: UM.Theme.getSize("setting_control").height
             unit: "degrees"
-            text: UM.Controller.properties.getValue("RX")
+            text: xText
 
+            validator: UM.FloatValidator
+            {
+                maxBeforeDecimal: 3
+                maxAfterDecimal: 2
+            }
             onEditingFinished:
             {
                 var modified_text = text.replace(",", ".") // User convenience. We use dots for decimal values
-                UM.Controller.setProperty("RX", modified_text)
+                if(text !="")
+                {
+                    UM.Controller.setProperty("RX", modified_text)
+                }
             }
             onActiveFocusChanged:
             {
                 if(!activeFocus && text =="")
                 {
                     xText = 0.1; // Yeaaah i know. We need to change it to something else so we can force it to 0
-                    xText = 0
+                    xText = UM.Controller.properties.getValue("RX")
                 }
             }
         }
@@ -233,19 +241,27 @@ Item
             width: UM.Theme.getSize("setting_control").width
             height: UM.Theme.getSize("setting_control").height
             unit: "degrees"
-            text: UM.Controller.properties.getValue("RY")
+            text: yText
 
+            validator: UM.FloatValidator
+            {
+                maxBeforeDecimal: 3
+                maxAfterDecimal: 2
+            }
             onEditingFinished:
             {
                 var modified_text = text.replace(",", ".") // User convenience. We use dots for decimal values
-                UM.Controller.setProperty("RY", modified_text)
+                if(text !="")
+                {
+                    UM.Controller.setProperty("RY", modified_text)
+                }
             }
             onActiveFocusChanged:
             {
                 if(!activeFocus && text =="")
                 {
                     yText = 0.1; // Yeaaah i know. We need to change it to something else so we can force it to 0
-                    yText = 0
+                    yText = UM.Controller.properties.getValue("RY")
                 }
             }
         }
@@ -255,19 +271,27 @@ Item
             width: UM.Theme.getSize("setting_control").width
             height: UM.Theme.getSize("setting_control").height
             unit: "degrees"
-            text: UM.Controller.properties.getValue("RZ")
+            text: zText
 
+            validator: UM.FloatValidator
+            {
+                maxBeforeDecimal: 3
+                maxAfterDecimal: 2
+            }
             onEditingFinished:
             {
                 var modified_text = text.replace(",", ".") // User convenience. We use dots for decimal values
-                UM.Controller.setProperty("RZ", modified_text)
+                if(text !="")
+                {
+                    UM.Controller.setProperty("RZ", modified_text)
+                }
             }
             onActiveFocusChanged:
             {
                 if(!activeFocus && text =="")
                 {
                     zText = 0.1; // Yeaaah i know. We need to change it to something else so we can force it to 0
-                    zText = 0
+                    zText = UM.Controller.properties.getValue("RZ")
                 }
             }
         }
@@ -293,5 +317,26 @@ Item
         target: base
         property: "snapText"
         value: base.roundFloat(UM.Controller.properties.getValue("RotationSnapAngle"), 2)
+    }
+
+    Binding
+    {
+        target: base
+        property: "xText"
+        value: base.roundFloat(UM.Controller.properties.getValue("RX"), 2)
+    }
+
+    Binding
+    {
+        target: base
+        property: "yText"
+        value: base.roundFloat(UM.Controller.properties.getValue("RY"), 2)
+    }
+
+    Binding
+    {
+        target: base
+        property: "zText"
+        value: base.roundFloat(UM.Controller.properties.getValue("RZ"), 2)
     }
 }

--- a/plugins/Tools/RotateTool/RotateTool.qml
+++ b/plugins/Tools/RotateTool/RotateTool.qml
@@ -15,6 +15,7 @@ Item
     property string yText
     property string zText
     property string snapText
+    property bool snapEnabled: snapRotationCheckbox.checked
 
     //Rounds a floating point number to 4 decimals. This prevents floating
     //point rounding errors.
@@ -170,143 +171,146 @@ Item
         onClicked: UM.Controller.setProperty("RotationSnap", checked)
     }
 
-    Grid
-    {
-        id: manualInputTextFields
-
-        anchors.leftMargin: UM.Theme.getSize("default_margin").width
+    Item {
+        id: dynamicContainer
         anchors.top: snapRotationCheckbox.bottom
+        anchors.topMargin: UM.Theme.getSize("default_margin").width
 
-        columns: 2
-        flow: Grid.TopToBottom
-        spacing: Math.round(UM.Theme.getSize("default_margin").width / 2)
-        visible: !snapRotationCheckbox.checked
+        width: manualInputTextFields.visible ? manualInputTextFields.width : 0
+        height: manualInputTextFields.visible ? manualInputTextFields.height : 0
 
-        UM.Label
-        {
-            height: UM.Theme.getSize("setting_control").height
-            text: "X"
-            color: UM.Theme.getColor("x_axis")
-            width: Math.ceil(contentWidth) //Make sure that the grid cells have an integer width.
-        }
+        Grid {
+            id: manualInputTextFields
+            columns: 2
+            flow: Grid.TopToBottom
+            spacing: Math.round(UM.Theme.getSize("default_margin").width / 2)
+            visible: !snapEnabled
 
-        UM.Label
-        {
-            height: UM.Theme.getSize("setting_control").height
-            text: "Y"
-            color: UM.Theme.getColor("z_axis"); // This is intentional. The internal axis are switched.
-            width: Math.ceil(contentWidth) //Make sure that the grid cells have an integer width.
-        }
-
-        UM.Label
-        {
-            height: UM.Theme.getSize("setting_control").height
-            text: "Z"
-            color: UM.Theme.getColor("y_axis"); // This is intentional. The internal axis are switched.
-            width: Math.ceil(contentWidth) //Make sure that the grid cells have an integer width.
-        }
-
-        UM.TextFieldWithUnit
-        {
-            id: xangleTextField
-            width: UM.Theme.getSize("setting_control").width
-            height: UM.Theme.getSize("setting_control").height
-            unit: "°"
-            text: xText
-
-            validator: UM.FloatValidator
+            UM.Label
             {
-                maxBeforeDecimal: 3
-                maxAfterDecimal: 2
+                height: UM.Theme.getSize("setting_control").height
+                text: "X"
+                color: UM.Theme.getColor("x_axis")
+                width: Math.ceil(contentWidth) // Make sure that the grid cells have an integer width.
             }
-            onEditingFinished:
+
+            UM.Label
             {
-                var modified_text = text.replace(",", ".") // User convenience. We use dots for decimal values
-                if(text != "")
+                height: UM.Theme.getSize("setting_control").height
+                text: "Y"
+                color: UM.Theme.getColor("z_axis"); // This is intentional. The internal axis are switched.
+                width: Math.ceil(contentWidth) // Make sure that the grid cells have an integer width.
+            }
+
+            UM.Label
+            {
+                height: UM.Theme.getSize("setting_control").height
+                text: "Z"
+                color: UM.Theme.getColor("y_axis"); // This is intentional. The internal axis are switched.
+                width: Math.ceil(contentWidth) // Make sure that the grid cells have an integer width.
+            }
+
+            UM.TextFieldWithUnit
+            {
+                id: xAngleTextField
+                width: UM.Theme.getSize("setting_control").width
+                height: UM.Theme.getSize("setting_control").height
+                unit: "°"
+                text: xText
+
+                validator: UM.FloatValidator
                 {
-                    UM.Controller.setProperty("RotationX", modified_text)
-                    text = "0"
+                    maxBeforeDecimal: 3
+                    maxAfterDecimal: 2
+                }
+                onEditingFinished:
+                {
+                    var modified_text = text.replace(",", ".") // User convenience. We use dots for decimal values
+                    if(text != "")
+                    {
+                        UM.Controller.setProperty("RotationX", modified_text)
+                        text = "0"
+                    }
+                }
+                onActiveFocusChanged:
+                {
+                    if(!activeFocus && text == "")
+                    {
+                        xText = 0.1; // Need to change it to something else so we can force it to getvalue
+                        xText = 0
+                    }
                 }
             }
-            onActiveFocusChanged:
+
+            UM.TextFieldWithUnit
             {
-                if(!activeFocus && text == "")
+                id: yAngleTextField
+                width: UM.Theme.getSize("setting_control").width
+                height: UM.Theme.getSize("setting_control").height
+                unit: "°"
+                text: yText
+
+                validator: UM.FloatValidator
                 {
-                    xText = 0.1; // Need to change it to something else so we can force it to getvalue
-                    xText = 0
+                    maxBeforeDecimal: 3
+                    maxAfterDecimal: 2
+                }
+                onEditingFinished:
+                {
+                    var modified_text = text.replace(",", ".") // User convenience. We use dots for decimal values
+                    if(text != "")
+                    {
+                        // Yes this is intentional. Y & Z are flipped between model axes and build plate axes
+                        UM.Controller.setProperty("RotationZ", modified_text)
+                        text = "0"
+                    }
+                }
+                onActiveFocusChanged:
+                {
+                    if(!activeFocus && text == "")
+                    {
+                        yText = 0.1; // Need to change it to something else so we can force it to getvalue
+                        // Yes this is intentional. Y & Z are flipped between model axes and build plate axes
+                        yText = 0
+                    }
+                }
+            }
+
+            UM.TextFieldWithUnit
+            {
+                id: zAngleTextField
+                width: UM.Theme.getSize("setting_control").width
+                height: UM.Theme.getSize("setting_control").height
+                unit: "°"
+                text: zText
+
+                validator: UM.FloatValidator
+                {
+                    maxBeforeDecimal: 3
+                    maxAfterDecimal: 2
+                }
+                onEditingFinished:
+                {
+                    var modified_text = text.replace(",", ".") // User convenience. We use dots for decimal values
+                    if(text != "")
+                    {
+                        // Yes this is intentional. Y & Z are flipped between model axes and build plate axes
+                        UM.Controller.setProperty("RotationY", modified_text)
+                        text = "0"
+                    }
+                }
+                onActiveFocusChanged:
+                {
+                    if(!activeFocus && text == "")
+                    {
+                        zText = 0.1; // Need to change it to something else so we can force it to getvalue
+                        // Yes this is intentional. Y & Z are flipped between model axes and build plate axes
+                        zText = 0
+                    }
                 }
             }
         }
-
-        UM.TextFieldWithUnit
-        {
-            id: yangleTextField
-            width: UM.Theme.getSize("setting_control").width
-            height: UM.Theme.getSize("setting_control").height
-            unit: "°"
-            text: yText
-
-            validator: UM.FloatValidator
-            {
-                maxBeforeDecimal: 3
-                maxAfterDecimal: 2
-            }
-            onEditingFinished:
-            {
-                var modified_text = text.replace(",", ".") // User convenience. We use dots for decimal values
-                if(text != "")
-                {
-                    // Yes this is intentional. Y & Z are flipped between model axes and build plate axes
-                    UM.Controller.setProperty("RotationZ", modified_text)
-                    text = "0"
-                }
-            }
-            onActiveFocusChanged:
-            {
-                if(!activeFocus && text == "")
-                {
-                    yText = 0.1; // Need to change it to something else so we can force it to getvalue
-                    // Yes this is intentional. Y & Z are flipped between model axes and build plate axes
-                    yText = 0
-                }
-            }
-        }
-
-        UM.TextFieldWithUnit
-        {
-            id: zangleTextField
-            width: UM.Theme.getSize("setting_control").width
-            height: UM.Theme.getSize("setting_control").height
-            unit: "°"
-            text: zText
-
-            validator: UM.FloatValidator
-            {
-                maxBeforeDecimal: 3
-                maxAfterDecimal: 2
-            }
-            onEditingFinished:
-            {
-                var modified_text = text.replace(",", ".") // User convenience. We use dots for decimal values
-                if(text != "")
-                {
-                    // Yes this is intentional. Y & Z are flipped between model axes and build plate axes
-                    UM.Controller.setProperty("RotationY", modified_text)
-                    text = "0"
-                }
-            }
-            onActiveFocusChanged:
-            {
-                if(!activeFocus && text == "")
-                {
-                    zText = 0.1; // Need to change it to something else so we can force it to getvalue
-                    // Yes this is intentional. Y & Z are flipped between model axes and build plate axes
-                    zText = 0
-                }
-            }
-        }
-
-	}
+    }
 
     Binding
     {

--- a/plugins/Tools/RotateTool/RotateTool.qml
+++ b/plugins/Tools/RotateTool/RotateTool.qml
@@ -145,6 +145,12 @@ Item
                 var modified_text = text.replace(",", ".") // User convenience. We use dots for decimal values
                 if(text != "")
                 {
+                    var value = parseFloat(modified_text)
+                    if (value === 0)
+                    {
+                        text = snapText; // Revert to previous valid value
+                        return;
+                    }
                     UM.Controller.setProperty("RotationSnapAngle", modified_text)
                 }
             }

--- a/plugins/Tools/RotateTool/RotateTool.qml
+++ b/plugins/Tools/RotateTool/RotateTool.qml
@@ -83,7 +83,8 @@ Item
         // visible: ! UM.Controller.properties.getValue("SelectFaceSupported");
     }
 
-    UM.ToolbarButton{
+    UM.ToolbarButton
+    {
         id: alignFaceButton
 
         anchors.left: layFlatButton.visible ? layFlatButton.right : resetRotationButton.right
@@ -171,7 +172,8 @@ Item
         onClicked: UM.Controller.setProperty("RotationSnap", checked)
     }
 
-    Item {
+    Item
+    {
         id: dynamicContainer
         anchors.top: snapRotationCheckbox.bottom
         anchors.topMargin: UM.Theme.getSize("default_margin").width
@@ -179,7 +181,8 @@ Item
         width: manualInputTextFields.visible ? manualInputTextFields.width : 0
         height: manualInputTextFields.visible ? manualInputTextFields.height : 0
 
-        Grid {
+        Grid
+        {
             id: manualInputTextFields
             columns: 2
             flow: Grid.TopToBottom

--- a/plugins/Tools/ScaleTool/ScaleTool.qml
+++ b/plugins/Tools/ScaleTool/ScaleTool.qml
@@ -121,6 +121,7 @@ Item
 
             checked: !UM.Controller.properties.getValue("NonUniformScale")
             onClicked: UM.Controller.setProperty("NonUniformScale", !checked)
+            tooltip: catalog.i18nc("@checkbox:description", "If a model has been rotated then 'Non-Uniform Scaling' might result in skewing of the model.")
         }
 
         Binding


### PR DESCRIPTION
Add rotation by input fields
- Fields only active when snap rotation is disabled
- Fields take user input, rotate the model and return to value 0
- Getting model rotation or storing the rotation values lead to unexpected behavior (read leave Quaternions alone)
- Includes the snap rotation PR (https://github.com/Ultimaker/Uranium/pull/979)
- Adds setter and getter for RX,RY,RZ (rotations in each axis)
- Applies the rotations for single or multiple model(s)

Rotate by input
![rotation_by_input1](https://github.com/user-attachments/assets/ab458266-7342-49bc-aa59-d0f7f3e05575)

Snap angle update
Based on the idea of GregValiant
![snap_angle](https://github.com/user-attachments/assets/c306524e-2237-415c-9038-05cac29a3c39)

