### PR TITLE
CURA-12754 dynamic dialogs

### DIFF
--- a/UM/Decorators.py
+++ b/UM/Decorators.py
@@ -29,6 +29,25 @@ def deprecated(message, since = "Unknown"): #pylint: disable=bad-whitespace
     return deprecated_decorator
 
 
+def deprecated_argument(argument_index: int, argument_name: str, message, since = "Unknown"): #pylint: disable=bad-whitespace
+    """Decorator that can be used to indicate a method has been deprecated
+
+    :param argument: The name or index of the argument that is no more used
+    :param message: The message to display when the method is called with a non-default argument. Should include a suggestion about what to use.
+    :param since: A version since when this method has been deprecated.
+    """
+
+    def deprecated_decorator(function):
+        def deprecated_function(*args, **kwargs):
+            if argument_name in kwargs or argument_index < len(args):
+                warning = f"Argument '{argument_name}' of function {function} is deprecated (since {since}): {message}"
+                Logger.log("w_once", warning)
+                warnings.warn(warning, DeprecationWarning, stacklevel=2)
+            return function(*args, **kwargs)
+        return deprecated_function
+    return deprecated_decorator
+
+
 def ascopy(function):
     """Decorator to ensure the returned value is always a copy and never a direct reference
 

--- a/UM/Qt/QtApplication.py
+++ b/UM/Qt/QtApplication.py
@@ -631,7 +631,7 @@ class QtApplication(QApplication, Application):
 
         return result
 
-    def createQmlComponent(self, qml_file_path: str, context_properties: Dict[str, "QObject"] = None) -> Optional["QObject"]:
+    def createQmlComponent(self, qml_file_path: str, context_properties: Dict[str, "QObject"] = None, initial_properties: Dict[str, "QObject"] = {}) -> Optional["QObject"]:
         """Create a QML component from a qml file.
         :param qml_file_path: The absolute file path to the root qml file.
         :param context_properties: Optional dictionary containing the properties that will be set on the context of the
@@ -648,7 +648,7 @@ class QtApplication(QApplication, Application):
         if context_properties is not None:
             for name, value in context_properties.items():
                 result_context.setContextProperty(name, value)
-        result = component.create(result_context)
+        result = component.createWithInitialProperties(initial_properties, result_context)
         for err in component.errors():
             Logger.log("e", str(err.toString()))
         if result is None:

--- a/UM/Qt/qml/UM/MessageDialog.qml
+++ b/UM/Qt/qml/UM/MessageDialog.qml
@@ -31,6 +31,7 @@ Dialog
     */
     id: root
 
+    property bool selfDestroy: false  // Automatically destroys the dialog when it has been hidden, useful if it has been created with component.createObject
     property alias text: content.text //The text to show in the body of the dialogue.
 
     width: UM.Theme.getSize("small_popup_dialog").width
@@ -234,5 +235,13 @@ Dialog
                 }
             }
         }
-   }
+    }
+
+    onClosed:
+    {
+        if(selfDestroy)
+        {
+            destroy();
+        }
+    }
 }

--- a/tests/benchmarks/conftest.py
+++ b/tests/benchmarks/conftest.py
@@ -7,7 +7,7 @@ import warnings
 warn = True
 
 @pytest.hookimpl
-def pytest_ignore_collect(path, config):
+def pytest_ignore_collect(collection_path, config):
     if config.pluginmanager.hasplugin("pytest-benchmark"):
         return False
     else:


### PR DESCRIPTION
This PR adds a few functionalities for the dialogs cleaning:
* Add a `deprecated_argument` decorator to allow only deprecating an argument of a function
* Add a `initial_properties` argument to the `createQmlComponent`: this helps creating QML components faster, since properties are set directly at construction, so it does not trigger event when actually setting their values. Also it can help when using a component having a Python object as a property.
* Add a `selfDestroy` property to dialogs so that they are destroyed immediatly after being hidden

Comes with https://github.com/Ultimaker/Cura/pull/21570
CURA-12754