### PR TITLE
CURA-12408 separate alpha config folders

### DIFF
--- a/UM/Resources.py
+++ b/UM/Resources.py
@@ -480,10 +480,10 @@ class Resources:
     def __initializeStoragePaths(cls) -> None:
         Logger.log("d", "Initializing storage paths")
         # use nested structure: <app-name>/<version>/...
-        if cls.ApplicationVersion in ["master", "main", "dev"] or cls.ApplicationVersion == "unknown":
+        version = Version(cls.ApplicationVersion)
+        if version.getPostfixType() == "alpha" or cls.ApplicationVersion == "unknown":
             storage_dir_name = os.path.join(cls.ApplicationIdentifier, cls.ApplicationVersion)
         else:
-            version = Version(cls.ApplicationVersion)
             storage_dir_name = os.path.join(cls.ApplicationIdentifier, "%s.%s" % (version.getMajor(), version.getMinor()))
 
         # config is saved in "<CONFIG_ROOT>/<storage_dir_name>"


### PR DESCRIPTION
When using an alpha version, create a config folder specific to this version, so that non compatible configs won't mix

CURA-12408

This removes the check for a version called `master`, `main` or `dev`, since we do not use that anymore. The Cura version is handled through Conan and there is no situation where this could happen.