### PR TITLE
Re-fix typos

### DIFF
--- a/resources/i18n/de_DE/uranium.po
+++ b/resources/i18n/de_DE/uranium.po
@@ -554,7 +554,7 @@ msgstr "Beim Deinstallieren der folgenden Pakete traten Fehler auf:"
 "{packages}"
 
 msgctxt "@info:status Don't translate the XML tag <filename>!"
-msgid "There where no models in <filename>{0}</filename>."
+msgid "There were no models in <filename>{0}</filename>."
 msgstr "Es waren keine Modelle in <filename>{0}</filename> vorhanden."
 
 msgctxt "@action:description"

--- a/resources/i18n/es_ES/uranium.po
+++ b/resources/i18n/es_ES/uranium.po
@@ -554,7 +554,7 @@ msgstr "Se han producido algunos errores al desinstalar los siguientes paquetes:
 "{packages}"
 
 msgctxt "@info:status Don't translate the XML tag <filename>!"
-msgid "There where no models in <filename>{0}</filename>."
+msgid "There were no models in <filename>{0}</filename>."
 msgstr "No había modelos en <filename>{0}</filename>."
 
 msgctxt "@action:description"

--- a/resources/i18n/fr_FR/uranium.po
+++ b/resources/i18n/fr_FR/uranium.po
@@ -554,7 +554,7 @@ msgstr "Des erreurs se sont produites lors de la désinstallation des paquets su
 "{packages}"
 
 msgctxt "@info:status Don't translate the XML tag <filename>!"
-msgid "There where no models in <filename>{0}</filename>."
+msgid "There were no models in <filename>{0}</filename>."
 msgstr "Aucun modèle trouvé dans <filename>{0}</filename>."
 
 msgctxt "@action:description"

--- a/resources/i18n/it_IT/uranium.po
+++ b/resources/i18n/it_IT/uranium.po
@@ -554,7 +554,7 @@ msgstr "Si sono verificati alcuni errori durante la disinstallazione dei seguent
 "{packages}"
 
 msgctxt "@info:status Don't translate the XML tag <filename>!"
-msgid "There where no models in <filename>{0}</filename>."
+msgid "There were no models in <filename>{0}</filename>."
 msgstr "Nessun modello in <filename>{0}</filename>."
 
 msgctxt "@action:description"

--- a/resources/i18n/ja_JP/uranium.po
+++ b/resources/i18n/ja_JP/uranium.po
@@ -563,7 +563,7 @@ msgid "There were some errors uninstalling the following packages: {packages}"
 msgstr "次のパッケージのアンインストールでエラーが発生しました:{packages}"
 
 msgctxt "@info:status Don't translate the XML tag <filename>!"
-msgid "There where no models in <filename>{0}</filename>."
+msgid "There were no models in <filename>{0}</filename>."
 msgstr "<filename>{0}</filename>にはモデルがありませんでした。"
 
 msgctxt "@action:description"

--- a/resources/i18n/ko_KR/uranium.po
+++ b/resources/i18n/ko_KR/uranium.po
@@ -554,7 +554,7 @@ msgstr "다음 패키지를 제거하는 중에 오류가 발생했습니다. "
 "{packages}"
 
 msgctxt "@info:status Don't translate the XML tag <filename>!"
-msgid "There where no models in <filename>{0}</filename>."
+msgid "There were no models in <filename>{0}</filename>."
 msgstr "<filename>{0}</filename>에 모델이 없습니다."
 
 msgctxt "@action:description"

--- a/resources/i18n/nl_NL/uranium.po
+++ b/resources/i18n/nl_NL/uranium.po
@@ -554,7 +554,7 @@ msgstr "Er zijn fouten opgetreden bij het deïnstalleren van de volgende package
 "{packages}"
 
 msgctxt "@info:status Don't translate the XML tag <filename>!"
-msgid "There where no models in <filename>{0}</filename>."
+msgid "There were no models in <filename>{0}</filename>."
 msgstr "Er waren geen modellen in <filename>{0}</filename>."
 
 msgctxt "@action:description"

--- a/resources/i18n/pt_PT/uranium.po
+++ b/resources/i18n/pt_PT/uranium.po
@@ -554,7 +554,7 @@ msgstr "Ocorreram alguns erros ao desinstalar os seguintes pacotes:"
 "{packages}"
 
 msgctxt "@info:status Don't translate the XML tag <filename>!"
-msgid "There where no models in <filename>{0}</filename>."
+msgid "There were no models in <filename>{0}</filename>."
 msgstr "Não existiam modelos em <filename>{0}</filename>."
 
 msgctxt "@action:description"

--- a/resources/i18n/ru_RU/uranium.po
+++ b/resources/i18n/ru_RU/uranium.po
@@ -554,7 +554,7 @@ msgstr "Возникли некоторые ошибки при удалении
 "{packages}"
 
 msgctxt "@info:status Don't translate the XML tag <filename>!"
-msgid "There where no models in <filename>{0}</filename>."
+msgid "There were no models in <filename>{0}</filename>."
 msgstr "Там, где нет моделей в <filename>{0}</filename>."
 
 msgctxt "@action:description"

--- a/resources/i18n/tr_TR/uranium.po
+++ b/resources/i18n/tr_TR/uranium.po
@@ -554,7 +554,7 @@ msgstr "Şu paketler kaldırılırken bazı hatalar meydana geldi:"
 "{packages}"
 
 msgctxt "@info:status Don't translate the XML tag <filename>!"
-msgid "There where no models in <filename>{0}</filename>."
+msgid "There were no models in <filename>{0}</filename>."
 msgstr "<filename>{0}</filename> dosyasında model bulunamadı."
 
 msgctxt "@action:description"

--- a/resources/i18n/zh_CN/uranium.po
+++ b/resources/i18n/zh_CN/uranium.po
@@ -554,7 +554,7 @@ msgstr "卸载以下程序包时出现了一些错误："
 "{packages}"
 
 msgctxt "@info:status Don't translate the XML tag <filename>!"
-msgid "There where no models in <filename>{0}</filename>."
+msgid "There were no models in <filename>{0}</filename>."
 msgstr "<filename>{0}</filename> 中没有模型。"
 
 msgctxt "@action:description"


### PR DESCRIPTION
[This pull](https://github.com/Ultimaker/Uranium/pull/958) seems to have been overwritten by another pull, so this is re-fixing those typos.

Interestingly, I run the English Cura, but I still find this bug, despite it supposedly being fixed already for English? Strange.
https://github.com/Ultimaker/Uranium/blob/7e8bc91864cf7854e4e4928e8e88ab2b80994d61/UM/FileHandler/ReadFileJob.py#L94

Related Issues:
https://github.com/Ultimaker/Cura/issues/16810
https://github.com/Ultimaker/Cura/issues/17267
https://github.com/Ultimaker/Cura/issues/17623
https://github.com/Ultimaker/Cura/issues/19316