### PR TITLE
CURA-13243 center dialogs on linux

### DIFF
--- a/UM/Qt/QtApplication.py
+++ b/UM/Qt/QtApplication.py
@@ -606,7 +606,7 @@ class QtApplication(QApplication, Application):
         if not visible:
             self._sub_windows.remove(self.sender())
 
-    def createQmlSubWindow(self, qml_file_path: str, context_properties: Dict[str, "QObject"] = None) -> Optional["QQuickWindow"]:
+    def createQmlSubWindow(self, qml_file_path: str, context_properties: Dict[str, "QObject"] = None, initial_properties: Dict[str, "QObject"] = {}) -> Optional["QQuickWindow"]:
         """
         Create a QML window from a QML file. This method uses createQmlComponent internally, but adds a few specific
         features for windows management:
@@ -619,7 +619,7 @@ class QtApplication(QApplication, Application):
         qml instance before creation.
         :return: The created QQuickWindow instance, or None in case the creation failed (qml error)
         """
-        result = self.createQmlComponent(qml_file_path, context_properties)
+        result = self.createQmlComponent(qml_file_path, context_properties, initial_properties)
         if result is None:
             return None
 

--- a/UM/Qt/qml/UM/Dialog.qml
+++ b/UM/Qt/qml/UM/Dialog.qml
@@ -1,9 +1,9 @@
 // Copyright (c) 2022 Ultimaker B.V.
 // Uranium is released under the terms of the LGPLv3 or higher.
 
-import QtQuick 2.10
-import QtQuick.Window 2.2
-import QtQuick.Layouts 1.3
+import QtQuick
+import QtQuick.Window
+import QtQuick.Layouts
 import QtQuick.Dialogs
 
 import UM 1.5 as UM
@@ -161,6 +161,19 @@ Window
             Layout.preferredWidth: parent.width
             Layout.preferredHeight: childrenRect.height
             sourceComponent: footerComponent
+        }
+    }
+
+    onTransientParentChanged: centerOnParent()
+    Component.onCompleted: centerOnParent()
+
+    function centerOnParent()
+    {
+        if (transientParent && Qt.platform.os == "linux")
+        {
+            // CURA-13243: since Qt 6.10, dialogs do not appear centered on Linux, so force centering them
+            x = transientParent.x + (transientParent.width - width) / 2;
+            y = transientParent.y + (transientParent.height - height) / 2;
         }
     }
 }


### PR DESCRIPTION
Since the update to Qt 6.10, dialogs don't appear centered on Linux environment. Since this should really happen natively, I found no other way but to actually set the window position manually.

An other solution would be to have `UM.Dialog` use a `QtQuick.Controls.Dialog` instead of a `QtQuick.Controls.Window`, which fixes the centering, but that leads to other issues such at not being able to set a minimum size.

CURA-13243