### PR TITLE
CURA-13182 fix build plate not rendered

### DIFF
--- a/UM/Qt/QtRenderer.py
+++ b/UM/Qt/QtRenderer.py
@@ -160,8 +160,6 @@ class QtRenderer(Renderer):
 
         self._batches.sort()
 
-        # print(self.getRenderPasses())
-
         for render_pass in self.getRenderPasses():
             width, height = render_pass.getSize()
             self._gl.glViewport(0, 0, width, height)

--- a/UM/Qt/QtRenderer.py
+++ b/UM/Qt/QtRenderer.py
@@ -172,7 +172,6 @@ class QtRenderer(Renderer):
         """
 
         self.beginRendering() # First ensure that the viewport is set correctly.
-        # print([self.getRenderPasses()[-1]])
         self.getRenderPasses()[-1].render()
 
     def endRendering(self) -> None:

--- a/UM/Qt/QtRenderer.py
+++ b/UM/Qt/QtRenderer.py
@@ -131,6 +131,7 @@ class QtRenderer(Renderer):
         if not self._initialized:
             self._initialize()
 
+        self._gl.glFrontFace(self._gl.GL_CCW)
         self._gl.glViewport(0, 0, self._viewport_width, self._viewport_height)
         self._gl.glClearColor(self._background_color.redF(), self._background_color.greenF(), self._background_color.blueF(), self._background_color.alphaF())
         self._gl.glClear(self._gl.GL_COLOR_BUFFER_BIT | self._gl.GL_DEPTH_BUFFER_BIT)
@@ -159,6 +160,8 @@ class QtRenderer(Renderer):
 
         self._batches.sort()
 
+        # print(self.getRenderPasses())
+
         for render_pass in self.getRenderPasses():
             width, height = render_pass.getSize()
             self._gl.glViewport(0, 0, width, height)
@@ -171,6 +174,7 @@ class QtRenderer(Renderer):
         """
 
         self.beginRendering() # First ensure that the viewport is set correctly.
+        # print([self.getRenderPasses()[-1]])
         self.getRenderPasses()[-1].render()
 
     def endRendering(self) -> None:

--- a/UM/View/CompositePass.py
+++ b/UM/View/CompositePass.py
@@ -85,7 +85,7 @@ class CompositePass(RenderPass):
         texture_unit = 0
         for binding in self._layer_bindings:
             render_pass = self._renderer.getRenderPass(binding)
-            if not render_pass:
+            if not render_pass or not render_pass.isEnabled():
                 continue
 
             self._gl.glActiveTexture(getattr(self._gl, "GL_TEXTURE{0}".format(texture_unit)))


### PR DESCRIPTION
it seems that in Qt 6.10, the QML rendering can sometimes leave OpenGL in a state where it displays front-faces clockwise, whereas the convention is counter-clockwise. So we now force the ccw rendering when starting our own rendering of the 3D scene.
Also a tiny optimization of not trying to include disabled render passes when rendering the composite pass.

CURA-13182