### PR TITLE
Don't overwrite fixed dialog save path

### DIFF
--- a/plugins/LocalFileOutputDevice/LocalFileOutputDevice.py
+++ b/plugins/LocalFileOutputDevice/LocalFileOutputDevice.py
@@ -123,7 +123,8 @@ class LocalFileOutputDevice(ProjectOutputDevice):
             raise OutputDeviceError.UserCanceledError()
 
         save_path = dialog.directory().absolutePath()
-        Application.getInstance().getPreferences().setValue("local_file/dialog_save_path", save_path)
+        if not Application.getInstance().getPreferences().getValue("local_file/use_fixed_dialog_paths"):
+            Application.getInstance().getPreferences().setValue("local_file/dialog_save_path", save_path)
 
         selected_type = file_types[filters.index(dialog.selectedNameFilter())]
         Application.getInstance().getPreferences().setValue("local_file/last_used_type", selected_type["mime_type"])


### PR DESCRIPTION
Skip updating `local_file/dialog_save_path` when `local_file/use_fixed_dialog_paths` is enabled, so the configured fixed path is preserved across saves.


CURA-13289