### PR TITLE
Update TranslateToolHandle.py

### DIFF
--- a/plugins/Tools/TranslateTool/TranslateToolHandle.py
+++ b/plugins/Tools/TranslateTool/TranslateToolHandle.py
@@ -55,7 +55,7 @@ class TranslateToolHandle(ToolHandle):
                 width = self._line_width,
                 height = self._line_width,
                 depth = self._line_length,
-                center = Vector(0, 0, self._handle_position / 2),
+                center = Vector(0, 0, -(self._handle_position / 2)),
                 color = self._z_axis_color
             )
 
@@ -85,10 +85,10 @@ class TranslateToolHandle(ToolHandle):
                 width = self._handle_width,
                 height = self._handle_height,
                 depth = self._handle_width,
-                center = Vector(0, 0, self._handle_position),
+                center = Vector(0, 0, -(self._handle_position)),
                 color = self._z_axis_color,
                 axis = Vector.Unit_X,
-                angle = -90
+                angle = 90
             )
 
         self.setSolidMesh(mb.build())
@@ -117,7 +117,7 @@ class TranslateToolHandle(ToolHandle):
                 width = self._active_line_width,
                 height = self._active_line_width,
                 depth = self._active_line_length,
-                center = Vector(0, 0, self._active_handle_position / 2),
+                center = Vector(0, 0, -(self._active_handle_position / 2)),
                 color = self._z_axis_color
             )
 
@@ -142,7 +142,7 @@ class TranslateToolHandle(ToolHandle):
             width = self._active_handle_width,
             height = self._active_handle_width,
             depth = self._active_handle_width,
-            center = Vector(0, 0, self._active_handle_position),
+            center = Vector(0, 0, -(self._active_handle_position)),
             color = ToolHandle.ZAxisSelectionColor
         )
         self.setSelectionMesh(mb.build())


### PR DESCRIPTION
Flip the Y axis of the model coordinate system so that +Y is towards the back of the build plate.  This brings it in line with the build plate axis, and conventional coordinate systems.

This has been a pet peeve of mine for years.  Apparently it's not just me.  This goes back to at least 2017 and [#2152 ](https://github.com/Ultimaker/Cura/issues/2152).

North should be north.
![image](https://github.com/user-attachments/assets/d8ea2cb1-a6a0-48b4-afda-e3ef80d9f71d)
