### PR TITLE
Cura 13267 file menu rework

### DIFF
--- a/UM/FileProvider.py
+++ b/UM/FileProvider.py
@@ -1,7 +1,7 @@
 # Copyright (c) 2022 Ultimaker B.V.
 # Uranium is released under the terms of the LGPLv3 or higher.
 
-from PyQt6.QtCore import pyqtSignal, QObject
+from PyQt6.QtCore import pyqtSignal, QObject, pyqtProperty, pyqtSlot
 
 from UM.PluginObject import PluginObject
 from typing import Optional
@@ -22,17 +22,17 @@ class FileProvider(PluginObject, QObject):
         PluginObject.__init__(self)
         QObject.__init__(self)
 
-        self.menu_item_display_text = None  # type: Optional[str]
+        self._menu_item_display_text = None  # type: Optional[str]
         """
         Text that will be displayed as an option in the Open File(s) menu.
         """
 
-        self.shortcut = None  # type: Optional[str]
+        self._shortcut = None  # type: Optional[str]
         """
         Shortcut key combination (e.g. "Ctrl+O").
         """
 
-        self.enabled = True
+        self._enabled = True
         """
         If the provider is not enabled, it should not be displayed in the interface.
         """
@@ -41,6 +41,43 @@ class FileProvider(PluginObject, QObject):
         """
         Where it should be sorted in lists, or which should be tried first.
         """
+
+    def setShortcut(self, shortcut: str):
+        self._shortcut = shortcut
+
+    @pyqtProperty(str, fset=setShortcut, constant=True)
+    def shortcut(self) -> str:
+        return self._shortcut
+
+    def setMenuItemDisplayText(self, text: str):
+        self._menu_item_display_text = text
+
+    @pyqtProperty(str, fset=setMenuItemDisplayText, constant=True)
+    def menuItemDisplayText(self) -> str:
+        return self._menu_item_display_text
+
+    @pyqtProperty(str, fset=setMenuItemDisplayText, constant=True)
+    def menu_item_display_text(self) -> str:
+        '''Duplicate of the menuItemDisplayText property, used for retro-compatibility purposes'''
+        return self._menu_item_display_text
+
+    def setEnabled(self, enabled: bool):
+        if enabled != self._enabled:
+            self._enabled = enabled
+            self.enabledChanged.emit()
+
+    @pyqtProperty(bool, fset=setEnabled, notify=enabledChanged)
+    def enabled(self) -> bool:
+        return self._enabled
+
+    @pyqtSlot()
+    def runSlot(self) -> None:
+        '''
+        Slot that calls the run() function. Technically we could directly declare the run() method to be a slot, but
+        that requires doing so on all the overridden definitions of the methods in the plugins, so for
+        retro-compatibility purposes, we just define this main slot.
+        '''
+        self.run()
 
     def run(self) -> None:
         """Call function associated with the file provider"""

--- a/UM/OutputDevice/OutputDeviceManager.py
+++ b/UM/OutputDevice/OutputDeviceManager.py
@@ -116,6 +116,12 @@ class OutputDeviceManager:
     projectOutputDevicesChanged = Signal()
     """Emitted whenever an output device that can handle project files is added or removed."""
 
+    projectOutputDeviceAdded = Signal()
+    """Emitted whenever an output device that can handle project files is added."""
+
+    projectOutputDeviceRemoved = Signal()
+    """Emitted whenever an output device that can handle project files is removed."""
+
     activeDeviceChanged = Signal()
     """Emitted whenever the active device changes."""
 
@@ -271,6 +277,7 @@ class OutputDeviceManager:
                 self.connectWriteSignalsToDevice(device)
 
         self.projectOutputDevicesChanged.emit()
+        self.projectOutputDeviceAdded.emit(device)
 
     def removeProjectOutputDevice(self, device_id: str) -> bool:
         """Remove a registered project output device by ID
@@ -290,6 +297,7 @@ class OutputDeviceManager:
 
         self.disconnectWriteSignalsFromDevice(device)
         self.projectOutputDevicesChanged.emit()
+        self.projectOutputDeviceRemoved.emit(device)
 
         if device_id in self._output_devices:
             del self._output_devices[device_id]

--- a/UM/OutputDevice/ProjectOutputDevice.py
+++ b/UM/OutputDevice/ProjectOutputDevice.py
@@ -3,7 +3,7 @@
 
 from typing import Optional
 
-from PyQt6.QtCore import pyqtSignal, QObject
+from PyQt6.QtCore import pyqtSignal, pyqtProperty, QObject
 
 from UM.Application import Application
 from UM.Decorators import deprecated
@@ -24,7 +24,7 @@ class ProjectOutputDevice(QObject, OutputDevice):
     """Signal which informs whether the project output device has been enabled or disabled, so that it can be added or removed 
      from the 'File->Save Project...' submenu"""
 
-    last_out_name = None  # type: Optional[str]
+    last_out_name: Optional[str] = None
     """Last output project name, gives the possibility to do something with the updated project-name on saving, if any.
     """
 
@@ -43,22 +43,17 @@ class ProjectOutputDevice(QObject, OutputDevice):
         device will appear as an option also in the OutputDevicesActionButton.
         """
 
-        self.menu_entry_text = None  # type: Optional[str]
+        self._menu_entry_text: Optional[str] = None
         """
         Text that appears as the title of the menu item in the 'File->Save Project...' submenu
         """
 
-        self.shortcut = None  # type: Optional[str]
+        self._shortcut: Optional[str] = None
         """
         Shortcut key combination
         """
 
-    @property
-    def enabled(self) -> bool:
-        return self._enabled
-
-    @enabled.setter
-    def enabled(self, enabled: bool) -> None:
+    def setEnabled(self, enabled: bool) -> None:
         """
         Setter for the enable property. It ensures that a project output device that gets enabled is also added to
         the output devices, if that is necessary.
@@ -76,6 +71,32 @@ class ProjectOutputDevice(QObject, OutputDevice):
                     Application.getInstance().getOutputDeviceManager().addOutputDevice(self)
                 else:
                     Application.getInstance().getOutputDeviceManager().removeOutputDevice(self.getId())
+
+    @pyqtProperty(str, constant=True)
+    def id(self) -> str:
+        return self.getId()
+
+    @pyqtProperty(bool, fset=setEnabled, notify=enabledChanged)
+    def enabled(self) -> bool:
+        return self._enabled
+
+    def setMenuEntryText(self, menu_entry_text: str) -> None:
+        self._menu_entry_text = menu_entry_text
+
+    @pyqtProperty(str, fset=setMenuEntryText, constant=True)
+    def menu_entry_text(self):
+        return self._menu_entry_text
+
+    @pyqtProperty(str, fset=setMenuEntryText, constant=True)
+    def menuEntryText(self):
+        return self._menu_entry_text
+
+    def setShortcut(self, shortcut: str) -> None:
+        self._shortcut = shortcut
+
+    @pyqtProperty(str, fset=setShortcut, constant=True)
+    def shortcut(self) -> str:
+        return self._shortcut
 
     @staticmethod
     def popLastOutputName() -> Optional[str]:

--- a/UM/OutputDevice/ProjectOutputDevice.py
+++ b/UM/OutputDevice/ProjectOutputDevice.py
@@ -98,6 +98,10 @@ class ProjectOutputDevice(QObject, OutputDevice):
     def shortcut(self) -> str:
         return self._shortcut
 
+    @pyqtProperty(str, constant=True)
+    def iconName(self) -> str:
+        return self.getIconName()
+
     @staticmethod
     def popLastOutputName() -> Optional[str]:
         output_name = ProjectOutputDevice.last_out_name

--- a/UM/Qt/Bindings/FileProviderModel.py
+++ b/UM/Qt/Bindings/FileProviderModel.py
@@ -1,86 +1,27 @@
 # Copyright (c) 2022 Ultimaker B.V.
 # Uranium is released under the terms of the LGPLv3 or higher.
 
-from typing import Callable, Optional
-
 from PyQt6.QtCore import Qt
-from UM.FlameProfiler import pyqtSlot
-from UM.i18n import i18nCatalog
 from UM.Qt.ListModel import ListModel
-from UM.Logger import Logger
 
-i18n_catalog = i18nCatalog("uranium")
 
 class FileProviderModel(ListModel):
-    NameRole = Qt.ItemDataRole.UserRole + 1
-    DisplayTextRole = Qt.ItemDataRole.UserRole + 2
-    FileProviderRole = Qt.ItemDataRole.UserRole + 3
-    ShortcutRole = Qt.ItemDataRole.UserRole + 4
+    ModelDataRole = Qt.ItemDataRole.UserRole
 
     def __init__(self, application = None, parent = None):
         super().__init__(parent)
-        self.addRoleName(self.NameRole, "name")
-        self.addRoleName(self.DisplayTextRole, "displayText")
-        self.addRoleName(self.FileProviderRole, "fileProvider")
-        self.addRoleName(self.ShortcutRole, "shortcut")
+        self.addRoleName(self.ModelDataRole, "modelData")
+
         self._application = application
 
-    def initialize(self, file_provider_enabled_call_function: Optional[Callable]) -> None:
-        """
-        Initializes the file provider model.
-        This is achieved by connecting the enabledChanged signal of all the file_providers to the given function.
-
-        :param file_provider_enabled_call_function: The function which will be called when a file provider gets enabled
-                                                    or disabled
-        """
-        for file_provider in self._application.getFileProviders():
-            file_provider.enabledChanged.connect(file_provider_enabled_call_function)
-        self.update()
-
-    def update(self) -> None:
-        """
-        Updates the FileProviderModel to contain only the enabled file providers.
-        """
-        self.clear()
-
-        # Always add the local file provider to the list. Since it is not really a plugin, fake an entry in the file providers
-        # list and handle it in the front-end by triggering the openAction when that item is selected
-        self.appendItem({
-            "name"         : "LocalFileProvider",
-            "displayText"  : i18n_catalog.i18nc("@menu", "From Disk"),
-            "fileProvider" : None,  # it's not loaded via a plugin, so its FileProvider is empty
-            "shortcut"     : "Ctrl+O",
-            "priority"     : 99,  # Assign a high value to make sure it appears on top in the File->Open File(s) submenu
-        })
+    def initialize(self) -> None:
+        """ Initializes the file provider model. """
 
         for file_provider in self._application.getFileProviders():
             plugin_id = file_provider.getPluginId()
             meta_data = self._application.getPluginRegistry().getMetaData(plugin_id)
 
-            if "plugin" in meta_data and file_provider.enabled:
+            if "plugin" in meta_data:
+                self.appendItem({ "modelData": file_provider })
 
-                self.appendItem({
-                    "name": plugin_id,
-                    "displayText" : file_provider.menu_item_display_text,
-                    "fileProvider": file_provider,
-                    "shortcut": file_provider.shortcut,
-                    "priority": file_provider.priority,
-                })
-
-        self.sort(lambda x: -float(x["priority"]))
-
-    @pyqtSlot(str)
-    def trigger(self, file_provider_name) -> None:
-        """
-        Safely triggers the run function of the given file_provider_name
-
-        :param file_provider_name: The file provider which was requested to be triggered
-        """
-        for item in self._items:
-            if item["name"] == file_provider_name:
-                try:
-                    item["fileProvider"].run()
-                except Exception:
-                    # Yes, we really want a broad exception here. These items are always plugins, and those should be
-                    # kept from crashing the main application as much as possible.
-                    Logger.logException("w", "Failed to activate the file provider '{}'".format(file_provider_name))
+        self.sort(lambda x: -float(x["modelData"].priority))

--- a/UM/Qt/Bindings/ProjectOutputDevicesModel.py
+++ b/UM/Qt/Bindings/ProjectOutputDevicesModel.py
@@ -25,7 +25,6 @@ class ProjectOutputDevicesModel(ListModel):
         items = []
         for device in self._device_manager.getProjectOutputDevices():
             items.append({"modelData": device})
-            print(device.menuEntryText)
         self.setItems(items)
         self.sort(lambda x: -float(x["modelData"].getPriority()))
 

--- a/UM/Qt/Bindings/ProjectOutputDevicesModel.py
+++ b/UM/Qt/Bindings/ProjectOutputDevicesModel.py
@@ -1,64 +1,53 @@
 # Copyright (c) 2022 Ultimaker B.V.
 # Uranium is released under the terms of the LGPLv3 or higher.
 
-from typing import List
-
-from PyQt6.QtCore import Qt, pyqtSignal
-from PyQt6.QtQml import QQmlEngine
+from PyQt6.QtCore import Qt
 
 from UM.Application import Application
 from UM.OutputDevice.OutputDeviceManager import OutputDeviceManager
-from UM.OutputDevice.ProjectOutputDevice import ProjectOutputDevice
 from UM.Qt.ListModel import ListModel
 
 
 class ProjectOutputDevicesModel(ListModel):
-    """A list model providing a list of all registered OutputDevices that can save projects.
+    """A list model providing a list of all registered OutputDevices that can save projects."""
 
-    Exposes the following roles:
-    * id - The device ID
-    * name - The human-readable name of the device
-    * priority - The device priority
-
-    """
-
-    IdRole = Qt.ItemDataRole.UserRole + 1
-    NameRole = Qt.ItemDataRole.UserRole + 2
-    PriorityRole = Qt.ItemDataRole.UserRole + 3
-    ShortcutRole = Qt.ItemDataRole.UserRole + 4
-
-    projectOutputDevicesChanged = pyqtSignal()
+    ModelDataRole = Qt.ItemDataRole.UserRole
 
     def __init__(self, parent = None):
         super().__init__(parent)
-        # Ensure that this model doesn't get garbage collected (Now the bound object is destroyed when the wrapper is)
-        QQmlEngine.setObjectOwnership(self, QQmlEngine.ObjectOwnership.CppOwnership)
-        self._device_manager = Application.getInstance().getOutputDeviceManager()  # type: OutputDeviceManager
+        self._device_manager: OutputDeviceManager = Application.getInstance().getOutputDeviceManager()
 
-        self.addRoleName(self.IdRole, "id")
-        self.addRoleName(self.NameRole, "name")
-        self.addRoleName(self.PriorityRole, "priority")
-        self.addRoleName(self.ShortcutRole, "shortcut")
+        self.addRoleName(self.ModelDataRole, "modelData")
 
-        self._device_manager.projectOutputDevicesChanged.connect(self._update)
-        self._update()
+        self._device_manager.projectOutputDeviceAdded.connect(self._onProjectOutputDeviceAdded)
+        self._device_manager.projectOutputDeviceRemoved.connect(self._onProjectOutputDeviceRemoved)
 
-    def _update(self):
-
-        self.clear()
         items = []
-
-        # Make a copy here, because we could discover devices during iteration.
-        devices = [device for device in self._device_manager.getProjectOutputDevices() if device.enabled]  # type: List[ProjectOutputDevice]
-        for device in devices:
-            items.append({
-                "id": device.getId(),
-                "name": device.menu_entry_text,
-                "priority": device.getPriority(),
-                "shortcut": device.shortcut
-            })
-
-        items.sort(key = lambda i: -i["priority"])
+        for device in self._device_manager.getProjectOutputDevices():
+            items.append({"modelData": device})
+            print(device.menuEntryText)
         self.setItems(items)
+        self.sort(lambda x: -float(x["modelData"].getPriority()))
 
-        self.projectOutputDevicesChanged.emit()
+    def _onProjectOutputDeviceAdded(self, device):
+        new_item = {"modelData": device}
+        actual_devices = self._device_manager.getProjectOutputDevices()
+        if actual_devices:
+            insert_position = None
+            for index, actual_device in enumerate(actual_devices):
+                if actual_device.getPriority() < device.getPriority():
+                    insert_position = index
+                    break
+
+            if insert_position is not None:
+                self.insertItem(insert_position, new_item)
+            else:
+                self.appendItem(new_item)
+        else:
+            self.appendItem(new_item)
+
+    def _onProjectOutputDeviceRemoved(self, device):
+        for index, item in enumerate(self.items):
+            if item["modelData"] is device:
+                self.removeItem(index)
+                return

--- a/UM/Qt/qml/UM/Menu.qml
+++ b/UM/Qt/qml/UM/Menu.qml
@@ -7,23 +7,20 @@ Menu
 {
     id: root
 
-    // This is a work around for menu's not actually being visual items. Upon creation, a visual item is created
-    // The work around is based on the suggestion given in https://stackoverflow.com/questions/59167352/qml-how-to-hide-submenu
-    property bool shouldBeVisible: true
-
     // Automatically set the width to fit the widest MenuItem
     // Based on https://martin.rpdev.net/2018/03/13/qt-quick-controls-2-automatically-set-the-width-of-menus.html
-    function setWidth()
+    width:
     {
-        var result = 0;
         var padding = 0;
         var result = 0;
-        for (var i = 0; i < count; ++i) {
+        for (var i = 0; i < count; ++i)
+        {
             var item = itemAt(i);
             if (item.hasOwnProperty("contentWidth"))
             {
                 var itemWidth = item.contentWidth;
-                if (item.hasOwnProperty("shortcut") && item.shortcut != null) {
+                if (item.hasOwnProperty("shortcut") && item.shortcut != null)
+                {
                     itemWidth += UM.Theme.getSize("default_margin").width;
                 }
                 result = Math.max(itemWidth, result);
@@ -33,24 +30,19 @@ Menu
         return result + padding * 2;
     }
 
-    function adjustWidth()
-    {
-        root.width = shouldBeVisible ? setWidth() : 0
-    }
+    // This is a workaround for menu's not actually being visual items. Upon creation, a visual item is created
+    // The work around is based on the suggestion given in https://stackoverflow.com/questions/59167352/qml-how-to-hide-submenu
+    property bool shouldBeVisible: true
 
     function handleVisibility()
     {
         if(parent)
         {
             root.parent.visible = shouldBeVisible
-            root.parent.height = shouldBeVisible ? UM.Theme.getSize("menu").height : 0
-            adjustWidth()
         }
     }
 
     onParentChanged: handleVisibility()
     Component.onCompleted: handleVisibility()
     onShouldBeVisibleChanged: handleVisibility()
-    onAboutToShow: adjustWidth()
-    implicitWidth: setWidth()
 }

--- a/UM/Qt/qml/UM/MenuItem.qml
+++ b/UM/Qt/qml/UM/MenuItem.qml
@@ -7,7 +7,6 @@ MenuItem
 {
     id: root
 
-    property alias shortcut: _shortcut.sequence
     property bool indicatorVisible: root.icon.source.length > 0 || root.checkable
     height: visible ? UM.Theme.getSize("context_menu").height : 0
     property int contentWidth:
@@ -18,24 +17,10 @@ MenuItem
 
     Shortcut
     {
-        id: _shortcut
-        // If this menuItem has an action, the shortcut stuff is handled by the action (so this shortcut is disabled)
-        // If only a shortcut is set, the menu item does need to handle it.
-        // If both handle it at the same time, the action is only triggered half the time.
-        enabled: root.action == null && root.enabled
-        onActivated: root.triggered()
-        context: Qt.ApplicationShortcut
-        sequences: root.action !== null ? [root.action] : []
-    }
-
-    // Workaround for menu items in controls not supporting mnemonic shortcuts in all cases.
-    // We use a seperate shortcut since we want the normal shortcut to be displayed to the right of the menu item
-    // This shortcut needs to be "invisible"
-    Shortcut
-    {
-        id: _mnemonicShortcut
-        enabled: root.enabled
-        onActivated: root.triggered()
+        // This objects exists only to get the shortcut native text, it is always disabled
+        id: dummyShortcut
+        enabled: false
+        sequences: root.action !== null ? [root.action.shortcut] : []
     }
 
     function replaceText(txt)
@@ -44,7 +29,6 @@ MenuItem
         if(index >= 0)
         {
             txt = txt.replace(txt.substr(index, 2), "<u>" + txt.substr(index + 1, 1) + "</u>")
-            _mnemonicShortcut.sequence = "Alt+" + txt.substr(index + 1, 1)
         }
         return txt
     }
@@ -84,14 +68,14 @@ MenuItem
         {
             // Middle margin
             id: middleSpacer
-            width: (_shortcut.nativeText != "" || root.subMenu) ? UM.Theme.getSize("default_margin").width : 0
+            width: (dummyShortcut.nativeText !== "" || root.subMenu) ? UM.Theme.getSize("default_margin").width : 0
         }
 
         UM.Label
         {
             id: shortcutLabel
             Layout.fillHeight: true
-            text: _shortcut.nativeText
+            text: dummyShortcut.nativeText
             color: UM.Theme.getColor("text_lighter")
         }
 

--- a/plugins/LocalFileOutputDevice/LocalFileOutputDevice.py
+++ b/plugins/LocalFileOutputDevice/LocalFileOutputDevice.py
@@ -30,7 +30,7 @@ class LocalFileOutputDevice(ProjectOutputDevice):
         self.setName(catalog.i18nc("@item:inmenu", "Local File"))
         self.setShortDescription(catalog.i18nc("@action:button Preceded by 'Ready to'.", "Save to Disk"))
         self.setDescription(catalog.i18nc("@info:tooltip", "Save to Disk"))
-        self.setIconName("save")
+        self.setIconName("document-save")
 
         self.shortcut = "Ctrl+S"
         self.menu_entry_text = catalog.i18nc("@item:inmenu About saving files to the hard drive", "To Disk")


### PR DESCRIPTION
This PR simplifies the logic behind the "File" menu. Since the "Save project" and "Load project" menus are dynamic depending on the loaded plugins and their enabled states, it is quite difficult to make it work reliably on all platforms.
* Change the `FileProvider` and `ProjectOutputDevice` classes so that their properties can be used directly from within QML
* Change the `FileProviderModel` and `ProjectOutputDevicesModel` classes so that they directly handle a list of objects to the QML part
* Change the `OutputDeviceManager` so that we can just add/remove the output devices instead of re-creating the full model every time something changes

CURA-13267