### PR TITLE
[CURA-13027] Be able to tell when a workspace is actively being loaded.

### DIFF
--- a/UM/Application.py
+++ b/UM/Application.py
@@ -113,6 +113,8 @@ class Application:
 
         self._app_install_dir = self.getInstallPrefix()  # type: str
 
+        self._loading_workspace = False
+
         # Intended for keeping plugin workspace metadata that is going to be saved in and retrieved from workspace files.
         # When the workspace is stored, all workspace readers will need to ensure that the workspace metadata is correctly
         # stored to the output file. The same also holds when loading a workspace; the existing data will be cleared
@@ -125,6 +127,12 @@ class Application:
 
     def getAPIVersion(self) -> "Version":
         return self._api_version
+
+    def getloadingWorkspace(self) -> bool:
+        return self._loading_workspace
+
+    def setloadingWorkspace(self, loading_workspace: bool) -> None:
+        self._loading_workspace = loading_workspace
 
     def getWorkspaceMetadataStorage(self) -> WorkspaceMetadataStorage:
         return self._workspace_metadata_storage

--- a/UM/Workspace/WorkspaceFileHandler.py
+++ b/UM/Workspace/WorkspaceFileHandler.py
@@ -46,6 +46,8 @@ class WorkspaceFileHandler(FileHandler):
         return results
 
     def _readLocalFile(self, file: QUrl, add_to_recent_files_hint: bool = True) -> None:
+        self._application.setloadingWorkspace(True)
+
         from UM.FileHandler.ReadFileJob import ReadFileJob
         filename = file.toLocalFile()
         job = ReadFileJob(filename, handler = self, add_to_recent_files = add_to_recent_files_hint)
@@ -71,3 +73,4 @@ class WorkspaceFileHandler(FileHandler):
 
             self._application.getWorkspaceMetadataStorage().setAllData(metadata)
             self._application.workspaceLoaded.emit(cast(WorkspaceReader, self.workspace_reader).workspaceName())
+        self._application.setloadingWorkspace(False)


### PR DESCRIPTION
Needed for keep/discard in the front-end; when a workspace is loaded, the user sort of implicitly agrees to 'keep' the changes, even if they put in 'always ask' (otherwise a screen would always pop-up after they load a workspace asking to undo the changes the file just made when loading...) -- this was fixed earlier in a different (wrong) way but that just shut out the keep/discard dialog _completely_.

See also: https://github.com/Ultimaker/Cura/pull/21494
