### PR TITLE
pin twisted version to the same version in use in Cura repository

### DIFF
--- a/conandata.yml
+++ b/conandata.yml
@@ -346,7 +346,8 @@ pip_requirements_core:
 pip_requirements_dev:
   any_os:
     pytest: {}
-    twisted: {}
+    twisted:
+      version: "21.2.0"
     pytest-benchmark: {}
     sip: {}
 


### PR DESCRIPTION
Dev requirements are used in unit tests, newer versions of the twisted don't have backwards compatibility with typing_extensions and cause an import error in the unit tests, this change is aimed to address that.


CURA-13214