### PR TITLE
CURA-12652 force depend causes slice invalidated

### DIFF
--- a/UM/Settings/InstanceContainer.py
+++ b/UM/Settings/InstanceContainer.py
@@ -161,10 +161,10 @@ class InstanceContainer(QObject, ContainerInterface, PluginObject):
             flat_container.setDefinition(instance_container1.getDefinition().getId())
 
         for key in instance_container2.getAllKeys():
-            flat_container.setProperty(key, "value", instance_container2.getProperty(key, "value"), set_from_cache = False)
+            flat_container.setProperty(key, "value", instance_container2.getProperty(key, "value"), set_from_cache = True)
 
         for key in instance_container1.getAllKeys():
-            flat_container.setProperty(key, "value", instance_container1.getProperty(key, "value"), set_from_cache = False)
+            flat_container.setProperty(key, "value", instance_container1.getProperty(key, "value"), set_from_cache = True)
 
         return flat_container
 


### PR DESCRIPTION
When creating the merged instance contained at save time, we don't need/want property signals to be emitted. This is usually harmless, because the container is created locally and nobody is connected to it. However, when you have a setting with force_depends_on_settings, it will emit the signal using the real global stack instead, invalidating the slice.

CURA-12652